### PR TITLE
Post-TEIGarage Zotero data

### DIFF
--- a/common/xslt/oxgarage_conversion.xsl
+++ b/common/xslt/oxgarage_conversion.xsl
@@ -359,6 +359,14 @@
     <!-- add quotation mark transformation? -->
     
     <!-- Transformations Re MathML -->
+    <xsl:template match="mml:*">
+      <!-- Make sure MathML element names have the "mml" prefix. -->
+      <xsl:element name="mml:{local-name()}">
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates/>
+      </xsl:element>
+    </xsl:template>
+    
     <xsl:template match="mml:mi/@xml:space"/>
     <!-- fix mathml display issue? -->
     

--- a/common/xslt/oxgarage_conversion.xsl
+++ b/common/xslt/oxgarage_conversion.xsl
@@ -241,8 +241,8 @@
     <!-- Any <hi> is likely to be a title of some kind when it appears inside one of Zotero's generated 
       "Bibliography" paragraphs. -->
     <xsl:template match="p[@rend eq 'Bibliography']//hi[@rend eq 'italic']" priority="5">
-      <title rend="italic">
-        <xsl:apply-templates/>
+      <title>
+        <xsl:apply-templates select="@* | node()"/>
       </title>
     </xsl:template>
     
@@ -362,8 +362,7 @@
     <xsl:template match="mml:*">
       <!-- Make sure MathML element names have the "mml" prefix. -->
       <xsl:element name="mml:{local-name()}">
-        <xsl:copy-of select="@*"/>
-        <xsl:apply-templates/>
+        <xsl:apply-templates select="@* | node()"/>
       </xsl:element>
     </xsl:template>
     
@@ -402,7 +401,8 @@
             <xsl:value-of select="$bibData?title"/>
           </title>
         </xsl:variable>
-        <biblStruct xml:id="{$citeKey}" type="{$bibData?type}">
+        <biblStruct xml:id="{$citeKey}" type="{$bibData?type}" 
+           corresp="{$citation-map?uris?1}">
           <xsl:if test="$hasContainer">
             <analytic>
               <xsl:sequence select="$basicInfo"/>

--- a/common/xslt/oxgarage_conversion.xsl
+++ b/common/xslt/oxgarage_conversion.xsl
@@ -16,6 +16,9 @@
     <xsl:output method="xml" indent="yes"/>
     <xsl:mode on-no-match="shallow-copy"/>
     
+    <!-- Whether to put the Zotero JSON bibliography entries in the article's <xenoData>. -->
+    <xsl:param name="show-zotero-json" select="false()" as="xs:boolean"/>
+    
     <!-- Before doing anything else, check for Zotero inline citations (processing instructions which contain 
       JSON). The bibliographic data is compiled here so that it can be used elsewhere in the document.s -->
     <xsl:template match="/">
@@ -143,7 +146,7 @@
                 </textClass>
             </profileDesc>
            <!-- Create a copy of the Zotero bibliographic data in <xenoData>. (Useful for debugging.) -->
-           <xsl:if test="exists($compiled-bibliography)">
+           <xsl:if test="$show-zotero-json and exists($compiled-bibliography)">
               <xenoData>
                 <xsl:text>[ </xsl:text>
                 <xsl:sequence select="string-join($compiled-bibliography?*?jsonStr, ',  

--- a/common/xslt/oxgarage_conversion.xsl
+++ b/common/xslt/oxgarage_conversion.xsl
@@ -3,6 +3,7 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xpath-default-namespace="http://www.tei-c.org/ns/1.0"
     xmlns="http://www.tei-c.org/ns/1.0"
+    xmlns:array="http://www.w3.org/2005/xpath-functions/array"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
     xmlns:mml="http://www.w3.org/1998/Math/MathML"
     xmlns:math="http://www.w3.org/2005/xpath-functions/math"
@@ -442,26 +443,41 @@
       <xsl:map-entry key="'jsonStr'" select="serialize($citation-map, map { 'method': 'json', 'indent': true() })"/>
       <!-- Generate a <biblStruct> that can be used in the bibliography instead of a <p> or plain <bibl>. -->
       <xsl:map-entry key="'teiBibEntry'">
+        <xsl:variable name="bibType" as="xs:string?">
+          <xsl:variable name="typeStr">
+            <xsl:analyze-string select="$bibData?type" regex="-(\w)">
+              <xsl:matching-substring>
+                <xsl:value-of select="upper-case(regex-group(1))"/>
+              </xsl:matching-substring>
+              <xsl:non-matching-substring>
+                <xsl:value-of select="."/>
+              </xsl:non-matching-substring>
+            </xsl:analyze-string>
+          </xsl:variable>
+          <xsl:value-of select="string-join($typeStr,'')"/>
+        </xsl:variable>
         <xsl:variable name="hasContainer" select="map:contains($bibData, 'container-title')"/>
+        <xsl:variable name="langAttr" as="attribute()?">
+          <xsl:if test="map:contains($bibData, 'language') 
+                        and not(lower-case($bibData?language) = ('en', 'eng', 'english', ''))">
+            <xsl:attribute name="xml:lang" select="$bibData?language"/>
+          </xsl:if>
+        </xsl:variable>
         <xsl:variable name="basicInfo">
-          <xsl:for-each select="$bibData?author?*">
-            <author>
-              <persName>
-                <forename>
-                  <xsl:value-of select=".?given"/>
-                </forename>
-                <surname>
-                  <xsl:value-of select=".?family"/>
-                </surname>
-              </persName>
-            </author>
-          </xsl:for-each>
           <title>
             <xsl:attribute name="level" select="if ( $hasContainer ) then 'a' else 'm'"/>
+            <xsl:copy-of select="$langAttr"/>
             <xsl:value-of select="$bibData?title"/>
           </title>
+          <xsl:for-each select="$bibData?author?*">
+            <author>
+              <xsl:call-template name="name-bibliography-contributor">
+                <xsl:with-param name="person-map" select="."/>
+              </xsl:call-template>
+            </author>
+          </xsl:for-each>
         </xsl:variable>
-        <biblStruct xml:id="{$citeKey}" type="{$bibData?type}" 
+        <biblStruct xml:id="{$citeKey}" type="{$bibType}" 
            corresp="{$citation-map?uris?1}">
           <xsl:if test="$hasContainer">
             <analytic>
@@ -471,7 +487,10 @@
           <monogr>
             <xsl:choose>
               <xsl:when test="$hasContainer">
-                <title level="m">
+                <title>
+                  <xsl:attribute name="level" 
+                    select="if ( $bibType eq 'journalArticle' ) then 'j' else 'm'"/>
+                  <xsl:copy-of select="$langAttr"/>
                   <xsl:value-of select="$bibData?container-title"/>
                 </title>
               </xsl:when>
@@ -479,29 +498,107 @@
                 <xsl:sequence select="$basicInfo"/>
               </xsl:otherwise>
             </xsl:choose>
+            <xsl:if test="map:contains($bibData, 'editor')">
+              <xsl:for-each select="$bibData?editor?*">
+                <editor>
+                  <xsl:call-template name="name-bibliography-contributor">
+                    <xsl:with-param name="person-map" select="."/>
+                  </xsl:call-template>
+                </editor>
+              </xsl:for-each>
+            </xsl:if>
+            <xsl:if test="map:contains($bibData, 'DOI')">
+              <idno type="DOI">
+                <xsl:value-of select="$bibData?DOI"/>
+              </idno>
+            </xsl:if>
             <xsl:if test="map:contains($bibData, 'ISBN')">
               <idno type="ISBN">
                 <xsl:value-of select="$bibData?ISBN"/>
               </idno>
             </xsl:if>
             <imprint>
-              <publisher>
-                <xsl:value-of select="$bibData?publisher"/>
-              </publisher>
+              <xsl:if test="map:contains($bibData, 'volume')">
+                <biblScope unit="volume">
+                  <xsl:value-of select="$bibData?volume"/>
+                </biblScope>
+              </xsl:if>
+              <xsl:if test="map:contains($bibData, 'issue')">
+                <biblScope unit="issue">
+                  <xsl:value-of select="$bibData?issue"/>
+                </biblScope>
+              </xsl:if>
+              <xsl:if test="map:contains($bibData, 'page')">
+                <biblScope unit="page">
+                  <xsl:value-of select="$bibData?page"/>
+                </biblScope>
+              </xsl:if>
+              <xsl:if test="map:contains($bibData, 'publisher')">
+                <publisher>
+                  <xsl:value-of select="$bibData?publisher"/>
+                </publisher>
+              </xsl:if>
               <xsl:if test="map:contains($bibData,'publisher-place')">
                 <pubPlace>
                   <xsl:value-of select="$bibData?publisher-place"/>
                 </pubPlace>
               </xsl:if>
               <date>
-                <xsl:value-of select="$bibData?issued?date-parts?*?*"/>
+                <xsl:variable name="dateParts" select="$bibData?issued?date-parts"/>
+                <xsl:choose>
+                  <xsl:when test="array:size($dateParts) gt 1">
+                    <xsl:variable name="parts" as="xs:string*">
+                      <xsl:for-each select="$dateParts?*">
+                        <xsl:value-of select="string-join(.?*, '-')"/>
+                      </xsl:for-each>
+                    </xsl:variable>
+                    <xsl:attribute name="from" select="$parts[1]"/>
+                    <xsl:attribute name="to" select="$parts[2]"/>
+                    <xsl:value-of select="string-join($parts, ', ')"/>
+                  </xsl:when>
+                  <xsl:when test="array:size($dateParts?*) le 3">
+                    <xsl:variable name="dateW3C">
+                      <xsl:value-of select="string-join($dateParts?*?*, '-')"/>
+                    </xsl:variable>
+                    <xsl:attribute name="when" select="$dateW3C"/>
+                    <xsl:value-of select="$dateW3C"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="string-join($dateParts?*?*, '-')"/>
+                  </xsl:otherwise>
+                </xsl:choose>
               </date>
+              <xsl:if test="map:contains($bibData,'URL')">
+                <note type="url">
+                  <xsl:value-of select="$bibData?URL"/>
+                </note>
+              </xsl:if>
             </imprint>
           </monogr>
+          <xsl:if test="map:contains($bibData, 'collection-title')">
+            <series>
+              <title level="s">
+                <xsl:value-of select="$bibData?collection-title"/>
+              </title>
+            </series>
+          </xsl:if>
         </biblStruct>
       </xsl:map-entry>
     </xsl:map>
   </xsl:template>
-
+  
+  <xsl:template name="name-bibliography-contributor">
+    <xsl:param name="person-map" as="map(*)?"/>
+    <xsl:if test="exists($person-map)">
+      <persName>
+        <forename>
+          <xsl:value-of select="$person-map?given"/>
+        </forename>
+        <surname>
+          <xsl:value-of select="$person-map?family"/>
+        </surname>
+      </persName>
+    </xsl:if>
+  </xsl:template>
     
 </xsl:stylesheet>


### PR DESCRIPTION
Updates the post-OxGarage XSLT to handle processing instructions that are artifacts of the Zotero word processor plugins (e.g. [article 000683](https://github.com/Digital-Humanities-Quarterly/dhq-journal/blob/main/articles/000683/tei.xml)).

If there are Zotero PIs containing JSON data, they are processed before anything else. The processed data is then tunneled to the templates that require them (inline citations, and the bibliography). The XSLT now provides a global parameter `show-zotero-data` that can copy the original PIs and print the JSON data for debugging purposes. By default, `show-zotero-data` is set to false.

The XSLT attempts to turn Zotero JSON data into `<biblStruct>`s and match them to `<p rend="Bibliography">` where possible. `<p rend="Bibliography">`s _not_ present in the inline citations (or simply not matched) are minimally converted to `<bibl>`s. `<biblStruct>`s that were cited inline but which could not be matched to a `<p>` are appended to the other bibliography entries (under a comment, marking them for review).