### PR TITLE
New and updated files for project registry

### DIFF
--- a/articles/templates/dhq-tei_template.xml
+++ b/articles/templates/dhq-tei_template.xml
@@ -47,6 +47,9 @@
                 <taxonomy xml:id="authorial_keywords">
                     <bibl>Keywords supplied by author; no controlled vocabulary</bibl>
                 </taxonomy>
+            	<taxonomy xml:id="project_keywords">
+            		<bibl>DHQ project registry; full list available at <ref target="http://www.digitalhumanities.org/dhq/projects.xml">http://www.digitalhumanities.org/dhq/projects.xml</ref></bibl>
+            	</taxonomy>
             </classDecl>
         </encodingDesc>
         <profileDesc>
@@ -67,6 +70,11 @@
                         <item></item>
                     </list>
                 </keywords>
+            	<keywords scheme="#project_keywords">
+            		<list type="simple">
+            			<item></item>
+            		</list>
+            	</keywords>
             </textClass>
         </profileDesc>
         <revisionDesc>

--- a/articles/templates/dhq_author_template.xml
+++ b/articles/templates/dhq_author_template.xml
@@ -45,6 +45,9 @@
                 <taxonomy xml:id="authorial_keywords">
                     <bibl>Keywords supplied by author; no controlled vocabulary</bibl>
                 </taxonomy>
+            	<taxonomy xml:id="project_keywords">
+            		<bibl>DHQ project registry; full list available at <ref target="http://www.digitalhumanities.org/dhq/projects.xml">http://www.digitalhumanities.org/dhq/projects.xml</ref></bibl>
+            	</taxonomy>
             </classDecl>
         </encodingDesc>
         <profileDesc>
@@ -64,6 +67,11 @@
                         <item></item>
                     </list>
                 </keywords>
+            	<keywords scheme="#project_keywords">
+            		<list type="simple">
+            			<item></item>
+            		</list>
+            	</keywords>
             </textClass>
         </profileDesc>
         <revisionDesc>

--- a/common/xml/projects.xml
+++ b/common/xml/projects.xml
@@ -19,7 +19,7 @@
 					<resp/>
 				</respStmt>
 				<respStmt>
-					<name xml:id="bg">Benjamin Grey</name>
+					<name xml:id="brg">Benjamin Grey</name>
 					<resp/>
 				</respStmt>
 			</titleStmt>
@@ -44,26 +44,37 @@
 		</profileDesc>
 		<revisionDesc>
 			<change when="2022-10-25" who="#jhf">Created file</change>
+			<change when="2022-10-30" who="#brg">Added list of projects to test xml:id naming
+				convention</change>
 		</revisionDesc>
 	</teiHeader>
 	<text xml:lang="en">
 		<front>
 			<div>
 				<head>About the DHQ Project Registry</head>
-				<p>This is an initial, local registry of digital humanities projects that are referenced from within DHQ articles. DHQ is working in partnership with other publications (in particular, Reviews in Digital Humanities) to develop a broader and more public project registry, possibly using Wikidata or other public linked open data platforms, to which this registry will refer. Currently this registry exists simply to create a target for project references and enable identification and disambiguation.</p>
+				<p>This is an initial, local registry of digital humanities projects that are
+					referenced from within DHQ articles. DHQ is working in partnership with other
+					publications (in particular, Reviews in Digital Humanities) to develop a broader
+					and more public project registry, possibly using Wikidata or other public linked
+					open data platforms, to which this registry will refer. Currently this registry
+					exists simply to create a target for project references and enable
+					identification and disambiguation.</p>
 			</div>
 			<div>
 				<head>Usage and expansion</head>
-				<p>Each DHQ article contains in its metadata one or more project identifiers which in
-					turn reference items in this registry. These project identifiers will be used in
-					several ways within the DHQ publishing system: <list>
-						<item>in the DHQ search interface, to enable readers to search for
-							articles that reference or discuss a specific project</item>
-						<item>to generate a project index that groups together articles based on project references</item>
+				<p>Each DHQ article contains in its metadata one or more project identifiers which
+					in turn reference items in this registry. These project identifiers will be used
+					in several ways within the DHQ publishing system: <list>
+						<item>in the DHQ search interface, to enable readers to search for articles
+							that reference or discuss a specific project</item>
+						<item>to generate a project index that groups together articles based on
+							project references</item>
 						<item>to support analytics and visualizations</item>
 					</list>
 				</p>
-				<p>When an article is accepted for publication, as part of the encoding process the managing editors will encode an inventory of project references in the article metadata. Any new projects will be added to the registry.</p>
+				<p>When an article is accepted for publication, as part of the encoding process the
+					managing editors will encode an inventory of project references in the article
+					metadata. Any new projects will be added to the registry.</p>
 			</div>
 		</front>
 		<body>
@@ -71,6 +82,119 @@
 				<org xml:id="">
 					<name>[project name here]</name>
 					<ptr type="project_site" target=""/>
+				</org>
+			</listOrg>
+
+			<listOrg>
+				<org xml:id="">
+					<name>Lincoln/Net</name>
+					<!-- article 000003 -->
+					<ptr type="project_site" target="http://lincoln.lib.niu.edu"/>
+					<!-- url given in article -->
+					<ptr type="project_site" target="https://digital.lib.niu.edu/illinois/lincoln"/>
+					<!-- current url -->
+				</org>
+			</listOrg>
+
+			<listOrg>
+				<org xml:id="">
+					<name>Suda On Line</name>
+					<!-- article 000025 -->
+					<ptr type="project_site" target="http://www.stoa.org/sol/"/>
+					<!-- url given in article -->
+					<ptr type="project_site" target="https://www.cs.uky.edu/~raphael/sol/sol-html/"/>
+					<!-- current url -->
+				</org>
+			</listOrg>
+
+			<listOrg>
+				<org xml:id="">
+					<name>Readies</name>
+					<!-- article 000108 -->
+					<ptr type="project_site" target="http://www.readies.org"/>
+					<!-- url given in article -->
+					<ptr type="project_site" target="http://www.readies.org/"/>
+					<!-- current url -->
+				</org>
+			</listOrg>
+
+			<listOrg>
+				<org xml:id="">
+					<name>PO.EX: A Digital Archive of Portuguese Experimental Literature</name>
+					<!-- article 000175 -->
+					<ptr type="project_site" target="http://po-ex.net/"/>
+					<!-- url given in article -->
+					<ptr type="project_site" target="https://po-ex.net/"/>
+					<!-- current url -->
+				</org>
+			</listOrg>
+
+			<listOrg>
+				<org xml:id="">
+					<name>TaDiRAH</name>
+					<!-- article 000175 -->
+					<ptr type="project_site" target="http://tadirah.dariah.eu/"/>
+					<!-- url given in article (and broken) -->
+					<ptr type="project_site" target="https://www.tadirah.info/"/>
+					<!-- current url -->
+				</org>
+			</listOrg>
+
+			<listOrg>
+				<org xml:id="">
+					<name>RIDGES</name>
+					<!-- article 000288 -->
+					<ptr type="project_site"
+						target="http://korpling.german.hu-berlin.de/ridges/index_en.html"/>
+					<!-- url given in article -->
+					<ptr type="project_site"
+						target="https://www.linguistik.hu-berlin.de/en/institut-en/professuren-en/korpuslinguistik/research/ridges-projekt"/>
+					<!-- current url (maybe?) -->
+				</org>
+			</listOrg>
+			
+			<listOrg>
+				<org xml:id="">
+					<name>London Stage Information Bank</name>
+					<!-- article 000321 -->
+					<ptr type="project_site" target="http://digitalhumanities.org:8081/dhq/vol/11/3/000321/000321.html"/>
+					<!-- url of article (written about a historic project) -->
+				</org>
+			</listOrg>
+			
+			<listOrg>
+				<org xml:id="">
+					<name>Ancient Dance in Modern Dancers</name>
+					<!-- article 000395 -->
+					<ptr type="project_site" target="http://digitalhumanities.org:8081/dhq/vol/12/3/000395/000395.html"/>
+					<!-- url of article (written about a seemingly unpublished project) -->
+				</org>
+			</listOrg>
+			
+			<listOrg>
+				<org xml:id="">
+					<name>Old Books New Science Lab (OBNS)</name>
+					<!-- article 000475 -->
+					<ptr type="project_site" target="https://oldbooksnewscience.com/"/>
+					<!-- url given in article and current -->
+				</org>
+			</listOrg>
+			
+			<listOrg>
+				<org xml:id="">
+					<name>Hands-On Reading</name>
+					<!-- article 000558 -->
+					<ptr type="project_site" target="https://hands-on-reading.atnu.ncl.ac.uk/login"/>
+					<!-- url given in article and current -->
+				</org>
+			</listOrg>
+			
+			<listOrg>
+				<org xml:id="">
+					<name>Caribbean Women Healers</name>
+					<!-- article 000631 -->
+					<ptr type="project_site" target="https://healers.uoregon.edu/"/>
+					<!-- url given in article and current -->
 				</org>
 			</listOrg>
 		</body>

--- a/common/xml/projects.xml
+++ b/common/xml/projects.xml
@@ -76,10 +76,21 @@
 					managing editors will encode an inventory of project references in the article
 					metadata. Any new projects will be added to the registry.</p>
 			</div>
+			<div>
+				<head>Definition of <term>digital humanities project</term></head>
+				<p>Criteria for characterizing something as a digital humanities project: 
+						<list>
+							<item>goal that goes beyond a singular output</item>
+							<item>an organization that continues after the output has been achieved</item>
+							<item>typically (but not necessarily) more than one person</item>
+							<item>an organization, not solely a publication</item>
+						</list>
+				</p>
+			</div>
 		</front>
 		<body>
 			<listOrg>
-				<org xml:id="">
+				<org xml:id="" cert="['low' if not certain]">
 					<name>[project name here]</name>
 					<ptr type="project_site" target=""/>
 				</org>

--- a/common/xml/projects.xml
+++ b/common/xml/projects.xml
@@ -90,6 +90,7 @@
 		</front>
 		<body>
 			<listOrg>
+				<!-- use @cert with value "low" in cases where we're not sure whether the entity is actually a "project" according to our definition -->
 				<org xml:id="" cert="['low' if not certain]">
 					<name>[project name here]</name>
 					<ptr type="project_site" target=""/>

--- a/common/xml/projects.xml
+++ b/common/xml/projects.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-stylesheet type="text/css" href="../css/taxonomy_tei.css"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:dhq="http://www.digitalhumanities.org/ns/dhq"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns" xmlns:cc="http://web.resource.org/cc/">
+	<teiHeader>
+		<fileDesc>
+			<titleStmt>
+				<title>DHQ Project Registry</title>
+				<author>Digital Humanities Quarterly</author>
+				<respStmt>
+					<name xml:id="jhf">Julia Flanders</name>
+					<resp/>
+				</respStmt>
+				<respStmt>
+					<name xml:id="rbf">R. B. Faure</name>
+					<resp/>
+				</respStmt>
+				<respStmt>
+					<name xml:id="bg">Benjamin Grey</name>
+					<resp/>
+				</respStmt>
+			</titleStmt>
+			<publicationStmt>
+				<publisher>Alliance of Digital Humanities Organizations</publisher>
+				<publisher>Association of Computers and the Humanities</publisher>
+				<availability>
+					<ab>Freely available under a <ref
+							target="https://creativecommons.org/licenses/by-nd/2.5/">Creative
+							Commons</ref>license.</ab>
+				</availability>
+			</publicationStmt>
+			<sourceDesc>
+				<p>This is the source.</p>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<langUsage>
+				<language ident="en"/>
+			</langUsage>
+			<!-- the textClass element can be lodged in a separate XML file and included here with XInclude if it gets unwieldy -->
+		</profileDesc>
+		<revisionDesc>
+			<change when="2022-10-25" who="#jhf">Created file</change>
+		</revisionDesc>
+	</teiHeader>
+	<text xml:lang="en">
+		<front>
+			<div>
+				<head>About the DHQ Project Registry</head>
+				<p>This is an initial, local registry of digital humanities projects that are referenced from within DHQ articles. DHQ is working in partnership with other publications (in particular, Reviews in Digital Humanities) to develop a broader and more public project registry, possibly using Wikidata or other public linked open data platforms, to which this registry will refer. Currently this registry exists simply to create a target for project references and enable identification and disambiguation.</p>
+			</div>
+			<div>
+				<head>Usage and expansion</head>
+				<p>Each DHQ article contains in its metadata one or more project identifiers which in
+					turn reference items in this registry. These project identifiers will be used in
+					several ways within the DHQ publishing system: <list>
+						<item>in the DHQ search interface, to enable readers to search for
+							articles that reference or discuss a specific project</item>
+						<item>to generate a project index that groups together articles based on project references</item>
+						<item>to support analytics and visualizations</item>
+					</list>
+				</p>
+				<p>When an article is accepted for publication, as part of the encoding process the managing editors will encode an inventory of project references in the article metadata. Any new projects will be added to the registry.</p>
+			</div>
+		</front>
+		<body>
+			<listOrg>
+				<org xml:id="">
+					<name>[project name here]</name>
+					<ptr type="project_site" target=""/>
+				</org>
+			</listOrg>
+		</body>
+	</text>
+</TEI>

--- a/common/xslt/oxgarage_conversion.xsl
+++ b/common/xslt/oxgarage_conversion.xsl
@@ -80,6 +80,9 @@
                     <taxonomy xml:id="authorial_keywords">
                         <bibl>Keywords supplied by author; no controlled vocabulary</bibl>
                     </taxonomy>
+            		<taxonomy xml:id="project_keywords">
+            			<bibl>DHQ project registry; full list available at <ref target="http://www.digitalhumanities.org/dhq/projects.xml">http://www.digitalhumanities.org/dhq/projects.xml</ref></bibl>
+            		</taxonomy>
                 </classDecl>
             </encodingDesc>
             <profileDesc>
@@ -100,6 +103,11 @@
                             <item></item>
                         </list>
                     </keywords>
+            		<keywords scheme="#project_keywords">
+            			<list type="simple">
+            				<item></item>
+            			</list>
+            		</keywords>
                 </textClass>
             </profileDesc>
            <revisionDesc>

--- a/common/xslt/oxgarage_conversion_translation.xsl
+++ b/common/xslt/oxgarage_conversion_translation.xsl
@@ -90,6 +90,9 @@
                     <taxonomy xml:id="authorial_keywords">
                         <bibl>Keywords supplied by author; no controlled vocabulary</bibl>
                     </taxonomy>
+            		<taxonomy xml:id="project_keywords">
+            			<bibl>DHQ project registry; full list available at <ref target="http://www.digitalhumanities.org/dhq/projects.xml">http://www.digitalhumanities.org/dhq/projects.xml</ref></bibl>
+            		</taxonomy>
                 </classDecl>
             </encodingDesc>
             <profileDesc>
@@ -110,6 +113,11 @@
                             <item></item>
                         </list>
                     </keywords>
+            		<keywords scheme="#project_keywords">
+            			<list type="simple">
+            				<item></item>
+            			</list>
+            		</keywords>
                 </textClass>
             </profileDesc>
             <revisionDesc>


### PR DESCRIPTION
I've created a branch with the various encoding changes needed to support the creation of a local project registry:

- Created projects.xml which is intended as a local project registry file 
- Edited all of the encoding templates (including the XML templates and also the XSLT stylesheets that generate TEI headers) to add metadata to accommodate an inventory of project references in DHQ article headers

I would love to get Syd's initial thoughts on the TEI encoding approach (Syd, take a look in particular at projects.xml and at the `<keywords scheme="#project_keywords">` and `<taxonomy xml:id="project_keywords">` elements), and also RB's and Benjamin's thoughts on how this approach would look from an encoder's perspective.