### PR TITLE
changes to XSLT and CSS to support listBibl outside of back

### DIFF
--- a/articles/000000/000000.xhtml
+++ b/articles/000000/000000.xhtml
@@ -101,8 +101,9 @@
                            							laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
                            							in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
                            							pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
-                           							qui officia deserunt mollit anim id est laborum.  (<span class="bibl"><span class="ref" id="d3e248"><!-- close --></span>Cicero,
-                              							perhaps?</span>) 
+                           							qui officia deserunt mollit anim id est laborum. 
+                           <div class="bibl"><span class="ref" id="d4e251"><!-- close --></span>Cicero,
+                              							perhaps?</div>
                            					</p>
                      </blockquote>
                      				</div>
@@ -111,7 +112,8 @@
                   				
                   <div class="epigraph">
                      					“The above quote really made me think about how to
-                     							format epigraphs.” (<span class="bibl"><span class="ref" id="d3e261"><!-- close --></span>You, three seconds ago</span>) 
+                     							format epigraphs.”
+                     <div class="bibl"><span class="ref" id="d4e263"><!-- close --></span>You, three seconds ago</div>
                      				</div>
                   			</div>
                
@@ -169,7 +171,7 @@
                      
                      					
                      <div class="counter"><a href="#p3">3</a></div>
-                     <div class="ptext" id="p3">An Ode to the Hamster (an example of encoded poetry)<a class="noteRef" href="#d3e333">[1]</a></div>
+                     <div class="ptext" id="p3">An Ode to the Hamster (an example of encoded poetry)<a class="noteRef" href="#d4e328">[1]</a></div>
                      
                      					
                      <div class="lg">
@@ -421,7 +423,7 @@
                      <div class="counter"><a href="#p22">22</a></div>
                      <div class="ptext" id="p22"><span class="monospace">&lt;code&gt;</span> displays in a mono-spaced font and should be given a value for
                         							<span class="monospace">@lang</span> as shown here: <span class="monospace">print("Hello,
-                           							World!")</span><a class="noteRef" href="#d3e653">[2]</a></div>
+                           							World!")</span><a class="noteRef" href="#d4e620">[2]</a></div>
                      				</div>
                   
                   				
@@ -862,9 +864,9 @@ public class HelloWorld {
                         <ul class="list simple">
                            <li class="item">Squid</li>
                            <li class="item">Tiger</li>
-                           <li class="item">Viper<a class="noteRef" href="#d3e1282">[3]</a></li>
+                           <li class="item">Viper<a class="noteRef" href="#d4e1182">[3]</a></li>
                            <li class="item">Wolf</li>
-                           <li class="item">Yak<a class="noteRef" href="#d3e1292">[4]</a></li>
+                           <li class="item">Yak<a class="noteRef" href="#d4e1192">[4]</a></li>
                            <li class="item">Zebra</li>
                         </ul>
                      </div>
@@ -877,9 +879,9 @@ public class HelloWorld {
                            <ul class="list simple">
                               <li class="item">Squid</li>
                               <li class="item">Tiger</li>
-                              <li class="item">Viper<a class="noteRef" href="#d3e1327">[5]</a></li>
+                              <li class="item">Viper<a class="noteRef" href="#d4e1223">[5]</a></li>
                               <li class="item">Wolf</li>
-                              <li class="item">Yak<a class="noteRef" href="#d3e1336">[6]</a></li>
+                              <li class="item">Yak<a class="noteRef" href="#d4e1232">[6]</a></li>
                               <li class="item">Zebra</li>
                            </ul>
                         </div>
@@ -889,8 +891,7 @@ public class HelloWorld {
                            								<span class="monospace">&lt;dhq:example&gt;</span> which is able to be referenced by <span class="monospace">&lt;ref&gt;</span>
                            							through its <span class="monospace">@xml:id</span>. This changes the indent level of the list
                            							however. Additionally, this list does not have an optional <span class="monospace">&lt;head&gt;</span>
-                           								element. <a href="#section5.4.2">Back to Section
-                              							5.4.2</a></div>
+                           							element. <a href="#section5.4.2">Back to Section 5.4.2</a></div>
                      </div>
                      
                      					
@@ -909,51 +910,51 @@ public class HelloWorld {
                         <table class="table">
                            <tr class="row label">
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">This</td>
+                              <td valign="top" class="cell">This</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">row</td>
+                              <td valign="top" class="cell">row</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">has</td>
+                              <td valign="top" class="cell">has</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1"><span class="monospace">@role</span></td>
+                              <td valign="top" class="cell"><span class="monospace">@role</span></td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">= label</td>
+                              <td valign="top" class="cell">= label</td>
                               						</tr>
                            <tr class="row">
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">This</td>
+                              <td valign="top" class="cell">This</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">row</td>
+                              <td valign="top" class="cell">row</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">has</td>
+                              <td valign="top" class="cell">has</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               						</tr>
                            <tr class="row">
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">So</td>
+                              <td valign="top" class="cell">So</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">does</td>
+                              <td valign="top" class="cell">does</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">this</td>
+                              <td valign="top" class="cell">this</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">one</td>
+                              <td valign="top" class="cell">one</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">too!</td>
+                              <td valign="top" class="cell">too!</td>
                               						</tr>
                            <tr class="row">
                               							
-                              <td valign="top" class="cell label" colspan="1" rowspan="1">Total:</td>
+                              <td valign="top" class="cell label">Total:</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">to the</td>
+                              <td valign="top" class="cell">to the</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">left</td>
+                              <td valign="top" class="cell">left</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">has a </td>
+                              <td valign="top" class="cell">has a </td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1"><span class="monospace">@role</span> = label</td>
+                              <td valign="top" class="cell"><span class="monospace">@role</span> = label</td>
                               						</tr>
                         </table>
                         <div class="caption">
@@ -972,56 +973,56 @@ public class HelloWorld {
                         <table class="table">
                            <tr class="row label">
                               							
-                              <td valign="top" class="cell" colspan="5" rowspan="1">This table has no <span class="monospace">&lt;head&gt;</span> and the first row spans 5
+                              <td valign="top" class="cell" colspan="5">This table has no <span class="monospace">&lt;head&gt;</span> and the first row spans 5
                                  								columns</td>
                               						</tr>
                            <tr class="row">
                               							
-                              <td valign="top" class="cell label" colspan="1" rowspan="1">These cells</td>
+                              <td valign="top" class="cell label">These cells</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               						</tr>
                            <tr class="row">
                               							
-                              <td valign="top" class="cell label" colspan="1" rowspan="1">have</td>
+                              <td valign="top" class="cell label">have</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               						</tr>
                            <tr class="row">
                               							
-                              <td valign="top" class="cell label" colspan="1" rowspan="1"><span class="monospace">@role</span> = label</td>
+                              <td valign="top" class="cell label"><span class="monospace">@role</span> = label</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               						</tr>
                            <tr class="row">
                               							
-                              <td valign="top" class="cell label" colspan="1" rowspan="1">Final<br />Total:</td>
+                              <td valign="top" class="cell label">Final<br />Total:</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">regular</td>
+                              <td valign="top" class="cell">regular</td>
                               							
-                              <td valign="top" class="cell" colspan="1" rowspan="1">data</td>
+                              <td valign="top" class="cell">data</td>
                               						</tr>
                         </table>
                         <div class="caption-no-label">
@@ -1033,10 +1034,48 @@ public class HelloWorld {
                   
                   			</div>
                			
+               <div class="div div0">
+                  				
+                  <h1 class="head">7: Styling</h1>
+                  				
+                  <div class="counter"><a href="#p43">43</a></div>
+                  <div class="ptext" id="p43">The @style attribute can be placed on any element and will be passed through to the
+                     XHTML output as a corresponding HTML @style attribute. This feature should <em class="emph">only</em> be used for specific styling overrides, after discussion with the editorial team.
+                     Ordinary styling of headings, terms, etc. should be left to the stylesheet.</div>
+                  				
+                  <div class="counter"><a href="#p44">44</a></div>
+                  <div class="ptext" id="p44">Some examples:
+                     					
+                     <ul class="list">
+                        <li class="item">thin solid blue border on the list</li>
+                        <li class="item">Red styling on the list item</li>
+                        <li class="item">Red styling just on <span class="hi" style="color:red;">highlighted text</span></li>
+                     </ul>
+                     					
+                     <div class="table">
+                        <table class="table">
+                           <tr class="row">
+                              							
+                              <td valign="top" class="cell" style="border:thick red dashed;">Cell with thick red dashed border</td>
+                              							
+                              <td valign="top" class="cell" style="border:none;">Cell with no border</td>
+                              						</tr>
+                        </table>
+                        <div class="caption-no-label">
+                           <div class="label">Table 3. </div>
+                        </div>
+                     </div>
+                     				</div>
+                  				
+                  <div class="counter"><a href="#p45">45</a></div>
+                  <div class="ptext" id="p45">Paragraph with red background color</div>
+                  				
+                  			</div>
+               
                			
                <div class="div div0">
                   				
-                  <h1 class="head">7: Mathematical Expressions and Equations</h1>
+                  <h1 class="head">8: Mathematical Expressions and Equations</h1>
                   			</div>
                
                			
@@ -1044,9 +1083,36 @@ public class HelloWorld {
                   				
                   <h1 class="head">Acknowledgements</h1>
                   				
-                  <div class="counter"><a href="#p43">43</a></div>
-                  <div class="ptext" id="p43">Thank you to everyone who made this “riveting” article
+                  <div class="counter"><a href="#p46">46</a></div>
+                  <div class="ptext" id="p46">Thank you to everyone who made this “riveting” article
                      					possible.</div>
+                  			</div>
+               			
+               <div class="div div0">
+                  				
+                  <h1 class="head">A Normal Discussion about Bibliographies</h1>
+                  				
+                  <div class="counter"><a href="#p47">47</a></div>
+                  <div class="ptext" id="p47">This is a section that talks about bibliographies.</div>
+                  				
+                  <div>
+                     					
+                     <div class="bibl"><span class="ref" id="milton1660"><!-- close -->Milton 1660</span> Milton, John. <cite class="title">Paradise Lost</cite></div>
+                     					
+                     <div class="bibl"><span class="ref" id="milton1661"><!-- close -->Milton 1661</span> Milton, John. <cite class="title">Paradise Regained</cite></div>
+                     				</div>
+                  			</div>
+               			
+               <div class="div div0">
+                  				
+                  <h1 class="head">Appendix: Sources</h1>
+                  				
+                  <div>
+                     					
+                     <div class="bibl"><span class="ref" id="dickens1857"><!-- close -->Dickens 1857</span> Dickens, Charles. <cite class="title italic">Bleak House</cite>.</div>
+                     					
+                     <div class="bibl"><span class="ref" id="bronte1838"><!-- close -->Brontë 1838</span> Brontë, Charlotte. <cite class="title italic">Jane Eyre</cite>.</div>
+                     				</div>
                   			</div>
                		
                		
@@ -1057,31 +1123,31 @@ public class HelloWorld {
             
             <div id="notes">
                <h2>Notes</h2>
-               <div class="endnote" id="d3e333"><span class="noteRef lang en">[1] A semi-randomly
+               <div class="endnote" id="d4e328"><span class="noteRef lang en">[1] A semi-randomly
                      							generated sonnet from <a href="https://www.poem-generator.org.uk/sonnet/" onclick="window.open('https://www.poem-generator.org.uk/sonnet/'); return false" class="ref">https://www.poem-generator.org.uk/sonnet/</a></span></div>
-               <div class="endnote" id="d3e653"><span class="noteRef lang en">[2] <span class="monospace">&lt;code&gt;</span> is rendered inline with other
+               <div class="endnote" id="d4e620"><span class="noteRef lang en">[2] <span class="monospace">&lt;code&gt;</span> is rendered inline with other
                      							paragraph text. It should not be used for snippets of code which are
                      							longer than 40 characters. It also should not be used simply for mere
                      							visual demarcation of words or variables, use <span class="monospace">&lt;hi&gt;</span> with
                      								<span class="monospace">@rend</span>=monospace instead.</span></div>
-               <div class="endnote" id="d3e1282"><span class="noteRef lang en">[3] Did you notice I skipped “u”?</span></div>
-               <div class="endnote" id="d3e1292"><span class="noteRef lang en">[4] I also skipped “x”</span></div>
-               <div class="endnote" id="d3e1327"><span class="noteRef lang en">[5] Did you notice I skipped “u”?</span></div>
-               <div class="endnote" id="d3e1336"><span class="noteRef lang en">[6] I also skipped “x”</span></div>
+               <div class="endnote" id="d4e1182"><span class="noteRef lang en">[3] Did you notice I skipped “u”?</span></div>
+               <div class="endnote" id="d4e1192"><span class="noteRef lang en">[4] I also skipped “x”</span></div>
+               <div class="endnote" id="d4e1223"><span class="noteRef lang en">[5] Did you notice I skipped “u”?</span></div>
+               <div class="endnote" id="d4e1232"><span class="noteRef lang en">[6] I also skipped “x”</span></div>
             </div>
             <div id="worksCited">
                <h2>Works Cited</h2>
                <div class="bibl"><span class="ref" id="dunn2012"><!-- close -->Dunn 2012</span> Dunn, P. (2012) <cite class="title italic">Boston T-Time</cite>, Stonebrown Design. Available at: <a href="http://www.stonebrowndesign.com/boston-t-time.html" onclick="window.open('http://www.stonebrowndesign.com/boston-t-time.html'); return false" class="ref">http://www.stonebrowndesign.com/boston-t-time.html</a> (Accessed: 1
                   					September 2022).</div>
                <div class="bibl"><span class="ref" id="flanders_etal2007"><!-- close -->Flanders, Piez and Terras 2007</span> Flanders,
-                  					Julia, Piez, Wendell and Terras, Melissa. (2007) “Welcome to Digital
-                  						Humanities Quarterly”
+                  					Julia, Piez, Wendell and Terras, Melissa. (2007) “Welcome to
+                  						Digital Humanities Quarterly”
                   					<cite class="title italic">Digital Humanities Quarterly</cite>, 001(1).</div>
-               <div class="bibl"><span class="ref" id="xmlpdf"><!-- close -->Hello World Example</span> Hello World Example (no
-                  					date). Available at: <a href="https://www.xmlpdf.com/hello-world.html" onclick="window.open('https://www.xmlpdf.com/hello-world.html'); return false" class="ref">https://www.xmlpdf.com/hello-world.html</a> (Accessed: 31 August
+               <div class="bibl"><span class="ref" id="xmlpdf"><!-- close -->Hello World Example</span> Hello World Example (no date).
+                  					Available at: <a href="https://www.xmlpdf.com/hello-world.html" onclick="window.open('https://www.xmlpdf.com/hello-world.html'); return false" class="ref">https://www.xmlpdf.com/hello-world.html</a> (Accessed: 31 August
                   					2022).</div>
-               <div class="bibl"><span class="ref" id="loremipsum"><!-- close -->Lorem Ipsum – Generator, Origins and Meaning</span> Lorem Ipsum –
-                  					Generator, Origins and Meaning (no date) <cite class="title italic">Lorem
+               <div class="bibl"><span class="ref" id="loremipsum"><!-- close -->Lorem Ipsum – Generator, Origins and Meaning</span> Lorem
+                  					Ipsum – Generator, Origins and Meaning (no date) <cite class="title italic">Lorem
                      						Ipsum</cite>. Available at: <a href="https://loremipsum.io/" onclick="window.open('https://loremipsum.io/'); return false" class="ref">https://loremipsum.io/</a> (Accessed: 29 August 2022). </div>
                <div class="bibl"><span class="ref" id="raben2007"><!-- close -->Raben 2007</span> Raben, J. (2007) “Introducing Issues in Humanities Computing”
                   					<cite class="title italic">Digital Humanities Quarterly</cite>, 001(1).</div>

--- a/articles/000000/000000.xml
+++ b/articles/000000/000000.xml
@@ -884,6 +884,21 @@ public class HelloWorld {
 				<p>Thank you to everyone who made this <soCalled>riveting</soCalled> article
 					possible.</p>
 			</div>
+			<div>
+				<head>A Normal Discussion about Bibliographies</head>
+				<p>This is a section that talks about bibliographies.</p>
+				<listBibl>
+					<bibl xml:id="milton1660" label="Milton 1660">Milton, John. <title>Paradise Lost</title></bibl>
+					<bibl xml:id="milton1661" label="Milton 1661">Milton, John. <title>Paradise Regained</title></bibl>
+				</listBibl>
+			</div>
+			<div type="appendix">
+				<head>Appendix: Sources</head>
+				<listBibl>
+					<bibl xml:id="dickens1857" label="Dickens 1857">Dickens, Charles. <title rend="italic">Bleak House</title>.</bibl>
+					<bibl xml:id="bronte1838" label="Brontë 1838">Brontë, Charlotte. <title rend="italic">Jane Eyre</title>.</bibl>
+				</listBibl>
+			</div>
 		</body>
 		<back>
 			<listBibl>

--- a/common/css/dhq.css
+++ b/common/css/dhq.css
@@ -151,7 +151,7 @@ div#worksCited div.bibl span.ref {
     font-weight: bold;
 }
 /* added the rule below to accommodate bibls that are in a listBibl in an Appendix, to allow their labels to be bold */
-div.div0 span.bibl span.ref {
+div.div0 div.bibl span.ref {
     font-weight: bold;
 }
 

--- a/common/css/dhq.css
+++ b/common/css/dhq.css
@@ -150,6 +150,12 @@ div#worksCited h2, div#notes h2 {
 div#worksCited div.bibl span.ref {
     font-weight: bold;
 }
+/* added the rule below to accommodate bibls that are in a listBibl in an Appendix, to allow their labels to be bold */
+div.div0 span.bibl span.ref {
+    font-weight: bold;
+}
+
+
 a.ref {
      font-weight: normal;
 }

--- a/common/xslt/dhq2html.xsl
+++ b/common/xslt/dhq2html.xsl
@@ -110,7 +110,7 @@
     <xsl:template match="tei:encodingDesc"/>
     <xsl:template match="tei:profileDesc"/>
     <xsl:template match="tei:revisionDesc"/>
-    <xsl:template match="tei:listBibl"/>
+    <!--  <xsl:template match="tei:listBibl"/> reversing the suppression of listBibl since we need to be able to display listBibl outside of the works cited section-->
     <xsl:template match="dhq:label"/>
     <xsl:template match="dhq:teaser"/>
     <xsl:template match="dhq:langUsage"/>
@@ -1623,6 +1623,15 @@
         <xsl:call-template name="show-bibl-fallback"/>
       </span><xsl:text>)&#160;</xsl:text>
     </xsl:template>
+	
+	<!-- adding another template to provide an option without parentheses, in cases where the bibls are in a listBibl in an appendix, rather than in the back matter -->
+ <xsl:template match="tei:div[@type='appendix']//tei:listBibl/tei:bibl">
+      
+      <span class="bibl">
+        <xsl:call-template name="show-bibl-fallback"/>
+      </span>
+    </xsl:template>
+	
 
   <xsl:template name="show-bibl-fallback">
     <span class="ref">

--- a/common/xslt/dhq2html.xsl
+++ b/common/xslt/dhq2html.xsl
@@ -110,7 +110,8 @@
     <xsl:template match="tei:encodingDesc"/>
     <xsl:template match="tei:profileDesc"/>
     <xsl:template match="tei:revisionDesc"/>
-    <!--  <xsl:template match="tei:listBibl"/> reversing the suppression of listBibl since we need to be able to display listBibl outside of the works cited section-->
+    <!--  suppressing only listBibl in the <back>, to avoid duplicating its contents, but enabling listBibl elsewhere -->
+	<xsl:template match="/tei:TEI/tei:text/tei:back/tei:listBibl"/>
     <xsl:template match="dhq:label"/>
     <xsl:template match="dhq:teaser"/>
     <xsl:template match="dhq:langUsage"/>
@@ -1588,6 +1589,7 @@
         <xsl:number level="any"/>
     </xsl:template>
 
+<!-- create the structural space for the main article bibliography, and insert sorted list of bibls -->
     <xsl:template name="bibliography">
         <xsl:if test="/tei:TEI/tei:text/tei:back/tei:listBibl">
             <div id="worksCited">
@@ -1599,13 +1601,24 @@
             </div>
         </xsl:if>
     </xsl:template>
+	
+<!-- for <listBibl>s that are not the main article bibliography, create an ordinary div -->
+	<xsl:template match="tei:listBibl">
+		<div>
+			<xsl:apply-templates/>
+		</div>
+	</xsl:template>
 
-  <xsl:template match="tei:listBibl/tei:bibl">
+<!-- for each bibl, regardless of which listBibl it's in, create a div -->
+  <xsl:template match="tei:bibl">
     <div class="bibl">
       <xsl:call-template name="show-bibl-fallback"/>
     </div>
   </xsl:template>
 
+
+	
+	<!-- For annotated bibliographies, where the <bibl> is inside a <label> in a regular <list>, we handle <bibl> as a span instead. -->
   <xsl:template
     match="tei:label[not(*[not(self::tei:bibl)] | text()[normalize-space(.)])]/tei:bibl |
     tei:item[not(*[not(self::tei:bibl)] | text()[normalize-space(.)])]/tei:bibl">
@@ -1617,21 +1630,23 @@
     </span>
   </xsl:template>
 
+<!--  Removing this template, which handles <bibl> outside of <listBibl>, no longer needed
   <xsl:template match="tei:bibl">
       <xsl:text>&#160;(</xsl:text>
       <span class="bibl">
         <xsl:call-template name="show-bibl-fallback"/>
       </span><xsl:text>)&#160;</xsl:text>
     </xsl:template>
+-->
 	
-	<!-- adding another template to provide an option without parentheses, in cases where the bibls are in a listBibl in an appendix, rather than in the back matter -->
+	<!-- For cases where the bibls are in a listBibl in an appendix, rather than in the back matter 
  <xsl:template match="tei:div[@type='appendix']//tei:listBibl/tei:bibl">
       
       <span class="bibl">
         <xsl:call-template name="show-bibl-fallback"/>
       </span>
     </xsl:template>
-	
+	-->
 
   <xsl:template name="show-bibl-fallback">
     <span class="ref">
@@ -1647,7 +1662,19 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-
+<!--  
+  <xsl:template name="non-WC-bibl">
+    <span class="ref">
+      <xsl:attribute name="id">
+        <xsl:apply-templates select="." mode="id"/>
+      </xsl:attribute>
+    </span>
+    <xsl:if test="normalize-space(@label)">
+      <xsl:text>&#160;</xsl:text>
+    </xsl:if>
+    <xsl:apply-templates/>
+  </xsl:template>
+-->
     <xsl:template match="tei:foreign">
         <span>
             <xsl:call-template name="assign-class">


### PR DESCRIPTION
What needed to be done: support a separate use case for when a bibliography appears in an Appendix; this would be in cases where the bibliography is (in effect) "mentioned" rather than used as part of the article's bibliographic apparatus. 

Current problem case: article 000682 (this pull request has been tested with that article).

What this pull request tries to do:

- updated DHQ XSLT to create a template that provides a separate case for `<bibl>` when it appears in an Appendix. (We didn't want to interfere with existing XSLT rules, but we suspect that the current provision for `<bibl>` in contexts outside of `<back>` maybe obsolete and unnecessary.

- also added a CSS rule to support the desired formatting: take the value of `@label,` put it at the start,  and make it bold.