### PR TITLE
add `@xml:lang` to `<q>`

### DIFF
--- a/common/schema/DHQauthor-TEI.rnc
+++ b/common/schema/DHQauthor-TEI.rnc
@@ -12,7 +12,7 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
-# Schema generated from ODD source 2023-07-30T15:56:44Z. .
+# Schema generated from ODD source 2023-08-25T23:07:31Z. .
 # TEI Edition: Version 4.4.0. Last updated on
 #         19th April 2022, revision ff9cc28b0
 # TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.4.0/
@@ -1236,11 +1236,9 @@ dhq_att.anchoring.attributes =
   dhq_att.anchoring.attribute.anchored,
   dhq_att.anchoring.attribute.targetEnd
 dhq_att.anchoring.attribute.anchored =
-  
   ## (anchored) indicates whether the copy text shows the exact place of reference for the note.
   [ a:defaultValue = "true" ] attribute anchored { xsd:boolean }?
 dhq_att.anchoring.attribute.targetEnd =
-  
   ## (target end) points to the end of the span to which the note is attached, if the note is not embedded in the text at that point.
   attribute targetEnd {
     list {
@@ -1249,7 +1247,6 @@ dhq_att.anchoring.attribute.targetEnd =
   }?
 dhq_att.ascribed.attributes = dhq_att.ascribed.attribute.who
 dhq_att.ascribed.attribute.who =
-  
   ## indicates the person, or group of people, to whom the element content is ascribed.
   attribute who {
     list {
@@ -1260,7 +1257,6 @@ dhq_att.ascribed.directed.attributes =
   dhq_att.ascribed.attributes,
   dhq_att.ascribed.directed.attribute.toWhom
 dhq_att.ascribed.directed.attribute.toWhom =
-  
   ## indicates the person, or group of people, to whom a speech act or action is directed.
   attribute toWhom {
     list {
@@ -1270,11 +1266,9 @@ dhq_att.ascribed.directed.attribute.toWhom =
 dhq_att.canonical.attributes =
   dhq_att.canonical.attribute.key, dhq_att.canonical.attribute.ref
 dhq_att.canonical.attribute.key =
-  
   ## provides an externally-defined means of identifying the entity (or entities) being named, using a coded value of some kind.
   attribute key { xsd:string }?
 dhq_att.canonical.attribute.ref =
-  
   ## (reference) provides an explicit means of locating a full definition or identity for the entity being named by means of one or more URIs.
   attribute ref {
     list {
@@ -1295,36 +1289,24 @@ dhq_att.written.attribute.hand =
   }?
 dhq_att.breaking.attributes = dhq_att.breaking.attribute.break
 dhq_att.breaking.attribute.break =
-  
   ## indicates whether or not the element bearing this attribute should be considered to mark the end of an orthographic token in the same way as whitespace.
   attribute break {
     xsd:token { pattern = "[^\p{C}\p{Z}]+" }
   }?
 dhq_att.fragmentable.attributes = dhq_att.fragmentable.attribute.part
 dhq_att.fragmentable.attribute.part =
-  
   ## specifies whether or not its parent element is fragmented in some way, typically by some other overlapping structure: for example a speech which is divided between two or more verse stanzas, a paragraph which is split across a page division, a verse line which is divided between two speakers.
   [ a:defaultValue = "N" ]
   attribute part {
-    
     ## (yes) the element is fragmented in some (unspecified) respect
-    "Y"
-    | 
-      ## (no) the element is not fragmented, or no claim is made as to its completeness
-      "N"
-    | 
-      ## (initial) this is the initial part of a fragmented element
-      "I"
-    | 
-      ## (medial) this is a medial part of a fragmented element
-      "M"
-    | 
-      ## (final) this is the final part of a fragmented element
+    "Y" | ## (no) the element is not fragmented, or no claim is made as to its completeness
+      "N" | ## (initial) this is the initial part of a fragmented element
+      "I" | ## (medial) this is a medial part of a fragmented element
+      "M" | ## (final) this is the final part of a fragmented element
       "F"
   }?
 dhq_att.docStatus.attributes = dhq_att.docStatus.attribute.status
 dhq_att.docStatus.attribute.status =
-  
   ## describes the status of a document either currently or, when associated with a dated element, at the time indicated.
   ## Sample values include: 1] approved; 2] candidate; 3] cleared; 4] deprecated; 5] draft; 6] embargoed; 7] expired; 8] frozen; 9] galley; 10] proposed; 11] published; 12] recommendation; 13] submitted; 14] unfinished; 15] withdrawn
   [ a:defaultValue = "draft" ]
@@ -1334,13 +1316,11 @@ dhq_att.docStatus.attribute.status =
 dhq_att.global.rendition.attributes =
   dhq_att.global.rendition.attribute.style
 dhq_att.global.rendition.attribute.style =
-  
   ## contains an expression in some formal style definition language which defines the rendering or presentation used for this element in the source text
   attribute style { xsd:string }?
 dhq_att.global.source.attributes =
   dhq_att.global.source.attribute.source
 dhq_att.global.source.attribute.source =
-  
   ## specifies the source from which some aspect of this element is drawn.
   attribute source {
     list {
@@ -1386,7 +1366,6 @@ dhq_att.global.attributes =
 dhq_att.internetMedia.attributes =
   dhq_att.internetMedia.attribute.mimeType
 dhq_att.internetMedia.attribute.mimeType =
-  
   ## (MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type
   attribute mimeType {
     list {
@@ -1394,7 +1373,6 @@ dhq_att.internetMedia.attribute.mimeType =
     }
   }?
 dhq_att.media.attribute.scale =
-  
   ## Where the media are displayed, indicates a scale factor to be applied when generating the desired display size
   attribute scale {
     xsd:double
@@ -1403,21 +1381,18 @@ dhq_att.media.attribute.scale =
   }?
 dhq_att.resourced.attributes = dhq_att.resourced.attribute.url
 dhq_att.resourced.attribute.url =
-  
   ## (uniform resource locator) specifies the URL from which the media concerned may be obtained.
   attribute url {
     xsd:anyURI { pattern = "\S+" }
   }
 dhq_att.notated.attributes = dhq_att.notated.attribute.notation
 dhq_att.notated.attribute.notation =
-  
   ## names the notation used for the content of the element.
   attribute notation {
     xsd:token { pattern = "[^\p{C}\p{Z}]+" }
   }?
 dhq_att.sortable.attributes = dhq_att.sortable.attribute.sortKey
 dhq_att.sortable.attribute.sortKey =
-  
   ## supplies the sort key for this element in an index, list or group which contains it.
   attribute sortKey {
     xsd:token { pattern = "[^\p{C}\p{Z}]+" }
@@ -1425,7 +1400,6 @@ dhq_att.sortable.attribute.sortKey =
 dhq_att.edition.attributes =
   dhq_att.edition.attribute.ed, dhq_att.edition.attribute.edRef
 dhq_att.edition.attribute.ed =
-  
   ## (edition) supplies a sigil or other arbitrary identifier for the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.
   attribute ed {
     list {
@@ -1433,7 +1407,6 @@ dhq_att.edition.attribute.ed =
     }
   }?
 dhq_att.edition.attribute.edRef =
-  
   ## (edition reference) provides a pointer to the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.
   attribute edRef {
     list {
@@ -1445,33 +1418,17 @@ dhq_att.citing.attributes =
   dhq_att.citing.attribute.from,
   dhq_att.citing.attribute.to
 dhq_att.citing.attribute.unit =
-  
   ## identifies the unit of information conveyed by the element, e.g. columns, pages, volume, entry.
   ## Suggested values include: 1] volume (volume); 2] issue; 3] page (page); 4] line; 5] chapter (chapter); 6] part; 7] column; 8] entry
   attribute unit {
-    
     ## (volume) the element contains a volume number.
-    "volume"
-    | 
-      ## the element contains an issue number, or volume and issue numbers.
-      "issue"
-    | 
-      ## (page) the element contains a page number or page range.
-      "page"
-    | 
-      ## the element contains a line number or line range.
-      "line"
-    | 
-      ## (chapter) the element contains a chapter indication (number and/or title)
-      "chapter"
-    | 
-      ## the element identifies a part of a book or collection.
-      "part"
-    | 
-      ## the element identifies a column.
-      "column"
-    | 
-      ## the element identifies an entry number or label in a list of entries.
+    "volume" | ## the element contains an issue number, or volume and issue numbers.
+      "issue" | ## (page) the element contains a page number or page range.
+      "page" | ## the element contains a line number or line range.
+      "line" | ## (chapter) the element contains a chapter indication (number and/or title)
+      "chapter" | ## the element identifies a part of a book or collection.
+      "part" | ## the element identifies a column.
+      "column" | ## the element identifies an entry number or label in a list of entries.
       "entry"
     | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
   }?
@@ -1802,8 +1759,8 @@ dhq_model.correspContextPart =
 dhq_model.correspDescPart =
   dhq_note | dhq_noteGrp | dhq_correspAction | dhq_correspContext
 dhq_model.resource = dhq_text | dhq_standOff
+
 dhq_p =
-  
   ## (paragraph) marks paragraphs in prose. [3.1. Paragraphs 7.2.5. Speech Contents]
   element tei:p {
     dhq_macro.paraContent
@@ -1856,65 +1813,46 @@ dhq_p =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_foreign =
-  
   ## (foreign) identifies a word or phrase as belonging to some language other than that of the surrounding text. [3.3.2.1. Foreign Words or Expressions]
   element tei:foreign {
     dhq_macro.phraseSeq,
     dhq_att.global.attributes,
-    
     ## Identifies the language of the element's content
     attribute xml:lang { text }?,
     empty
   }
+
 dhq_emph =
-  
   ## (emphasized) marks words or phrases which are stressed or emphasized for linguistic or rhetorical effect. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]
   element tei:emph {
     dhq_macro.paraContent, dhq_att.global.attributes, empty
   }
+
 dhq_hi =
-  
   ## (highlighted) marks a word or phrase as graphically distinct from the surrounding text, for reasons concerning which no claim is made. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]
   element tei:hi {
     dhq_macro.paraContent,
     dhq_att.global.attributes,
     dhq_att.written.attributes,
-    
     ## Describes the presentation of the highlighted material.
     attribute rend {
-      
       ## The designated content is intended to be rendered in bold type.
-      "bold"
-      | 
-        ## The designated content is intended to be rendered in italic type.
-        "italic"
-      | 
-        ## The designated content is intended to be rendered in monospace type.
-        "monospace"
-      | 
-        ## The designated content is intended to be rendered within quotation marks. The nesting of single and double quotation marks will be handled by the stylesheet.
-        "quotes"
-      | 
-        ## The designated content is intended to be rendered in small capital letters.
-        "smcaps"
-      | 
-        ## The designated content is intended to be rendered as a subscript.
-        "subscript"
-      | 
-        ## The designated content is intended to be rendered as a superscript.
-        "superscript"
-      | 
-        ## The designated content is intended to be rendered with an underline.
-        "underlined"
-      | 
-        ## The designated content is intended to be rendered with a strikethrough.
+      "bold" | ## The designated content is intended to be rendered in italic type.
+        "italic" | ## The designated content is intended to be rendered in monospace type.
+        "monospace" | ## The designated content is intended to be rendered within quotation marks. The nesting of single and double quotation marks will be handled by the stylesheet.
+        "quotes" | ## The designated content is intended to be rendered in small capital letters.
+        "smcaps" | ## The designated content is intended to be rendered as a subscript.
+        "subscript" | ## The designated content is intended to be rendered as a superscript.
+        "superscript" | ## The designated content is intended to be rendered with an underline.
+        "underlined" | ## The designated content is intended to be rendered with a strikethrough.
         "strikethrough"
     }?,
     empty
   }
+
 dhq_said =
-  
   ## (speech or thought) indicates passages thought or spoken aloud, whether explicitly indicated in the source or not, whether directly or indirectly reported, whether by real people or fictional characters. [3.3.3. Quotation]
   element tei:said {
     dhq_macro.specialPara,
@@ -1922,39 +1860,34 @@ dhq_said =
     dhq_att.ascribed.directed.attributes,
     empty
   }
+
 dhq_quote =
-  
   ## (quotation) contains a phrase or passage attributed by the narrator or author to some agency external to the text. [3.3.3. Quotation 4.3.1. Grouped Texts]
   element tei:quote {
     dhq_macro.specialPara,
     dhq_att.global.attributes,
     dhq_att.notated.attributes,
-    
     ## Describes the presentation of the quoted material, whether inline or set as a block.
     attribute rend {
-      
       ## Designates an inline quotation (i.e. one that is flowed into the surrounding text rather than set off from it), typically containing text and inline elements.
-      "inline"
-      | 
-        ## Designates a block quotation, typically containing one or more paragraphs or other chunky things.
+      "inline" | ## Designates a block quotation, typically containing one or more paragraphs or other chunky things.
         "block"
     },
-    
-    ##
     attribute xml:lang { text }?,
     empty
   }
+
 dhq_q =
-  
   ## (quoted) contains material which is distinguished from the surrounding text using quotation marks or a similar method, for any one of a variety of reasons including, but not limited to: direct speech or thought, technical terms or jargon, authorial distance, quotations from elsewhere, and passages that are mentioned but not used. [3.3.3. Quotation]
   element tei:q {
     dhq_macro.specialPara,
     dhq_att.global.attributes,
     dhq_att.ascribed.directed.attributes,
+    attribute xml:lang { text }?,
     empty
   }
+
 dhq_cit =
-  
   ## (cited quotation) contains a quotation from some other document, together with a bibliographic reference to its source. In a dictionary it may contain an example text with at least one occurrence of the word form, used in the sense being described, or a translation of the headword, or an example. [3.3.3. Quotation 4.3.1. Grouped Texts 9.3.5.1. Examples]
   element tei:cit {
     (dhq_quote,
@@ -1962,14 +1895,14 @@ dhq_cit =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_soCalled =
-  
   ## (so called) contains a word or phrase for which the author or narrator indicates a disclaiming of responsibility, for example by the use of scare quotes or italics. [3.3.3. Quotation]
   element tei:soCalled {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_desc =
-  
   ## (description) contains a short description of the purpose, function, or use of its parent element, or when the parent is a documentation element, describes or defines the object being documented.  [22.4.1. Description of Components]
   element tei:desc {
     dhq_macro.limitedContent
@@ -1999,300 +1932,33 @@ dhq_desc =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_term =
-  
   ## (term) contains a single-word, multi-word, or symbolic designation which is regarded as a technical term. [3.4.1. Terms and Glosses]
   element tei:term {
     dhq_macro.phraseSeq,
     dhq_att.global.attributes,
     dhq_att.canonical.attributes,
-    
-    ##
     attribute xml:lang { text }?,
-    
-    ##
     attribute corresp {
-      
-      ##
-      "#access"
-      | 
-        ##
-        "#annotation"
-      | 
-        ##
-        "#anthropology"
-      | 
-        ##
-        "#ar"
-      | 
-        ##
-        "#archaeology"
-      | 
-        ##
-        "#archives"
-      | 
-        ##
-        "#area_studies"
-      | 
-        ##
-        "#citation"
-      | 
-        ##
-        "#classics"
-      | 
-        ##
-        "#code_studies"
-      | 
-        ##
-        "#collaboration"
-      | 
-        ##
-        "#comics"
-      | 
-        ##
-        "#communications"
-      | 
-        ##
-        "#content_analysis"
-      | 
-        ##
-        "#corpora"
-      | 
-        ##
-        "#cs"
-      | 
-        ##
-        "#cultural_criticism"
-      | 
-        ##
-        "#cultural_heritage"
-      | 
-        ##
-        "#data_analytics"
-      | 
-        ##
-        "#data_curation"
-      | 
-        ##
-        "#data_modeling"
-      | 
-        ##
-        "#data_visualization"
-      | 
-        ##
-        "#databases"
-      | 
-        ##
-        "#dh"
-      | 
-        ##
-        "#digital"
-      | 
-        ##
-        "#digital_libraries"
-      | 
-        ##
-        "#digital_literacy"
-      | 
-        ##
-        "#digitization"
-      | 
-        ##
-        "#editing"
-      | 
-        ##
-        "#elit"
-      | 
-        ##
-        "#ecocriticism"
-      | 
-        ##
-        "#ethics"
-      | 
-        ##
-        "#games"
-      | 
-        ##
-        "#gender"
-      | 
-        ##
-        "#geospatial"
-      | 
-        ##
-        "#glam"
-      | 
-        ##
-        "#globalDH"
-      | 
-        ##
-        "#graphic_design"
-      | 
-        ##
-        "#history"
-      | 
-        ##
-        "#hypertext"
-      | 
-        ##
-        "#images"
-      | 
-        ##
-        "#indigenous"
-      | 
-        ##
-        "#info_architecture"
-      | 
-        ##
-        "#informatics"
-      | 
-        ##
-        "#information_retrieval"
-      | 
-        ##
-        "#infrastructure"
-      | 
-        ##
-        "#interdisciplinarity"
-      | 
-        ##
-        "#language_studies"
-      | 
-        ##
-        "#linguistics"
-      | 
-        ##
-        "#literary_studies"
-      | 
-        ##
-        "#machine_learning"
-      | 
-        ##
-        "#manuscripts"
-      | 
-        ##
-        "#markup"
-      | 
-        ##
-        "#materialisms"
-      | 
-        ##
-        "#media_history"
-      | 
-        ##
-        "#media_studies"
-      | 
-        ##
-        "#medieval"
-      | 
-        ##
-        "#metadata"
-      | 
-        ##
-        "#minimal_computing"
-      | 
-        ##
-        "#mobile"
-      | 
-        ##
-        "#moving_images"
-      | 
-        ##
-        "#music"
-      | 
-        ##
-        "#network"
-      | 
-        ##
-        "#nlp"
-      | 
-        ##
-        "#oral_history"
-      | 
-        ##
-        "#pedagogy"
-      | 
-        ##
-        "#performance"
-      | 
-        ##
-        "#philosophy"
-      | 
-        ##
-        "#project_management"
-      | 
-        ##
-        "#project_report"
-      | 
-        ##
-        "#public_history"
-      | 
-        ##
-        "#publishing"
-      | 
-        ##
-        "#race"
-      | 
-        ##
-        "#reading"
-      | 
-        ##
-        "#religion"
-      | 
-        ##
-        "#rhetoric"
-      | 
-        ##
-        "#semantic_web"
-      | 
-        ##
-        "#social_justice"
-      | 
-        ##
-        "#social_media"
-      | 
-        ##
-        "#sound"
-      | 
-        ##
-        "#standards"
-      | 
-        ##
-        "#stylistics"
-      | 
-        ##
-        "#tools"
-      | 
-        ##
-        "#transcription"
-      | 
-        ##
-        "#translation"
-      | 
-        ##
-        "#users"
-      | 
-        ##
-        "#visual_art"
-      | 
-        ##
-        "#web"
+      "#access" | "#annotation" | "#anthropology" | "#ar" | "#archaeology" | "#archives" | "#area_studies" | "#citation" | "#classics" | "#code_studies" | "#collaboration" | "#comics" | "#communications" | "#content_analysis" | "#corpora" | "#cs" | "#cultural_criticism" | "#cultural_heritage" | "#data_analytics" | "#data_curation" | "#data_modeling" | "#data_visualization" | "#databases" | "#dh" | "#digital" | "#digital_libraries" | "#digital_literacy" | "#digitization" | "#editing" | "#elit" | "#ecocriticism" | "#ethics" | "#games" | "#gender" | "#geospatial" | "#glam" | "#globalDH" | "#graphic_design" | "#history" | "#hypertext" | "#images" | "#indigenous" | "#info_architecture" | "#informatics" | "#information_retrieval" | "#infrastructure" | "#interdisciplinarity" | "#language_studies" | "#linguistics" | "#literary_studies" | "#machine_learning" | "#manuscripts" | "#markup" | "#materialisms" | "#media_history" | "#media_studies" | "#medieval" | "#metadata" | "#minimal_computing" | "#mobile" | "#moving_images" | "#music" | "#network" | "#nlp" | "#oral_history" | "#pedagogy" | "#performance" | "#philosophy" | "#project_management" | "#project_report" | "#public_history" | "#publishing" | "#race" | "#reading" | "#religion" | "#rhetoric" | "#semantic_web" | "#social_justice" | "#social_media" | "#sound" | "#standards" | "#stylistics" | "#tools" | "#transcription" | "#translation" | "#users" | "#visual_art" | "#web"
     }?,
     empty
   }
+
 dhq_ruby =
-  
   ## (ruby container) contains a passage of base text along with its associated ruby gloss(es). [3.4.2. Ruby Annotations]
   element tei:ruby {
     (dhq_rb, dhq_rt+), dhq_att.global.attributes, empty
   }
+
 dhq_rb =
-  
   ## (ruby base) contains the base text annotated by a ruby gloss. [3.4.2. Ruby Annotations]
   element tei:rb {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_rt =
-  
   ## (ruby text) contains a ruby text, an annotation closely associated with a passage of the main text. [3.4.2. Ruby Annotations]
   element tei:rt {
     dhq_macro.phraseSeq,
@@ -2375,76 +2041,60 @@ dhq_rt =
        ],
     empty
   }
+
 dhq_ellipsis =
-  
   ## (deliberately marked omission) indicates a purposeful marking in the source document signalling that content has been omitted, and may also supply or describe the omitted content. [3.5.3. Additions, Deletions, and Omissions]
   element tei:ellipsis {
     dhq_model.descLike?, dhq_att.global.attributes, empty
   }
+
 dhq_name =
-  
   ## (name, proper noun) contains a proper noun or noun phrase. [3.6.1. Referring Strings]
   element tei:name {
     dhq_macro.phraseSeq,
     dhq_att.global.attributes,
-    
     ## Specifies the role of the person named in relation to the bibliographic object.
     ## Suggested values include: 1] translator; 2] editor; 3] illustrator; 4] annotator; 5] programmer
     attribute role {
-      
-      ##
-      "translator"
-      | 
-        ##
-        "editor"
-      | 
-        ##
-        "illustrator"
-      | 
-        ##
-        "annotator"
-      | 
-        ##
-        "programmer"
+      "translator" | "editor" | "illustrator" | "annotator" | "programmer"
       | xsd:Name
     }?,
     empty
   }
+
 dhq_email =
-  
   ## (electronic mail address) contains an email address identifying a location to which email messages can be delivered. [3.6.2. Addresses]
   element tei:email {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_address =
-  
   ## (address) contains a postal address, for example of a publisher, an organization, or an individual. [3.6.2. Addresses 2.2.4. Publication, Distribution, Licensing, etc. 3.12.2.4. Imprint, Size of a Document, and Reprint Information]
   element tei:address {
     (dhq_model.global*, (dhq_model.addrPart, dhq_model.global*)+),
     dhq_att.global.attributes,
     empty
   }
+
 dhq_unit =
-  
   ## contains a symbol, a word or a phrase referring to a unit of measurement in any kind of formal or informal system. [3.6.3. Numbers and
   ## Measures]
   element tei:unit {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_date =
-  
   ## (date) contains a date in any format. [3.6.4. Dates and Times 2.2.4. Publication, Distribution, Licensing, etc. 2.6. The Revision Description 3.12.2.4. Imprint, Size of a Document, and Reprint Information 15.2.3. The Setting Description 13.4. Dates]
   element tei:date {
     (text | dhq_model.phrase | dhq_model.global)*,
     dhq_att.global.attributes,
     dhq_att.canonical.attributes,
-    
     ## Provides a date in regularized format.
     attribute when { text }?,
     empty
   }
+
 dhq_ptr =
-  
   ## (pointer) defines a pointer to another location. [3.7. Simple Links and Cross-References 16.1. Links]
   element tei:ptr {
     empty
@@ -2471,25 +2121,21 @@ dhq_ptr =
        ],
     dhq_att.global.attributes,
     dhq_att.internetMedia.attributes,
-    
     ## Provides a pointer to a bibliographic citation.
     attribute target {
       xsd:anyURI { pattern = "\S+" }
     }?,
-    
     ## The value will typically be either a numeric page reference or page range, or else a section number (which may be numeric or alphabetic, or may conceivably use some other ordering system)
     attribute loc { text }?,
-    
     ## Permits specialized types of pointers to be identified (e.g. those pointing to video or audio files).
     attribute type {
-      
       ## Indicates that the pointer references an embedded feed from the DHQ annex.
       "dhq-annex-embed"
     }?,
     empty
   }
+
 dhq_ref =
-  
   ## (reference) defines a reference to another location, possibly modified by additional text or comment. [3.7. Simple Links and Cross-References 16.1. Links]
   element tei:ref {
     dhq_macro.paraContent
@@ -2517,25 +2163,21 @@ dhq_ref =
        ],
     dhq_att.global.attributes,
     dhq_att.internetMedia.attributes,
-    
     ## Provides a pointer to a bibliographic citation.
     attribute target {
       xsd:anyURI { pattern = "\S+" }
     }?,
-    
     ## The value will typically be either a numeric page reference or page range, or else a section number (which may be numeric or alphabetic, or may conceivably use some other ordering system)
     attribute loc { text }?,
-    
     ## Provides a classification of the reference
     attribute type {
-      
       ## Indicates that the reference in question does not have a linked target.
       "offline"
     }?,
     empty
   }
+
 dhq_list =
-  
   ## (list) contains any sequence of items organized as a list. [3.8. Lists]
   element tei:list {
     (dhq_model.divTop*, dhq_item+)
@@ -2559,20 +2201,12 @@ dhq_list =
        ],
     dhq_att.global.attributes,
     dhq_att.sortable.attributes,
-    
     ## Classifies the element.
     attribute type {
-      
       ## A numbered list
-      "ordered"
-      | 
-        ## A bulleted list
-        "unordered"
-      | 
-        ## A list with no numbering or bullets
-        "simple"
-      | 
-        ## A gloss list, assumes the presence of a label preceding the item.
+      "ordered" | ## A bulleted list
+        "unordered" | ## A list with no numbering or bullets
+        "simple" | ## A gloss list, assumes the presence of a label preceding the item.
         "gloss"
       | [
           a:documentation [
@@ -2587,8 +2221,8 @@ dhq_list =
     }?,
     empty
   }
+
 dhq_item =
-  
   ## (item) contains one component of a list. [3.8. Lists 2.6. The Revision Description]
   element tei:item {
     dhq_macro.specialPara,
@@ -2596,8 +2230,8 @@ dhq_item =
     dhq_att.sortable.attributes,
     empty
   }
+
 dhq_label =
-  
   ## (label) contains any label or heading used to identify part of a text, typically but not exclusively in a list or glossary. [3.8. Lists]
   element tei:label {
     (dhq_macro.phraseSeq | dhq_bibl | dhq_q)*,
@@ -2605,8 +2239,8 @@ dhq_label =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_head =
-  
   ## (heading) contains any type of heading, for example the title of a section, or the heading of a list, glossary, manuscript description, etc. [4.2.1. Headings and Trailers]
   element tei:head {
     (text
@@ -2625,20 +2259,19 @@ dhq_head =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_note =
-  
   ## (note) contains a note or annotation. [3.9.1. Notes and Simple Annotation 2.2.6. The Notes Statement 3.12.2.8. Notes and Statement of Language 9.3.5.4. Notes within Entries]
   element tei:note {
     dhq_macro.specialPara,
     dhq_att.global.attributes,
     dhq_att.written.attributes,
-    
     ## Provides a unique identifier for the note
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_noteGrp =
-  
   ## contains a group of notes [3.9.1.1. Encoding Grouped Notes]
   element tei:noteGrp {
     (dhq_desc*, (dhq_note | dhq_noteGrp)+),
@@ -2647,68 +2280,48 @@ dhq_noteGrp =
     dhq_att.anchoring.attributes,
     empty
   }
+
 dhq_media =
-  
   ## indicates the location of any form of external media such as an audio or video clip etc. [3.10. Graphics and Other Non-textual Components]
   element tei:media {
     dhq_model.descLike*,
     dhq_att.global.attributes,
     dhq_att.media.attribute.scale,
     dhq_att.resourced.attributes,
-    
-    ##
     attribute width { xsd:integer }?,
-    
-    ##
     attribute height { xsd:integer }?,
-    
-    ##
     attribute mimeType {
-      
       ## Waveform audio format (.wav)
-      "audio/wav"
-      | 
-        ## MP3 audio files (.mp3)
-        "audio/mpeg"
-      | 
-        ## SVG file (.svg)
-        "image/svg+xml"
-      | 
-        ## Quicktime videos (.mov)
-        "video/quicktime"
-      | 
-        ## MP4 audio/video (.mp4)
-        "video/mp4"
-      | 
-        ## WMA files (.wma)
+      "audio/wav" | ## MP3 audio files (.mp3)
+        "audio/mpeg" | ## SVG file (.svg)
+        "image/svg+xml" | ## Quicktime videos (.mov)
+        "video/quicktime" | ## MP4 audio/video (.mp4)
+        "video/mp4" | ## WMA files (.wma)
         "audio/x-ms-wma"
     }?,
-    
     ## A pointer to an image that serves as a "poster": a static image that displays when the media is not playing.
     attribute poster {
       xsd:anyURI { pattern = "\S+" }
     }?,
     empty
   }
+
 dhq_graphic =
-  
   ## (graphic) indicates the location of a graphic or illustration, either forming part of a text, or providing an image of it. [3.10. Graphics and Other Non-textual Components 11.1. Digital Facsimiles]
   element tei:graphic {
     dhq_model.descLike*,
     dhq_att.global.attributes,
     dhq_att.internetMedia.attribute.mimeType,
     dhq_att.resourced.attributes,
-    
     ## Classifies the type of graphic object.
     attribute type {
-      
       ## A link to a video file
       "video"
     }?,
     empty
   }
+
 dhq_gb =
-  
   ## (gathering beginning) marks the beginning of a new gathering or quire in a transcribed codex. [3.11.3. Milestone
   ## Elements]
   element tei:gb {
@@ -2718,8 +2331,8 @@ dhq_gb =
     dhq_att.edition.attributes,
     empty
   }
+
 dhq_lb =
-  
   ## (line beginning) marks the beginning of a new (typographic) line in some edition or version of a text. [3.11.3. Milestone
   ## Elements 7.2.5. Speech Contents]
   element tei:lb {
@@ -2729,8 +2342,8 @@ dhq_lb =
     dhq_att.breaking.attributes,
     empty
   }
+
 dhq_series =
-  
   ## (series information) contains information about the series in which a book or other bibliographic item has appeared. [3.12.2.1. Analytic, Monographic, and Series Levels]
   element tei:series {
     (text
@@ -2745,20 +2358,20 @@ dhq_series =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_author =
-  
   ## (author) in a bibliographic reference, contains the name(s) of an author, personal or corporate, of a work; for example in the same form as that provided by a recognized bibliographic name authority. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement]
   element tei:author {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_editor =
-  
   ## contains a secondary statement of responsibility for a bibliographic item, for example the name of an individual, institution or organization, (or of several such) acting as editor, compiler, translator, etc. [3.12.2.2. Titles, Authors, and Editors]
   element tei:editor {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_title =
-  
   ## (title) contains a title for any kind of work. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.5. The Series Statement]
   element tei:title {
     dhq_macro.paraContent,
@@ -2772,33 +2385,18 @@ dhq_title =
       ]
     ]
     attribute type {
-      
-      ##
-      "article"
-      | 
-        ##
-        "issue"
+      "article" | "issue"
     }?,
-    
     ## Identifies the language of the element's content
     attribute xml:lang { text }?,
-    
     ## Describes the presentation of a title in the main body of the text and in the bibliography.
     attribute rend {
-      
-      ##
-      "italic"
-      | 
-        ##
-        "none"
-      | 
-        ##
-        "quotes"
+      "italic" | "none" | "quotes"
     }?,
     empty
   }
+
 dhq_meeting =
-  
   ## contains the formalized descriptive title for a meeting or conference, for use in a bibliographic description for an item derived from such a meeting, or as a heading or preamble to publications emanating from it. [3.12.2.2. Titles, Authors, and Editors]
   element tei:meeting {
     dhq_macro.limitedContent,
@@ -2806,8 +2404,8 @@ dhq_meeting =
     dhq_att.canonical.attributes,
     empty
   }
+
 dhq_publisher =
-  
   ## (publisher) provides the name of the organization responsible for the publication or distribution of a bibliographic item. [3.12.2.4. Imprint, Size of a Document, and Reprint Information 2.2.4. Publication, Distribution, Licensing, etc.]
   element tei:publisher {
     dhq_macro.phraseSeq,
@@ -2815,8 +2413,8 @@ dhq_publisher =
     dhq_att.canonical.attributes,
     empty
   }
+
 dhq_biblScope =
-  
   ## (scope of bibliographic reference) defines the scope of a bibliographic reference, for example as a list of page numbers, or a named subdivision of a larger work. [3.12.2.5. Scopes and Ranges in Bibliographic Citations]
   element tei:biblScope {
     dhq_macro.phraseSeq,
@@ -2824,8 +2422,8 @@ dhq_biblScope =
     dhq_att.citing.attribute.unit,
     empty
   }
+
 dhq_citedRange =
-  
   ## (cited range) defines the range of cited content, often represented by pages or other units [3.12.2.5. Scopes and Ranges in Bibliographic Citations]
   element tei:citedRange {
     dhq_macro.phraseSeq,
@@ -2833,14 +2431,14 @@ dhq_citedRange =
     dhq_att.citing.attributes,
     empty
   }
+
 dhq_pubPlace =
-  
   ## (publication place) contains the name of the place where a bibliographic item was published. [3.12.2.4. Imprint, Size of a Document, and Reprint Information]
   element tei:pubPlace {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_bibl =
-  
   ## (bibliographic citation) contains a loosely-structured bibliographic citation of which the sub-components may or may not be explicitly tagged. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]
   element tei:bibl {
     (text
@@ -2854,19 +2452,16 @@ dhq_bibl =
     dhq_att.global.attributes,
     dhq_att.sortable.attributes,
     dhq_att.docStatus.attributes,
-    
     ## provides a reference to a centralized bibliography
     attribute biblioID { text }?,
-    
     ## Provides a label for use in generated bibliographies.
     attribute label { text }?,
-    
     ## Provides a unique identifier for the bibliographic item
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_listBibl =
-  
   ## (citation list) contains a list of bibliographic citations of any kind. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]
   element tei:listBibl {
     (dhq_model.headLike*,
@@ -2877,8 +2472,8 @@ dhq_listBibl =
     dhq_att.sortable.attributes,
     empty
   }
+
 dhq_l =
-  
   ## (verse line) contains a single, possibly incomplete, line of verse. [3.13.1. Core Tags for Verse 3.13. Passages of Verse or Drama 7.2.5. Speech Contents]
   element tei:l {
     ((text | dhq_model.phrase | dhq_model.inter | dhq_model.global)*)
@@ -2904,32 +2499,19 @@ dhq_l =
          "         "
        ],
     dhq_att.global.attributes,
-    
-    ##
     attribute rend {
-      
       ## the line is indented by 1
-      "indent-1"
-      | 
-        ## the line is indented by 2
-        "indent-2"
-      | 
-        ## the line is indented by 3
-        "indent-3"
-      | 
-        ## the line is indented by 4
-        "indent-4"
-      | 
-        ## the line is indented by 5
-        "indent-5"
-      | 
-        ## the line is indented by 6
+      "indent-1" | ## the line is indented by 2
+        "indent-2" | ## the line is indented by 3
+        "indent-3" | ## the line is indented by 4
+        "indent-4" | ## the line is indented by 5
+        "indent-5" | ## the line is indented by 6
         "indent-6"
     }?,
     empty
   }
+
 dhq_lg =
-  
   ## (line group) contains one or more verse lines functioning as a formal unit, e.g. a stanza, refrain, verse paragraph, etc. [3.13.1. Core Tags for Verse 3.13. Passages of Verse or Drama 7.2.5. Speech Contents]
   element tei:lg {
     ((dhq_model.divTop | dhq_model.global)*,
@@ -2988,8 +2570,8 @@ dhq_lg =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_sp =
-  
   ## (speech) contains an individual speech in a performance text, or a passage presented as such in a prose or verse text. [3.13.2. Core Tags for Drama 3.13. Passages of Verse or Drama 7.2.2. Speeches and Speakers]
   element tei:sp {
     (dhq_model.global*,
@@ -3005,14 +2587,14 @@ dhq_sp =
     dhq_att.ascribed.directed.attributes,
     empty
   }
+
 dhq_speaker =
-  
   ## contains a specialized form of heading or label, giving the name of one or more speakers in a dramatic text or fragment. [3.13.2. Core Tags for Drama]
   element tei:speaker {
     dhq_macro.phraseSeq, dhq_att.global.attributes, empty
   }
+
 dhq_stage =
-  
   ## (stage direction) contains any kind of stage direction within a dramatic text or fragment. [3.13.2. Core Tags for Drama 3.13. Passages of Verse or Drama 7.2.4. Stage Directions]
   element tei:stage {
     dhq_macro.specialPara,
@@ -3021,27 +2603,23 @@ dhq_stage =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_textLang =
-  
   ## (text language) describes the languages and writing systems identified within the bibliographic work being described, rather than its description. [3.12.2.4. Imprint, Size of a Document, and Reprint Information 10.6.6. Languages and Writing Systems]
   element tei:textLang {
     dhq_macro.phraseSeq,
     dhq_att.global.attributes,
-    
     ## (main language) supplies a code which identifies the chief language used in the bibliographic work.
     attribute mainLang {
       xsd:language
       | (
-         ##
          "")
     }?,
-    
     ## (other languages) one or more codes identifying any other languages used in the bibliographic work.
     attribute otherLangs {
       list {
         (xsd:language
          | (
-            ##
             ""))*
       }
     }?,
@@ -3062,7 +2640,6 @@ dhq_att.patternReplacement.attributes =
   dhq_att.patternReplacement.attribute.matchPattern,
   dhq_att.patternReplacement.attribute.replacementPattern
 dhq_att.patternReplacement.attribute.matchPattern =
-  
   ## specifies a regular expression against which the values of other attributes can be matched.
   attribute matchPattern { xsd:token }
 dhq_att.patternReplacement.attribute.replacementPattern =
@@ -3074,30 +2651,30 @@ dhq_att.patternReplacement.attribute.replacementPattern =
     ]
   ]
   attribute replacementPattern { text }
+
 dhq_teiHeader =
-  
   ## (TEI header) supplies descriptive and declarative metadata associated with a digital resource or set of resources. [2.1.1. The TEI Header and Its Components 15.1. Varieties of Composite Text]
   element tei:teiHeader {
     (dhq_fileDesc, dhq_model.teiHeaderPart*, dhq_revisionDesc?),
     dhq_att.global.attributes,
     empty
   }
+
 dhq_fileDesc =
-  
   ## (file description) contains a full bibliographic description of an electronic file. [2.2. The File Description 2.1.1. The TEI Header and Its Components]
   element tei:fileDesc {
     ((dhq_titleStmt, dhq_publicationStmt), dhq_sourceDesc+),
     dhq_att.global.attributes,
     empty
   }
+
 dhq_titleStmt =
-  
   ## (title statement) groups information about the title of a work and those responsible for its content. [2.2.1. The Title Statement 2.2. The File Description]
   element tei:titleStmt {
     (dhq_title+, dhq_model.respLike*), dhq_att.global.attributes, empty
   }
+
 dhq_sponsor =
-  
   ## (sponsor) specifies the name of a sponsoring organization or institution. [2.2.1. The Title Statement]
   element tei:sponsor {
     dhq_macro.phraseSeq.limited,
@@ -3105,8 +2682,8 @@ dhq_sponsor =
     dhq_att.canonical.attributes,
     empty
   }
+
 dhq_publicationStmt =
-  
   ## (publication statement) groups information concerning the publication or distribution of an electronic or other text. [2.2.4. Publication, Distribution, Licensing, etc. 2.2. The File Description]
   element tei:publicationStmt {
     ((dhq_model.publicationStmtPart.agency,
@@ -3115,88 +2692,68 @@ dhq_publicationStmt =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_idno =
-  
   ## (identifier) supplies any form of identifier used to identify some object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized way. [13.3.1. Basic Principles 2.2.4. Publication, Distribution, Licensing, etc. 2.2.5. The Series Statement 3.12.2.4. Imprint, Size of a Document, and Reprint Information]
   element tei:idno {
     (text | dhq_idno)*,
     dhq_att.global.attributes,
     dhq_att.sortable.attributes,
-    
-    ##
     attribute type {
-      
       ## used for the DHQ article ID
-      "DHQarticle-id"
-      | 
-        ## used for the volume number
-        "volume"
-      | 
-        ## used for the issue number
-        "issue"
-      | 
-        ## used for author ORCID IDs
+      "DHQarticle-id" | ## used for the volume number
+        "volume" | ## used for the issue number
+        "issue" | ## used for author ORCID IDs
         "ORCID"
     }?,
     empty
   }
+
 dhq_availability =
-  
   ## (availability) supplies information about the availability of a text, for example any restrictions on its use or distribution, its copyright status, any licence applying to it, etc. [2.2.4. Publication, Distribution, Licensing, etc.]
   element tei:availability {
     dhq_License,
     dhq_att.global.attributes,
-    
-    ##
     attribute status {
-      
-      ##
-      "CC-BY-ND"
-      | 
-        ##
-        "CC-BY"
-      | 
-        ##
-        "CC0"
+      "CC-BY-ND" | "CC-BY" | "CC0"
     }?,
     empty
   }
+
 dhq_licence =
-  
   ## contains information about a licence or other legal agreement applicable to the text. [2.2.4. Publication, Distribution, Licensing, etc.]
   element tei:licence {
     dhq_macro.specialPara, dhq_att.global.attributes, empty
   }
+
 dhq_sourceDesc =
-  
   ## (source description) describes the source(s) from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as "born digital" for a text which has no previous existence. [2.2.7. The Source Description]
   element tei:sourceDesc {
     (dhq_model.pLike+ | (dhq_model.biblLike | dhq_model.listLike)+),
     dhq_att.global.attributes,
     empty
   }
+
 dhq_encodingDesc =
-  
   ## (encoding description) documents the relationship between an electronic text and the source or sources from which it was derived. [2.3. The Encoding Description 2.1.1. The TEI Header and Its Components]
   element tei:encodingDesc {
     (dhq_model.encodingDescPart | dhq_model.pLike)+,
     dhq_att.global.attributes,
     empty
   }
+
 dhq_schemaRef =
-  
   ## (schema reference) describes or points to a related customization or schema file [2.3.10. The Schema Specification]
   element tei:schemaRef {
     dhq_model.descLike?,
     dhq_att.global.attributes,
     dhq_att.resourced.attributes,
-    
     ## the identifier used for the customization or schema
     attribute key { xsd:NCName }?,
     empty
   }
+
 dhq_citeStructure =
-  
   ## (citation structure) declares a structure and method for citing the current document. [3.11.4. Declaring Reference Systems 16.2.5.4. Citation Structures]
   element tei:citeStructure {
     (dhq_citeData*, dhq_citeStructure*, dhq_model.descLike*),
@@ -3301,63 +2858,60 @@ dhq_citeStructure =
     }?,
     empty
   }
+
 dhq_citeData =
-  
   ## (citation data) specifies how information may be extracted from citation structures. [3.11.4. Declaring Reference Systems 16.2.5.4. Citation Structures]
   element tei:citeData {
     empty,
     dhq_att.global.attributes,
     dhq_att.citeStructurePart.attributes,
-    
     ## (property) A URI indicating a property definition.
     attribute property {
       xsd:anyURI { pattern = "\S+" }
     },
     empty
   }
+
 dhq_prefixDef =
-  
   ## (prefix definition) defines a prefixing scheme used in teidata.pointer values, showing how abbreviated URIs using the scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]
   element tei:prefixDef {
     dhq_model.pLike*,
     dhq_att.global.attributes,
     dhq_att.patternReplacement.attributes,
-    
     ## supplies a name which functions as the prefix for an abbreviated pointing scheme such as a private URI scheme. The prefix constitutes the text preceding the first colon.
     attribute ident {
       xsd:token { pattern = "[a-z][a-z0-9\+\.\-]*" }
     },
     empty
   }
+
 dhq_listPrefixDef =
-  
   ## (list of prefix definitions) contains a list of definitions of prefixing schemes used in teidata.pointer values, showing how abbreviated URIs using each scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]
   element tei:listPrefixDef {
     (dhq_desc*, (dhq_prefixDef | dhq_listPrefixDef)+),
     dhq_att.global.attributes,
     empty
   }
+
 dhq_classDecl =
-  
   ## (classification declarations) contains one or more taxonomies defining any classificatory codes used elsewhere in the text. [2.3.7. The Classification Declaration 2.3. The Encoding Description]
   element tei:classDecl {
     dhq_taxonomy+, dhq_att.global.attributes, empty
   }
+
 dhq_taxonomy =
-  
   ## (taxonomy) defines a typology either implicitly, by means of a bibliographic citation, or explicitly by a structured taxonomy. [2.3.7. The Classification Declaration]
   element tei:taxonomy {
     (((dhq_taxonomy)+
       | ((dhq_model.descLike)+, (dhq_taxonomy)*))
      | (dhq_model.biblLike, (dhq_taxonomy)*)),
     dhq_att.global.attributes,
-    
     ## Provides a unique identifier for the taxonomy
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_unitDecl =
-  
   ## (unit declarations) provides information about units of measurement that are not members of the International System of Units. [2.3.9. The Unit Declaration]
   element tei:unitDecl {
     dhq_unitDef+,
@@ -3365,8 +2919,8 @@ dhq_unitDecl =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_unitDef =
-  
   ## (unit definition) contains descriptive information related to a specific unit of measurement. [2.3.9. The Unit Declaration]
   element tei:unitDef {
     (dhq_model.labelLike
@@ -3377,8 +2931,8 @@ dhq_unitDef =
     dhq_att.canonical.attributes,
     empty
   }
+
 dhq_conversion =
-  
   ## defines how to calculate one unit of measure in terms of another. [2.3.9. The Unit Declaration]
   element tei:conversion {
     empty,
@@ -3407,28 +2961,28 @@ dhq_conversion =
     },
     empty
   }
+
 dhq_profileDesc =
-  
   ## (text-profile description) provides a detailed description of non-bibliographic aspects of a text, specifically the languages and sublanguages used, the situation in which it was produced, the participants and their setting. [2.4. The Profile Description 2.1.1. The TEI Header and Its Components]
   element tei:profileDesc {
     dhq_model.profileDescPart*, dhq_att.global.attributes, empty
   }
+
 dhq_creation =
-  
   ## (creation) contains information about the creation of a text. [2.4.1. Creation 2.4. The Profile Description]
   element tei:creation {
     (text | dhq_model.limitedPhrase | dhq_listChange)*,
     dhq_att.global.attributes,
     empty
   }
+
 dhq_langUsage =
-  
   ## (language usage) describes the languages, sublanguages, registers, dialects, etc. represented within a text. [2.4.2. Language Usage 2.4. The Profile Description 15.3.2. Declarable Elements]
   element tei:langUsage {
     (dhq_model.pLike+ | dhq_language+), dhq_att.global.attributes, empty
   }
+
 dhq_language =
-  
   ## (language) characterizes a single language or sublanguage used within a text. [2.4.2. Language Usage]
   element tei:language {
     dhq_macro.phraseSeq.limited,
@@ -3443,14 +2997,9 @@ dhq_language =
       ]
     ]
     attribute extent {
-      
       ## indicates that the language is used for the original article
-      "original"
-      | 
-        ## indicates that the language is used for a translation stub (i.e. a placeholder or incomplete translation)
-        "translation_stub"
-      | 
-        ## indicates that the language is used for a full translation of the article
+      "original" | ## indicates that the language is used for a translation stub (i.e. a placeholder or incomplete translation)
+        "translation_stub" | ## indicates that the language is used for a full translation of the article
         "translation"
     }?,
     [
@@ -3465,22 +3014,20 @@ dhq_language =
     attribute ident {
       xsd:language
       | (
-         ##
          "")
     },
-    
     ## specifies the approximate percentage (by volume) of the text which uses this language.
     attribute usage { xsd:nonNegativeInteger }?,
     empty
   }
+
 dhq_textClass =
-  
   ## (text classification) groups information which describes the nature or topic of a text in terms of a standard classification scheme, thesaurus, etc. [2.4.3. The Text Classification]
   element tei:textClass {
     (dhq_keywords)*, dhq_att.global.attributes, empty
   }
+
 dhq_keywords =
-  
   ## (keywords) contains a list of keywords or phrases identifying the topic or nature of a text. [2.4.3. The Text Classification]
   element tei:keywords {
     (dhq_term+ | dhq_list),
@@ -3497,20 +3044,20 @@ dhq_keywords =
     }?,
     empty
   }
+
 dhq_calendarDesc =
-  
   ## (calendar description) contains a description of the calendar system used in any dating expression found in the text. [2.4. The Profile Description 2.4.5. Calendar Description]
   element tei:calendarDesc {
     dhq_calendar+, dhq_att.global.attributes, empty
   }
+
 dhq_calendar =
-  
   ## (calendar) describes a calendar or dating system used in a dating formula in the text. [2.4.5. Calendar Description]
   element tei:calendar {
     dhq_model.pLike+, dhq_att.global.attributes, empty
   }
+
 dhq_correspDesc =
-  
   ## (correspondence
   ##     description) contains a description of the actions related to one act of correspondence. [2.4.6. Correspondence Description]
   element tei:correspDesc {
@@ -3519,8 +3066,8 @@ dhq_correspDesc =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_correspAction =
-  
   ## (correspondence action) contains a structured description of the place, the name of a person/organization and the date related to the sending/receiving of a message or any other action related to the correspondence. [2.4.6. Correspondence Description]
   element tei:correspAction {
     (dhq_model.correspActionPart+ | dhq_model.pLike+),
@@ -3528,48 +3075,28 @@ dhq_correspAction =
     dhq_att.sortable.attributes,
     empty
   }
+
 dhq_correspContext =
-  
   ## (correspondence context) provides references to preceding or following correspondence related to this piece of correspondence. [2.4.6. Correspondence Description]
   element tei:correspContext {
     dhq_model.correspContextPart+, dhq_att.global.attributes, empty
   }
+
 dhq_xenoData =
-  
   ## (non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]
   element tei:xenoData {
     (text | anyElement-xenoData),
     dhq_att.global.attributes,
-    
-    ##
     attribute type {
-      
-      ##
-      "embed_map"
-      | 
-        ##
-        "embed_audio"
-      | 
-        ##
-        "embed_video"
-      | 
-        ##
-        "embed_3d"
+      "embed_map" | "embed_audio" | "embed_video" | "embed_3d"
     }?,
-    
-    ##
     attribute subtype {
-      
-      ##
-      "soundcloud"
-      | 
-        ##
-        "google"
+      "soundcloud" | "google"
     }?,
     empty
   }
+
 dhq_revisionDesc =
-  
   ## (revision description) summarizes the revision history for a file. [2.6. The Revision Description 2.1.1. The TEI Header and Its Components]
   element tei:revisionDesc {
     (dhq_list | dhq_listChange | dhq_change+),
@@ -3577,18 +3104,16 @@ dhq_revisionDesc =
     dhq_att.docStatus.attributes,
     empty
   }
+
 dhq_change =
-  
   ## (change) documents a change or set of changes made during the production of a source document, or during the revision of an electronic file. [2.6. The Revision Description 2.4.1. Creation 11.7. Identifying Changes and Revisions]
   element tei:change {
     dhq_macro.specialPara,
     dhq_att.ascribed.attributes,
     dhq_att.docStatus.attributes,
     dhq_att.global.attributes,
-    
     ## Provides a date in regularized format.
     attribute when { text }?,
-    
     ## (target) points to one or more elements that belong to this change.
     attribute target {
       list {
@@ -3597,8 +3122,8 @@ dhq_change =
     }?,
     empty
   }
+
 dhq_listChange =
-  
   ## groups a number of change descriptions associated with either the creation of a source text or the revision of an encoded text. [2.6. The Revision Description 11.7. Identifying Changes and Revisions]
   element tei:listChange {
     (dhq_desc*, (dhq_listChange | dhq_change)+),
@@ -3639,8 +3164,8 @@ dhq_TEI =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_text =
-  
   ## (text) contains a single text of any kind, whether unitary or composite, for example a poem or drama, a collection of essays, a novel, a dictionary, or a corpus sample. [4. Default Text Structure 15.1. Varieties of Composite Text]
   element tei:text {
     (dhq_model.global*,
@@ -3650,7 +3175,6 @@ dhq_text =
      (dhq_back, dhq_model.global*)?),
     dhq_att.global.attributes,
     dhq_att.written.attributes,
-    
     ## Identifies the language of the element's content
     attribute xml:lang { text }?,
     [
@@ -3665,23 +3189,17 @@ dhq_text =
         xsd:anyURI { pattern = "\S+" }+
       }
     }?,
-    
     ## Identifies whether the text is in the language of its original authorship, or is a full translation, or is a stub translation (i.e. abstract only)
     attribute type {
-      
       ## The text is in the language of its original authorship
-      "original"
-      | 
-        ## The text is a full translation of the originally authored article
-        "translation"
-      | 
-        ## The text is a stub or partial translation
+      "original" | ## The text is a full translation of the originally authored article
+        "translation" | ## The text is a stub or partial translation
         "translation_stub"
     }?,
     empty
   }
+
 dhq_body =
-  
   ## (text body) contains the whole body of a single unitary text, excluding any front or back matter. [4. Default Text Structure]
   element tei:body {
     (dhq_model.global*,
@@ -3696,8 +3214,8 @@ dhq_body =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_group =
-  
   ## (group) contains the body of a composite text, grouping together a sequence of distinct texts (or groups of such texts) which are regarded as a unit for some purpose, for example the collected works of an author, a sequence of prose essays, etc. [4. Default Text Structure 4.3.1. Grouped Texts 15.1. Varieties of Composite Text]
   element tei:group {
     ((dhq_model.divTop | dhq_model.global)*,
@@ -3707,8 +3225,8 @@ dhq_group =
     dhq_att.global.attributes,
     empty
   }
+
 dhq_floatingText =
-  
   ## (floating text) contains a single text of any kind, whether unitary or composite, which interrupts the text containing it at any point and after which the surrounding text resumes. [4.3.2. Floating Texts]
   element tei:floatingText {
     (dhq_model.global*,
@@ -3717,13 +3235,12 @@ dhq_floatingText =
      dhq_model.global*,
      (dhq_back, dhq_model.global*)?),
     dhq_att.global.attributes,
-    
     ## Identifies the language of the element's content
     attribute xml:lang { text }?,
     empty
   }
+
 dhq_div =
-  
   ## (text division) contains a subdivision of the front, body, or back of a text. [4.1. Divisions of the Body]
   element tei:div {
     ((dhq_model.divTop | dhq_model.global)*,
@@ -3777,23 +3294,16 @@ dhq_div =
        ],
     dhq_att.global.attributes,
     dhq_att.written.attributes,
-    
     ## Provides a unique identifier for the division.
     attribute xml:id { xsd:ID }?,
-    
-    ##
     attribute xml:lang { text }?,
-    
-    ##
     attribute type {
-      
-      ##
       "appendix"
     }?,
     empty
   }
+
 dhq_trailer =
-  
   ## contains a closing title or footer appearing at the end of a division of a text. [4.2.4. Content of Textual Divisions 4.2. Elements Common to All Divisions]
   element tei:trailer {
     (text
@@ -3806,31 +3316,29 @@ dhq_trailer =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_dateline =
-  
   ## (dateline) contains a brief description of the place, date, time, etc. of production of a letter, newspaper story, or other work, prefixed or suffixed to it as a kind of heading or trailer. [4.2.2. Openers and Closers]
   element tei:dateline {
     (text | dhq_model.phrase | dhq_model.global)*,
     dhq_att.global.attributes,
     empty
   }
+
 dhq_epigraph =
-  
   ## (epigraph) contains a quotation, anonymous or attributed, appearing at the start or end of a section or on a title page. [4.2.3. Arguments, Epigraphs, and Postscripts 4.2. Elements Common to All Divisions 4.6. Title Pages]
   element tei:epigraph {
     (dhq_model.common | dhq_model.global)*,
     dhq_att.global.attributes,
-    
     ## Describes the presentation of the quoted material, whether inline or set as a block.
     attribute rend {
-      
       ## Designates a block quotation, typically containing one or more paragraphs or other chunky things, with the block and text centered. 
       "center"
     }?,
     empty
   }
+
 dhq_salute =
-  
   ## (salutation) contains a salutation or greeting prefixed to a foreword, dedicatory epistle, or other division of a text, or the salutation in the closing of a letter, preface, etc. [4.2.2. Openers and Closers]
   element tei:salute {
     dhq_macro.paraContent,
@@ -3838,8 +3346,8 @@ dhq_salute =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_signed =
-  
   ## (signature) contains the closing salutation, etc., appended to a foreword, dedicatory epistle, or other division of a text. [4.2.2. Openers and Closers]
   element tei:signed {
     dhq_macro.paraContent,
@@ -3847,8 +3355,8 @@ dhq_signed =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_postscript =
-  
   ## contains a postscript, e.g. to a letter. [4.2. Elements Common to All Divisions]
   element tei:postscript {
     ((dhq_model.global | dhq_model.divTopPart)*,
@@ -3859,153 +3367,116 @@ dhq_postscript =
     dhq_att.written.attributes,
     empty
   }
+
 dhq_front =
-  
   ## The front matter consists of an abstract followed by a teaser.
   element tei:front { dhq_abstract+, dhq_teaser+ }
+
 dhq_back =
-  
-  ##
   element tei:back { dhq_listBibl? }
 dhq_att.tableDecoration.attribute.rows =
-  
   ## (rows) indicates the number of rows occupied by this cell or row.
   [ a:defaultValue = "1" ] attribute rows { xsd:nonNegativeInteger }?
 dhq_att.tableDecoration.attribute.cols =
-  
   ## (columns) indicates the number of columns occupied by this cell or row.
   [ a:defaultValue = "1" ] attribute cols { xsd:nonNegativeInteger }?
+
 dhq_table =
-  
   ## (table) contains text displayed in tabular form, in rows and columns. [14.1.1. TEI Tables]
   element tei:table {
     (dhq_head?, dhq_row+, dhq_caption?),
     dhq_att.global.attributes,
-    
     ## Provides a unique identifier for the table
     attribute xml:id { xsd:ID }?,
-    
-    ##
     attribute rend {
-      
-      ##
       "unbordered"
     }?,
-    
     ## (rows) indicates the number of rows in the table.
     attribute rows { xsd:nonNegativeInteger }?,
-    
     ## (columns) indicates the number of columns in each row of the table.
     attribute cols { xsd:nonNegativeInteger }?,
     empty
   }
+
 dhq_row =
-  
   ## (row) contains one row of a table. [14.1.1. TEI Tables]
   element tei:row {
     dhq_cell+,
     dhq_att.global.attributes,
     dhq_att.tableDecoration.attribute.rows,
     dhq_att.tableDecoration.attribute.cols,
-    
     ## Describes the role of the table row
     attribute role {
-      
       ## Indicates that the cell serves as a label (otherwise is assumed to be data)
-      "label"
-      | 
-        ## Indicates that the cell contains data (default value)
+      "label" | ## Indicates that the cell contains data (default value)
         "data"
     }?,
     empty
   }
+
 dhq_cell =
-  
   ## (cell) contains one cell of a table. [14.1.1. TEI Tables]
   element tei:cell {
     dhq_macro.specialPara,
     dhq_att.global.attributes,
     dhq_att.tableDecoration.attribute.rows,
     dhq_att.tableDecoration.attribute.cols,
-    
     ## Describes the role of the table cell
     attribute role {
-      
       ## Indicates that the cell serves as a label (otherwise is assumed to be data)
-      "label"
-      | 
-        ## Indicates that the cell contains data (default value)
+      "label" | ## Indicates that the cell contains data (default value)
         "data"
     }?,
     empty
   }
+
 dhq_formula =
-  
   ## (formula) contains a mathematical or other formula. [14.2. Formulæ and Mathematical Expressions]
   element tei:formula {
     (text | dhq_note | m_math | dhq_model.graphicLike)*,
     dhq_att.global.attributes,
-    
     ## names the notation used for the content of the element.
     attribute notation {
-      
-      ##
-      "asciimath"
-      | 
-        ##
-        "tex"
-      | 
-        ##
-        "mathml"
+      "asciimath" | "tex" | "mathml"
     }?,
-    
-    ##
     attribute rend {
-      
-      ##
-      "inline"
-      | 
-        ##
-        "block"
+      "inline" | "block"
     }?,
-    
     ## Provides a unique identifier for the formula
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_notatedMusic =
-  
   ## encodes the presence of music notation in a text [14.3. Notated Music in Written Text]
   element tei:notatedMusic {
     (dhq_model.labelLike | dhq_model.ptrLike | dhq_graphic | dhq_seg)*,
     dhq_att.global.attributes,
     empty
   }
+
 dhq_figure =
-  
   ## (figure) groups elements representing or containing graphic information such as an illustration, formula, or figure. [14.4. Specific Elements for Graphic Images]
   element tei:figure {
     (dhq_head?, (dhq_figDesc | dhq_model.graphicLike | dhq_figure)*),
     dhq_att.global.attributes,
     dhq_att.written.attributes,
-    
     ## Provides a unique identifier for the figure
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_figDesc =
-  
   ## (description of figure) contains a brief prose description of the appearance or content of a graphic figure, for use when documenting an image without displaying it. [14.4. Specific Elements for Graphic Images]
   element tei:figDesc {
     dhq_macro.limitedContent, dhq_att.global.attributes, empty
   }
+
 dhq_att =
-  
   ## (attribute) contains the name of an attribute appearing within running text. [22. Documentation Elements]
   element tei:att {
     xsd:Name,
     dhq_att.global.attributes,
-    
     ## (scheme) supplies an identifier for the scheme in which this name is defined.
     ## Sample values include: 1] TEI (Text Encoding Initiative); 2] DBK (Docbook); 3] XX (unknown); 4] imaginary (imaginary); 5] XHTML (XHTML); 6] XML (XML); 7] XI (XI)
     [ a:defaultValue = "TEI" ]
@@ -4014,130 +3485,65 @@ dhq_att =
     }?,
     empty
   }
+
 dhq_code =
-  
   ## contains literal code from some formal language such as a programming language. [22.1.1. Phrase Level Terms]
   element tei:code {
     text,
     dhq_att.global.attributes,
-    
-    ##
     attribute lang {
-      
       ## Used for code samples in bash
-      "bash"
-      | 
-        ## Used for code samples in CSS
-        "css"
-      | 
-        ## Used for code samples in Fortran
-        "fortran"
-      | 
-        ## Used for code samples in JSON
-        "json"
-      | 
-        ## Used for code samples in Perl
-        "perl"
-      | 
-        ## Used for code samples in PHP
-        "php"
-      | 
-        ## Used for code samples in Python
-        "python"
-      | 
-        ## Used for code samples in R
-        "r"
-      | 
-        ## Used for code samples in SQL
-        "sql"
-      | 
-        ## Used for code samples in SPARQL
-        "sparql"
-      | 
-        ## Used for code samples in languages not explicitly identified
-        "unspecified"
-      | 
-        ## Used for code samples in any XML language or syntactically similar language (such as HTML)
-        "xml"
-      | 
-        ## Used for code samples in XQuery or XPath
+      "bash" | ## Used for code samples in CSS
+        "css" | ## Used for code samples in Fortran
+        "fortran" | ## Used for code samples in JSON
+        "json" | ## Used for code samples in Perl
+        "perl" | ## Used for code samples in PHP
+        "php" | ## Used for code samples in Python
+        "python" | ## Used for code samples in R
+        "r" | ## Used for code samples in SQL
+        "sql" | ## Used for code samples in SPARQL
+        "sparql" | ## Used for code samples in languages not explicitly identified
+        "unspecified" | ## Used for code samples in any XML language or syntactically similar language (such as HTML)
+        "xml" | ## Used for code samples in XQuery or XPath
         "xquery"
     }?,
     empty
   }
+
 dhq_eg =
-  
   ## (example) contains any kind of illustrative example. [22.5. Element Specifications 22.5.3. Attribute List Specification]
   element tei:eg {
     (dhq_hi | dhq_formula | text)*,
     dhq_att.global.attributes,
-    
-    ##
     attribute lang {
-      
       ## Used for code samples in bash
-      "bash"
-      | 
-        ## Used for code samples in C++
-        "c++"
-      | 
-        ## Used for code samples in C#
-        "c#"
-      | 
-        ## Used for code samples in CSS
-        "css"
-      | 
-        ## Used for code samples in Fortran
-        "fortran"
-      | 
-        ## Used for code samples in JavaScript
-        "java"
-      | 
-        ## Used for code samples in JavaScript
-        "javascript"
-      | 
-        ## Used for code samples in JSON
-        "json"
-      | 
-        ## Used for code samples that should be handled as plain text (no syntax highlighting)
-        "nohighlight"
-      | 
-        ## Used for code samples in Perl
-        "perl"
-      | 
-        ## Used for code samples in PHP
-        "php"
-      | 
-        ## Used for code samples in Python
-        "python"
-      | 
-        ## Used for code samples in R
-        "r"
-      | 
-        ## Used for code samples in SQL
-        "sql"
-      | 
-        ## Used for code samples in SPARQL
-        "sparql"
-      | 
-        ## Used for code samples in languages not explicitly identified
-        "code-general"
-      | 
-        ## Used for code samples in any XML language or syntactically similar language (such as HTML)
-        "xml"
-      | 
-        ## Used for code samples in XQuery or XPath
+      "bash" | ## Used for code samples in C++
+        "c++" | ## Used for code samples in C#
+        "c#" | ## Used for code samples in CSS
+        "css" | ## Used for code samples in Fortran
+        "fortran" | ## Used for code samples in JavaScript
+        "java" | ## Used for code samples in JavaScript
+        "javascript" | ## Used for code samples in JSON
+        "json" | ## Used for code samples that should be handled as plain text (no syntax highlighting)
+        "nohighlight" | ## Used for code samples in Perl
+        "perl" | ## Used for code samples in PHP
+        "php" | ## Used for code samples in Python
+        "python" | ## Used for code samples in R
+        "r" | ## Used for code samples in SQL
+        "sql" | ## Used for code samples in SPARQL
+        "sparql" | ## Used for code samples in languages not explicitly identified
+        "code-general" | ## Used for code samples in any XML language or syntactically similar language (such as HTML)
+        "xml" | ## Used for code samples in XQuery or XPath
         "xquery"
     },
     empty
   }
+
 dhq_gi =
-  
   ## (element name) contains the name (generic identifier) of an element. [22. Documentation Elements 22.5. Element Specifications]
   element tei:gi {
     xsd:Name,
     dhq_att.global.attributes,
-    
     ## supplies the name of the scheme in which this name is defined.
     ## Sample values include: 1] TEI; 2] DBK (docbook); 3] XX (unknown); 4] Schematron; 5] HTML
     [ a:defaultValue = "TEI" ]
@@ -4146,12 +3552,12 @@ dhq_gi =
     }?,
     empty
   }
+
 dhq_val =
-  
   ## (value) contains a single attribute value. [22. Documentation Elements 22.5.3. Attribute List Specification]
   element tei:val { text, dhq_att.global.attributes, empty }
+
 dhq_ab =
-  
   ## (anonymous block) contains any arbitrary component-level unit of text, acting as an anonymous container for phrase or inter level elements analogous to, but without the semantic baggage of, a paragraph. [16.3. Blocks, Segments, and Anchors]
   element tei:ab {
     dhq_macro.paraContent
@@ -4201,44 +3607,35 @@ dhq_ab =
        ],
     dhq_att.global.attributes,
     dhq_att.written.attributes,
-    
-    ##
     attribute type { text }?,
     empty
   }
+
 dhq_anchor =
-  
   ## (anchor point) attaches an identifier to a point within a text, whether or not it corresponds with a textual element. [8.4.2. Synchronization and Overlap 16.5. Correspondence and Alignment]
   element tei:anchor {
     empty,
     dhq_att.global.attributes,
-    
-    ##
     attribute xml:id { xsd:ID }?,
-    
-    ##
     attribute type {
-      
       ## identifies a revision location in a revised article
       "revisionLoc"
     }?,
     empty
   }
+
 dhq_seg =
-  
   ## (arbitrary segment) represents any segmentation of text below the chunk level. [16.3. Blocks, Segments, and Anchors 6.2. Components of the Verse Line 7.2.5. Speech Contents]
   element tei:seg {
     dhq_macro.paraContent,
     dhq_att.global.attributes,
     dhq_att.written.attributes,
     dhq_att.notated.attributes,
-    
-    ##
     attribute type { text }?,
     empty
   }
+
 dhq_standOff =
-  
   ## Functions as a container element for linked data, contextual information, and stand-off annotations embedded in a TEI document. [16.10. The standOff Container]
   element tei:standOff {
     (dhq_model.standOffPart+)
@@ -4308,48 +3705,22 @@ dhq_annotation =
   element tei:annotation {
     (dhq_revisionDesc*, dhq_licence*, dhq_model.annotationPart.body*),
     dhq_att.global.attributes,
-    
-    ##
     attribute motivation {
       list {
         (
          ## intent is to assess the target resource in some way, rather than simply make a comment about it
-         "assessing"
-         | 
-           ## intent is to create a bookmark to the target or part thereof
-           "bookmarking"
-         | 
-           ## intent is to classify the target in some way
-           "classifying"
-         | 
-           ## intent is to comment about the target
-           "commenting"
-         | 
-           ## intent is to describe the target, rather than (for example) comment on it
-           "describing"
-         | 
-           ## intent is to request an edit or a change to the target resource
-           "editing"
-         | 
-           ## intent is to highlight the target resource or a segment thereof
-           "highlighting"
-         | 
-           ## intent is to assign an identity to the target
-           "identifying"
-         | 
-           ## intent is to link to a resource related to the target
-           "linking"
-         | 
-           ## intent is to assign some value or quality to the target
-           "moderating"
-         | 
-           ## intent is to ask a question about the target
-           "questioning"
-         | 
-           ## intent is to reply to a previous statement, either an annotation or another resource
-           "replying"
-         | 
-           ## intent is to associate a tag with the target
+         "assessing" | ## intent is to create a bookmark to the target or part thereof
+           "bookmarking" | ## intent is to classify the target in some way
+           "classifying" | ## intent is to comment about the target
+           "commenting" | ## intent is to describe the target, rather than (for example) comment on it
+           "describing" | ## intent is to request an edit or a change to the target resource
+           "editing" | ## intent is to highlight the target resource or a segment thereof
+           "highlighting" | ## intent is to assign an identity to the target
+           "identifying" | ## intent is to link to a resource related to the target
+           "linking" | ## intent is to assign some value or quality to the target
+           "moderating" | ## intent is to ask a question about the target
+           "questioning" | ## intent is to reply to a previous statement, either an annotation or another resource
+           "replying" | ## intent is to associate a tag with the target
            "tagging")+
       }
     }?,
@@ -4365,44 +3736,36 @@ dhq_citRef =
     ]
   ]
   element citRef { (dhq_ptr | dhq_ref | dhq_bibl | text)+ }
+
 dhq_passThroughCode =
-  
   ## Passthrough code gets passed through to the HTML output where it can be executed. The assumption is that this code will be HTML, or something that can be embedded within an HTML document.
   element passThroughCode {
     (text | anyElement-passThroughCode)*,
-    
     ## Indicates whether the code is to be presented as block or in-line element. If "block", a border will be generated.
     attribute rend {
-      
       ## indicates that the embedded code should be presented as a block element
-      "block"
-      | 
-        ## indicates that the embedded code should be presented as an inline element
+      "block" | ## indicates that the embedded code should be presented as an inline element
         "inline"
     }?,
-    
     ## Provides a unique identifier for the element
     attribute xml:id { xsd:ID }?,
-    
     ## Identifies the formal language in which the code is expressed
     attribute lang { dhq_teidata.word }?,
     empty
   }
+
 dhq_example =
-  
   ## An example is similar to a figure, but presents textual information (e.g. code or a sample text) instead of a graphic.
   element example {
     (dhq_head?, dhq_model.common*, dhq_caption?),
-    
     ## Provides a unique identifier for the example item
     attribute xml:id { xsd:ID }?,
-    
     ## Identifies the language of the element's content
     attribute xml:lang { text }?,
     empty
   }
+
 dhq_articleType =
-  
   ## Designates the type of article
   element articleType {
     "article"
@@ -4413,50 +3776,44 @@ dhq_articleType =
     | "case study"
     | "field report"
   }
+
 dhq_abstract =
-  
   ## The abstract for the article. Contains one or more paragraphs.
   element abstract {
     dhq_p+,
-    
-    ##
     attribute xml:lang { text }?,
     empty
   }
+
 dhq_teaser =
-  
   ## The teaser for the article. Contains one or more paragraphs
   element teaser {
     dhq_p,
-    
-    ##
     attribute xml:lang { text }?,
     empty
   }
+
 dhq_author_name =
-  
   ## Contains the name of an author of the article.
   element author_name {
     (text | dhq_family)+,
-    
-    ##
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_translator_name =
-  
   ## Contains the name of a translator of the article.
   element translator_name { (text | dhq_family)+ }
+
 dhq_family =
-  
   ## Identifies the family name of the author.
   element family { text }
+
 dhq_affiliation =
-  
   ## Describes the author's affiliation.
   element affiliation { text }
+
 dhq_bio =
-  
   ## Contains a brief biography of the author. Contains one or more paragraphs.
   element bio { dhq_p+ }
 dhq_authorInfo =
@@ -4473,13 +3830,11 @@ dhq_authorInfo =
      dhq_affiliation?,
      dhq_email?,
      dhq_bio?),
-    
-    ##
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_caption =
-  
   ## A caption for an example or table. May contain either paragraphs or mixed content.
   element caption {
     (text
@@ -4498,28 +3853,20 @@ dhq_translatorInfo =
   ]
   element translatorInfo {
     (dhq_translator_name, dhq_affiliation?, dhq_email?, dhq_bio?),
-    
-    ##
     attribute xml:id { xsd:ID }?,
     empty
   }
+
 dhq_revisionNote =
-  
   ## A revisionNote contains information about a post-publication revision to the article.
   element revisionNote {
     dhq_macro.limitedContent,
-    
-    ##
     attribute previous {
       xsd:anyURI { pattern = "\S+" }
     }?,
-    
-    ##
     attribute next {
       xsd:anyURI { pattern = "\S+" }
     }?,
-    
-    ##
     attribute when { text }?,
     empty
   }
@@ -4532,13 +3879,10 @@ dhq_dedication =
     ]
   ]
   element dedication { text }
+
 dhq_License =
-  
-  ##
   element ns2:License {
     empty,
-    
-    ##
     attribute rdf:about {
       xsd:anyURI { pattern = "\S+" }
     }?,

--- a/common/schema/DHQauthor-TEI.rng
+++ b/common/schema/DHQauthor-TEI.rng
@@ -1,8829 +1,8670 @@
 <?xml version="1.0" encoding="utf-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0"
-         xmlns:tei="http://www.tei-c.org/ns/1.0"
-         xmlns:teix="http://www.tei-c.org/ns/Examples"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
-         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
-         ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2023-07-30T15:56:39Z. .
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:teix="http://www.tei-c.org/ns/Examples" xmlns:xlink="http://www.w3.org/1999/xlink" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" ns="http://www.tei-c.org/ns/1.0">
+  <!--
+Schema generated from ODD source 2023-08-25T23:07:31Z. .
 TEI Edition: Version 4.4.0. Last updated on
         19th April 2022, revision ff9cc28b0
 TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.4.0/
  This schema supports basic journal features. 
---><!---->
-   <div ns="http://www.w3.org/1998/Math/MathML">
-      <div datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-         <div ns="http://www.w3.org/1998/Math/MathML"
-              datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-            <define name="m_cn">
-               <element name="cn">
-                  <ref name="m_cn.attributes"/>
-                  <ref name="m_cn.content"/>
-               </element>
-            </define>
-            <define name="m_cn.content">
-               <text/>
-            </define>
-            <define name="m_cn.attributes">
-               <ref name="m_CommonAtt"/>
-               <attribute name="type">
-                  <choice>
-                     <value>integer</value>
-                     <value>real</value>
-                     <value>double</value>
-                     <value>hexdouble</value>
-                  </choice>
-               </attribute>
-            </define>
-            <define name="m_semantics-ci">
-               <element name="semantics">
-                  <ref name="m_semantics.attributes"/>
-                  <choice>
-                     <ref name="m_ci"/>
-                     <ref name="m_semantics-ci"/>
-                  </choice>
-                  <zeroOrMore>
-                     <choice>
-                        <ref name="m_annotation"/>
-                        <ref name="m_annotation-xml"/>
-                     </choice>
-                  </zeroOrMore>
-               </element>
-            </define>
-            <define name="m_semantics-contexp">
-               <element name="semantics">
-                  <ref name="m_semantics.attributes"/>
-                  <ref name="m_ContExp"/>
-                  <zeroOrMore>
-                     <choice>
-                        <ref name="m_annotation"/>
-                        <ref name="m_annotation-xml"/>
-                     </choice>
-                  </zeroOrMore>
-               </element>
-            </define>
-            <define name="m_ci">
-               <element name="ci">
-                  <ref name="m_ci.attributes"/>
-                  <ref name="m_ci.content"/>
-               </element>
-            </define>
-            <define name="m_ci.attributes">
-               <ref name="m_CommonAtt"/>
-               <optional>
-                  <ref name="m_ci.type"/>
-               </optional>
-            </define>
-            <define name="m_ci.type">
-               <attribute name="type">
-                  <choice>
-                     <value>integer</value>
-                     <value>rational</value>
-                     <value>real</value>
-                     <value>complex</value>
-                     <value>complex-polar</value>
-                     <value>complex-cartesian</value>
-                     <value>constant</value>
-                     <value>function</value>
-                     <value>vector</value>
-                     <value>list</value>
-                     <value>set</value>
-                     <value>matrix</value>
-                  </choice>
-               </attribute>
-            </define>
-            <define name="m_ci.content">
-               <text/>
-            </define>
-            <define name="m_csymbol">
-               <element name="csymbol">
-                  <ref name="m_csymbol.attributes"/>
-                  <ref name="m_csymbol.content"/>
-               </element>
-            </define>
-            <define name="m_SymbolName">
-               <data type="NCName"/>
-            </define>
-            <define name="m_csymbol.attributes">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_cd"/>
-            </define>
-            <define name="m_csymbol.content">
-               <ref name="m_SymbolName"/>
-            </define>
-            <define name="m_BvarQ">
-               <zeroOrMore>
-                  <ref name="m_bvar"/>
-               </zeroOrMore>
-            </define>
-            <define name="m_bvar">
-               <element name="bvar">
-                  <ref name="m_CommonAtt"/>
-                  <choice>
-                     <ref name="m_ci"/>
-                     <ref name="m_semantics-ci"/>
-                  </choice>
-               </element>
-            </define>
-            <define name="m_apply">
-               <element name="apply">
-                  <ref name="m_CommonAtt"/>
-                  <ref name="m_apply.content"/>
-               </element>
-            </define>
-            <define name="m_apply.content">
-               <oneOrMore>
-                  <ref name="m_ContExp"/>
-               </oneOrMore>
-            </define>
-            <define name="m_bind">
-               <element name="bind">
-                  <ref name="m_CommonAtt"/>
-                  <ref name="m_bind.content"/>
-               </element>
-            </define>
-            <define name="m_bind.content">
-               <ref name="m_ContExp"/>
-               <zeroOrMore>
-                  <ref name="m_bvar"/>
-               </zeroOrMore>
-               <ref name="m_ContExp"/>
-            </define>
-            <define name="m_share">
-               <element name="share">
-                  <ref name="m_CommonAtt"/>
-                  <ref name="m_src"/>
-                  <empty/>
-               </element>
-            </define>
-            <define name="m_cerror">
-               <element name="cerror">
-                  <ref name="m_cerror.attributes"/>
-                  <ref name="m_csymbol"/>
-                  <zeroOrMore>
-                     <ref name="m_ContExp"/>
-                  </zeroOrMore>
-               </element>
-            </define>
-            <define name="m_cerror.attributes">
-               <ref name="m_CommonAtt"/>
-            </define>
-            <define name="m_cbytes">
-               <element name="cbytes">
-                  <ref name="m_cbytes.attributes"/>
-                  <ref name="m_base64"/>
-               </element>
-            </define>
-            <define name="m_cbytes.attributes">
-               <ref name="m_CommonAtt"/>
-            </define>
-            <define name="m_base64">
-               <data type="base64Binary"/>
-            </define>
-            <define name="m_cs">
-               <element name="cs">
-                  <ref name="m_cs.attributes"/>
-                  <text/>
-               </element>
-            </define>
-            <define name="m_cs.attributes">
-               <ref name="m_CommonAtt"/>
-            </define>
-            <define name="m_MathExpression" combine="choice">
-               <ref name="m_ContExp"/>
-            </define>
-         </div>
-         <define name="m_PresentationExpression" combine="choice">
-            <notAllowed/>
-         </define>
-         <define name="m_DomainQ">
-            <zeroOrMore>
-               <choice>
-                  <ref name="m_domainofapplication"/>
-                  <ref name="m_condition"/>
-                  <ref name="m_interval"/>
-                  <group>
-                     <ref name="m_lowlimit"/>
-                     <optional>
-                        <ref name="m_uplimit"/>
-                     </optional>
-                  </group>
-               </choice>
-            </zeroOrMore>
-         </define>
-         <define name="m_domainofapplication">
-            <element name="domainofapplication">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_condition">
-            <element name="condition">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_uplimit">
-            <element name="uplimit">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_lowlimit">
-            <element name="lowlimit">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_degree">
-            <element name="degree">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_momentabout">
-            <element name="momentabout">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_logbase">
-            <element name="logbase">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_type">
-            <attribute name="type"/>
-         </define>
-         <define name="m_order">
-            <attribute name="order">
-               <choice>
-                  <value>numeric</value>
-                  <value>lexicographic</value>
-               </choice>
-            </attribute>
-         </define>
-         <define name="m_closure">
-            <attribute name="closure"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_piecewise"/>
-         </define>
-         <define name="m_piecewise">
-            <element name="piecewise">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <interleave>
-                  <zeroOrMore>
-                     <ref name="m_piece"/>
-                  </zeroOrMore>
-                  <optional>
-                     <ref name="m_otherwise"/>
-                  </optional>
-               </interleave>
-            </element>
-         </define>
-         <define name="m_piece">
-            <element name="piece">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <ref name="m_ContExp"/>
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_otherwise">
-            <element name="otherwise">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_DeprecatedContExp">
+-->
+  <!---->
+  <div ns="http://www.w3.org/1998/Math/MathML">
+    <div datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+      <div ns="http://www.w3.org/1998/Math/MathML" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+        <define name="m_cn">
+          <element name="cn">
+            <ref name="m_cn.attributes"/>
+            <ref name="m_cn.content"/>
+          </element>
+        </define>
+        <define name="m_cn.content">
+          <text/>
+        </define>
+        <define name="m_cn.attributes">
+          <ref name="m_CommonAtt"/>
+          <attribute name="type">
             <choice>
-               <ref name="m_reln"/>
-               <ref name="m_fn"/>
-               <ref name="m_declare"/>
+              <value>integer</value>
+              <value>real</value>
+              <value>double</value>
+              <value>hexdouble</value>
             </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_DeprecatedContExp"/>
-         </define>
-         <define name="m_reln">
-            <element name="reln">
-               <zeroOrMore>
-                  <ref name="m_ContExp"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_fn">
-            <element name="fn">
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_declare">
-            <element name="declare">
-               <optional>
-                  <attribute name="type">
-                     <data type="string"/>
-                  </attribute>
-               </optional>
-               <optional>
-                  <attribute name="scope">
-                     <data type="string"/>
-                  </attribute>
-               </optional>
-               <optional>
-                  <attribute name="nargs">
-                     <data type="nonNegativeInteger"/>
-                  </attribute>
-               </optional>
-               <optional>
-                  <attribute name="occurrence">
-                     <choice>
-                        <value>prefix</value>
-                        <value>infix</value>
-                        <value>function-model</value>
-                     </choice>
-                  </attribute>
-               </optional>
-               <ref name="m_DefEncAtt"/>
-               <oneOrMore>
-                  <ref name="m_ContExp"/>
-               </oneOrMore>
-            </element>
-         </define>
-         <define name="m_interval.class">
+          </attribute>
+        </define>
+        <define name="m_semantics-ci">
+          <element name="semantics">
+            <ref name="m_semantics.attributes"/>
+            <choice>
+              <ref name="m_ci"/>
+              <ref name="m_semantics-ci"/>
+            </choice>
+            <zeroOrMore>
+              <choice>
+                <ref name="m_annotation"/>
+                <ref name="m_annotation-xml"/>
+              </choice>
+            </zeroOrMore>
+          </element>
+        </define>
+        <define name="m_semantics-contexp">
+          <element name="semantics">
+            <ref name="m_semantics.attributes"/>
+            <ref name="m_ContExp"/>
+            <zeroOrMore>
+              <choice>
+                <ref name="m_annotation"/>
+                <ref name="m_annotation-xml"/>
+              </choice>
+            </zeroOrMore>
+          </element>
+        </define>
+        <define name="m_ci">
+          <element name="ci">
+            <ref name="m_ci.attributes"/>
+            <ref name="m_ci.content"/>
+          </element>
+        </define>
+        <define name="m_ci.attributes">
+          <ref name="m_CommonAtt"/>
+          <optional>
+            <ref name="m_ci.type"/>
+          </optional>
+        </define>
+        <define name="m_ci.type">
+          <attribute name="type">
+            <choice>
+              <value>integer</value>
+              <value>rational</value>
+              <value>real</value>
+              <value>complex</value>
+              <value>complex-polar</value>
+              <value>complex-cartesian</value>
+              <value>constant</value>
+              <value>function</value>
+              <value>vector</value>
+              <value>list</value>
+              <value>set</value>
+              <value>matrix</value>
+            </choice>
+          </attribute>
+        </define>
+        <define name="m_ci.content">
+          <text/>
+        </define>
+        <define name="m_csymbol">
+          <element name="csymbol">
+            <ref name="m_csymbol.attributes"/>
+            <ref name="m_csymbol.content"/>
+          </element>
+        </define>
+        <define name="m_SymbolName">
+          <data type="NCName"/>
+        </define>
+        <define name="m_csymbol.attributes">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_cd"/>
+        </define>
+        <define name="m_csymbol.content">
+          <ref name="m_SymbolName"/>
+        </define>
+        <define name="m_BvarQ">
+          <zeroOrMore>
+            <ref name="m_bvar"/>
+          </zeroOrMore>
+        </define>
+        <define name="m_bvar">
+          <element name="bvar">
+            <ref name="m_CommonAtt"/>
+            <choice>
+              <ref name="m_ci"/>
+              <ref name="m_semantics-ci"/>
+            </choice>
+          </element>
+        </define>
+        <define name="m_apply">
+          <element name="apply">
+            <ref name="m_CommonAtt"/>
+            <ref name="m_apply.content"/>
+          </element>
+        </define>
+        <define name="m_apply.content">
+          <oneOrMore>
+            <ref name="m_ContExp"/>
+          </oneOrMore>
+        </define>
+        <define name="m_bind">
+          <element name="bind">
+            <ref name="m_CommonAtt"/>
+            <ref name="m_bind.content"/>
+          </element>
+        </define>
+        <define name="m_bind.content">
+          <ref name="m_ContExp"/>
+          <zeroOrMore>
+            <ref name="m_bvar"/>
+          </zeroOrMore>
+          <ref name="m_ContExp"/>
+        </define>
+        <define name="m_share">
+          <element name="share">
+            <ref name="m_CommonAtt"/>
+            <ref name="m_src"/>
+            <empty/>
+          </element>
+        </define>
+        <define name="m_cerror">
+          <element name="cerror">
+            <ref name="m_cerror.attributes"/>
+            <ref name="m_csymbol"/>
+            <zeroOrMore>
+              <ref name="m_ContExp"/>
+            </zeroOrMore>
+          </element>
+        </define>
+        <define name="m_cerror.attributes">
+          <ref name="m_CommonAtt"/>
+        </define>
+        <define name="m_cbytes">
+          <element name="cbytes">
+            <ref name="m_cbytes.attributes"/>
+            <ref name="m_base64"/>
+          </element>
+        </define>
+        <define name="m_cbytes.attributes">
+          <ref name="m_CommonAtt"/>
+        </define>
+        <define name="m_base64">
+          <data type="base64Binary"/>
+        </define>
+        <define name="m_cs">
+          <element name="cs">
+            <ref name="m_cs.attributes"/>
+            <text/>
+          </element>
+        </define>
+        <define name="m_cs.attributes">
+          <ref name="m_CommonAtt"/>
+        </define>
+        <define name="m_MathExpression" combine="choice">
+          <ref name="m_ContExp"/>
+        </define>
+      </div>
+      <define name="m_PresentationExpression" combine="choice">
+        <notAllowed/>
+      </define>
+      <define name="m_DomainQ">
+        <zeroOrMore>
+          <choice>
+            <ref name="m_domainofapplication"/>
+            <ref name="m_condition"/>
             <ref name="m_interval"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_interval.class"/>
-         </define>
-         <define name="m_interval">
-            <element name="interval">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <optional>
-                  <ref name="m_closure"/>
-               </optional>
-               <ref name="m_ContExp"/>
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_unary-functional.class">
-            <choice>
-               <ref name="m_inverse"/>
-               <ref name="m_ident"/>
-               <ref name="m_domain"/>
-               <ref name="m_codomain"/>
-               <ref name="m_image"/>
-               <ref name="m_ln"/>
-               <ref name="m_log"/>
-               <ref name="m_moment"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_unary-functional.class"/>
-         </define>
-         <define name="m_inverse">
-            <element name="inverse">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_ident">
-            <element name="ident">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_domain">
-            <element name="domain">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_codomain">
-            <element name="codomain">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_image">
-            <element name="image">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_ln">
-            <element name="ln">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_log">
-            <element name="log">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_moment">
-            <element name="moment">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_lambda.class">
-            <ref name="m_lambda"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_lambda.class"/>
-         </define>
-         <define name="m_lambda">
-            <element name="lambda">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <ref name="m_BvarQ"/>
-               <ref name="m_DomainQ"/>
-               <ref name="m_ContExp"/>
-            </element>
-         </define>
-         <define name="m_nary-functional.class">
-            <ref name="m_compose"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-functional.class"/>
-         </define>
-         <define name="m_compose">
-            <element name="compose">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_binary-arith.class">
-            <choice>
-               <ref name="m_quotient"/>
-               <ref name="m_divide"/>
-               <ref name="m_minus"/>
-               <ref name="m_power"/>
-               <ref name="m_rem"/>
-               <ref name="m_root"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_binary-arith.class"/>
-         </define>
-         <define name="m_quotient">
-            <element name="quotient">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_divide">
-            <element name="divide">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_minus">
-            <element name="minus">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_power">
-            <element name="power">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_rem">
-            <element name="rem">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_root">
-            <element name="root">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_unary-arith.class">
-            <choice>
-               <ref name="m_factorial"/>
-               <ref name="m_minus"/>
-               <ref name="m_root"/>
-               <ref name="m_abs"/>
-               <ref name="m_conjugate"/>
-               <ref name="m_arg"/>
-               <ref name="m_real"/>
-               <ref name="m_imaginary"/>
-               <ref name="m_floor"/>
-               <ref name="m_ceiling"/>
-               <ref name="m_exp"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_unary-arith.class"/>
-         </define>
-         <define name="m_factorial">
-            <element name="factorial">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_abs">
-            <element name="abs">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_conjugate">
-            <element name="conjugate">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arg">
-            <element name="arg">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_real">
-            <element name="real">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_imaginary">
-            <element name="imaginary">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_floor">
-            <element name="floor">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_ceiling">
-            <element name="ceiling">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_exp">
-            <element name="exp">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-minmax.class">
-            <choice>
-               <ref name="m_max"/>
-               <ref name="m_min"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-minmax.class"/>
-         </define>
-         <define name="m_max">
-            <element name="max">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_min">
-            <element name="min">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-arith.class">
-            <choice>
-               <ref name="m_plus"/>
-               <ref name="m_times"/>
-               <ref name="m_gcd"/>
-               <ref name="m_lcm"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-arith.class"/>
-         </define>
-         <define name="m_plus">
-            <element name="plus">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_times">
-            <element name="times">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_gcd">
-            <element name="gcd">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_lcm">
-            <element name="lcm">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-logical.class">
-            <choice>
-               <ref name="m_and"/>
-               <ref name="m_or"/>
-               <ref name="m_xor"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-logical.class"/>
-         </define>
-         <define name="m_and">
-            <element name="and">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_or">
-            <element name="or">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_xor">
-            <element name="xor">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_unary-logical.class">
-            <ref name="m_not"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_unary-logical.class"/>
-         </define>
-         <define name="m_not">
-            <element name="not">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_binary-logical.class">
-            <choice>
-               <ref name="m_implies"/>
-               <ref name="m_equivalent"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_binary-logical.class"/>
-         </define>
-         <define name="m_implies">
-            <element name="implies">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_equivalent">
-            <element name="equivalent">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_quantifier.class">
-            <choice>
-               <ref name="m_forall"/>
-               <ref name="m_exists"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_quantifier.class"/>
-         </define>
-         <define name="m_forall">
-            <element name="forall">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_exists">
-            <element name="exists">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-reln.class">
-            <choice>
-               <ref name="m_eq"/>
-               <ref name="m_gt"/>
-               <ref name="m_lt"/>
-               <ref name="m_geq"/>
-               <ref name="m_leq"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-reln.class"/>
-         </define>
-         <define name="m_eq">
-            <element name="eq">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_gt">
-            <element name="gt">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_lt">
-            <element name="lt">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_geq">
-            <element name="geq">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_leq">
-            <element name="leq">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_binary-reln.class">
-            <choice>
-               <ref name="m_neq"/>
-               <ref name="m_approx"/>
-               <ref name="m_factorof"/>
-               <ref name="m_tendsto"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_binary-reln.class"/>
-         </define>
-         <define name="m_neq">
-            <element name="neq">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_approx">
-            <element name="approx">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_factorof">
-            <element name="factorof">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_tendsto">
-            <element name="tendsto">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <optional>
-                  <ref name="m_type"/>
-               </optional>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_int.class">
-            <ref name="m_int"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_int.class"/>
-         </define>
-         <define name="m_int">
-            <element name="int">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_Differential-Operator.class">
-            <ref name="m_diff"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_Differential-Operator.class"/>
-         </define>
-         <define name="m_diff">
-            <element name="diff">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_partialdiff.class">
-            <ref name="m_partialdiff"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_partialdiff.class"/>
-         </define>
-         <define name="m_partialdiff">
-            <element name="partialdiff">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_unary-veccalc.class">
-            <choice>
-               <ref name="m_divergence"/>
-               <ref name="m_grad"/>
-               <ref name="m_curl"/>
-               <ref name="m_laplacian"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_unary-veccalc.class"/>
-         </define>
-         <define name="m_divergence">
-            <element name="divergence">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_grad">
-            <element name="grad">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_curl">
-            <element name="curl">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_laplacian">
-            <element name="laplacian">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-setlist-constructor.class">
-            <choice>
-               <ref name="m_set"/>
-               <ref name="m_list"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-setlist-constructor.class"/>
-         </define>
-         <define name="m_set">
-            <element name="set">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <optional>
-                  <ref name="m_type"/>
-               </optional>
-               <zeroOrMore>
-                  <ref name="m_BvarQ"/>
-               </zeroOrMore>
-               <zeroOrMore>
-                  <ref name="m_DomainQ"/>
-               </zeroOrMore>
-               <zeroOrMore>
-                  <ref name="m_ContExp"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_list">
-            <element name="list">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <optional>
-                  <ref name="m_order"/>
-               </optional>
-               <zeroOrMore>
-                  <ref name="m_BvarQ"/>
-               </zeroOrMore>
-               <zeroOrMore>
-                  <ref name="m_DomainQ"/>
-               </zeroOrMore>
-               <zeroOrMore>
-                  <ref name="m_ContExp"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_nary-set.class">
-            <choice>
-               <ref name="m_union"/>
-               <ref name="m_intersect"/>
-               <ref name="m_cartesianproduct"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-set.class"/>
-         </define>
-         <define name="m_union">
-            <element name="union">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_intersect">
-            <element name="intersect">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_cartesianproduct">
-            <element name="cartesianproduct">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_binary-set.class">
-            <choice>
-               <ref name="m_in"/>
-               <ref name="m_notin"/>
-               <ref name="m_notsubset"/>
-               <ref name="m_notprsubset"/>
-               <ref name="m_setdiff"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_binary-set.class"/>
-         </define>
-         <define name="m_in">
-            <element name="in">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_notin">
-            <element name="notin">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_notsubset">
-            <element name="notsubset">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_notprsubset">
-            <element name="notprsubset">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_setdiff">
-            <element name="setdiff">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-set-reln.class">
-            <choice>
-               <ref name="m_subset"/>
-               <ref name="m_prsubset"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-set-reln.class"/>
-         </define>
-         <define name="m_subset">
-            <element name="subset">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_prsubset">
-            <element name="prsubset">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_unary-set.class">
-            <ref name="m_card"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_unary-set.class"/>
-         </define>
-         <define name="m_card">
-            <element name="card">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_sum.class">
-            <ref name="m_sum"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_sum.class"/>
-         </define>
-         <define name="m_sum">
-            <element name="sum">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_product.class">
-            <ref name="m_product"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_product.class"/>
-         </define>
-         <define name="m_product">
-            <element name="product">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_limit.class">
-            <ref name="m_limit"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_limit.class"/>
-         </define>
-         <define name="m_limit">
-            <element name="limit">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_unary-elementary.class">
-            <choice>
-               <ref name="m_sin"/>
-               <ref name="m_cos"/>
-               <ref name="m_tan"/>
-               <ref name="m_sec"/>
-               <ref name="m_csc"/>
-               <ref name="m_cot"/>
-               <ref name="m_sinh"/>
-               <ref name="m_cosh"/>
-               <ref name="m_tanh"/>
-               <ref name="m_sech"/>
-               <ref name="m_csch"/>
-               <ref name="m_coth"/>
-               <ref name="m_arcsin"/>
-               <ref name="m_arccos"/>
-               <ref name="m_arctan"/>
-               <ref name="m_arccosh"/>
-               <ref name="m_arccot"/>
-               <ref name="m_arccoth"/>
-               <ref name="m_arccsc"/>
-               <ref name="m_arccsch"/>
-               <ref name="m_arcsec"/>
-               <ref name="m_arcsech"/>
-               <ref name="m_arcsinh"/>
-               <ref name="m_arctanh"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_unary-elementary.class"/>
-         </define>
-         <define name="m_sin">
-            <element name="sin">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_cos">
-            <element name="cos">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_tan">
-            <element name="tan">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_sec">
-            <element name="sec">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_csc">
-            <element name="csc">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_cot">
-            <element name="cot">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_sinh">
-            <element name="sinh">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_cosh">
-            <element name="cosh">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_tanh">
-            <element name="tanh">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_sech">
-            <element name="sech">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_csch">
-            <element name="csch">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_coth">
-            <element name="coth">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arcsin">
-            <element name="arcsin">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arccos">
-            <element name="arccos">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arctan">
-            <element name="arctan">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arccosh">
-            <element name="arccosh">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arccot">
-            <element name="arccot">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arccoth">
-            <element name="arccoth">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arccsc">
-            <element name="arccsc">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arccsch">
-            <element name="arccsch">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arcsec">
-            <element name="arcsec">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arcsech">
-            <element name="arcsech">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arcsinh">
-            <element name="arcsinh">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_arctanh">
-            <element name="arctanh">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-stats.class">
-            <choice>
-               <ref name="m_mean"/>
-               <ref name="m_sdev"/>
-               <ref name="m_variance"/>
-               <ref name="m_median"/>
-               <ref name="m_mode"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-stats.class"/>
-         </define>
-         <define name="m_mean">
-            <element name="mean">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_sdev">
-            <element name="sdev">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_variance">
-            <element name="variance">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_median">
-            <element name="median">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_mode">
-            <element name="mode">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-constructor.class">
-            <choice>
-               <ref name="m_vector"/>
-               <ref name="m_matrix"/>
-               <ref name="m_matrixrow"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-constructor.class"/>
-         </define>
-         <define name="m_vector">
-            <element name="vector">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <ref name="m_BvarQ"/>
-               <ref name="m_DomainQ"/>
-               <zeroOrMore>
-                  <ref name="m_ContExp"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_matrix">
-            <element name="matrix">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <ref name="m_BvarQ"/>
-               <ref name="m_DomainQ"/>
-               <zeroOrMore>
-                  <ref name="m_ContExp"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_matrixrow">
-            <element name="matrixrow">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <ref name="m_BvarQ"/>
-               <ref name="m_DomainQ"/>
-               <zeroOrMore>
-                  <ref name="m_ContExp"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_unary-linalg.class">
-            <choice>
-               <ref name="m_determinant"/>
-               <ref name="m_transpose"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_unary-linalg.class"/>
-         </define>
-         <define name="m_determinant">
-            <element name="determinant">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_transpose">
-            <element name="transpose">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_nary-linalg.class">
-            <ref name="m_selector"/>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_nary-linalg.class"/>
-         </define>
-         <define name="m_selector">
-            <element name="selector">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_binary-linalg.class">
-            <choice>
-               <ref name="m_vectorproduct"/>
-               <ref name="m_scalarproduct"/>
-               <ref name="m_outerproduct"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_binary-linalg.class"/>
-         </define>
-         <define name="m_vectorproduct">
-            <element name="vectorproduct">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_scalarproduct">
-            <element name="scalarproduct">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_outerproduct">
-            <element name="outerproduct">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_constant-set.class">
-            <choice>
-               <ref name="m_integers"/>
-               <ref name="m_reals"/>
-               <ref name="m_rationals"/>
-               <ref name="m_naturalnumbers"/>
-               <ref name="m_complexes"/>
-               <ref name="m_primes"/>
-               <ref name="m_emptyset"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_constant-set.class"/>
-         </define>
-         <define name="m_integers">
-            <element name="integers">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_reals">
-            <element name="reals">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_rationals">
-            <element name="rationals">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_naturalnumbers">
-            <element name="naturalnumbers">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_complexes">
-            <element name="complexes">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_primes">
-            <element name="primes">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_emptyset">
-            <element name="emptyset">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_constant-arith.class">
-            <choice>
-               <ref name="m_exponentiale"/>
-               <ref name="m_imaginaryi"/>
-               <ref name="m_notanumber"/>
-               <ref name="m_true"/>
-               <ref name="m_false"/>
-               <ref name="m_pi"/>
-               <ref name="m_eulergamma"/>
-               <ref name="m_infinity"/>
-            </choice>
-         </define>
-         <define name="m_ContExp" combine="choice">
-            <ref name="m_constant-arith.class"/>
-         </define>
-         <define name="m_exponentiale">
-            <element name="exponentiale">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_imaginaryi">
-            <element name="imaginaryi">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_notanumber">
-            <element name="notanumber">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_true">
-            <element name="true">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_false">
-            <element name="false">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_pi">
-            <element name="pi">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_eulergamma">
-            <element name="eulergamma">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_infinity">
-            <element name="infinity">
-               <ref name="m_CommonAtt"/>
-               <ref name="m_DefEncAtt"/>
-               <empty/>
-            </element>
-         </define>
-      </div>
-      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Content  MathML</a:documentation>
-      <div ns="http://www.w3.org/1998/Math/MathML"
-           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-         <define name="m_MathExpression" combine="choice">
-            <ref name="m_PresentationExpression"/>
-         </define>
-         <define name="m_ImpliedMrow">
-            <zeroOrMore>
-               <ref name="m_MathExpression"/>
-            </zeroOrMore>
-         </define>
-         <define name="m_TableRowExpression">
-            <choice>
-               <ref name="m_mtr"/>
-               <ref name="m_mlabeledtr"/>
-            </choice>
-         </define>
-         <define name="m_TableCellExpression">
-            <ref name="m_mtd"/>
-         </define>
-         <define name="m_MstackExpression">
-            <choice>
-               <ref name="m_MathExpression"/>
-               <ref name="m_mscarries"/>
-               <ref name="m_msline"/>
-               <ref name="m_msrow"/>
-               <ref name="m_msgroup"/>
-            </choice>
-         </define>
-         <define name="m_MsrowExpression">
-            <choice>
-               <ref name="m_MathExpression"/>
-               <ref name="m_none"/>
-            </choice>
-         </define>
-         <define name="m_MultiScriptExpression">
-            <choice>
-               <ref name="m_MathExpression"/>
-               <ref name="m_none"/>
-            </choice>
-            <choice>
-               <ref name="m_MathExpression"/>
-               <ref name="m_none"/>
-            </choice>
-         </define>
-         <define name="m_mpadded-length">
-            <data type="string">
-               <param name="pattern">\s*([\+\-]?[0-9]*([0-9]\.?|\.[0-9])[0-9]*\s*((%?\s*(height|depth|width)?)|e[mx]|in|cm|mm|p[xtc]|((negative)?((very){0,2}thi(n|ck)|medium)mathspace))?)\s*</param>
-            </data>
-         </define>
-         <define name="m_linestyle">
-            <choice>
-               <value>none</value>
-               <value>solid</value>
-               <value>dashed</value>
-            </choice>
-         </define>
-         <define name="m_verticalalign">
-            <choice>
-               <value>top</value>
-               <value>bottom</value>
-               <value>center</value>
-               <value>baseline</value>
-               <value>axis</value>
-            </choice>
-         </define>
-         <define name="m_columnalignstyle">
-            <choice>
-               <value>left</value>
-               <value>center</value>
-               <value>right</value>
-            </choice>
-         </define>
-         <define name="m_idref">
-            <text/>
-         </define>
-         <define name="m_unsigned-integer">
-            <data type="unsignedLong"/>
-         </define>
-         <define name="m_integer">
-            <data type="integer"/>
-         </define>
-         <define name="m_number">
-            <data type="decimal"/>
-         </define>
-         <define name="m_character">
-            <data type="string">
-               <param name="pattern">\s*\S\s*</param>
-            </data>
-         </define>
-         <define name="m_color">
-            <data type="string">
-               <param name="pattern">\s*((#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?)|[aA][qQ][uU][aA]|[bB][lL][aA][cC][kK]|[bB][lL][uU][eE]|[fF][uU][cC][hH][sS][iI][aA]|[gG][rR][aA][yY]|[gG][rR][eE][eE][nN]|[lL][iI][mM][eE]|[mM][aA][rR][oO][oO][nN]|[nN][aA][vV][yY]|[oO][lL][iI][vV][eE]|[pP][uU][rR][pP][lL][eE]|[rR][eE][dD]|[sS][iI][lL][vV][eE][rR]|[tT][eE][aA][lL]|[wW][hH][iI][tT][eE]|[yY][eE][lL][lL][oO][wW])\s*</param>
-            </data>
-         </define>
-         <define name="m_group-alignment">
-            <choice>
-               <value>left</value>
-               <value>center</value>
-               <value>right</value>
-               <value>decimalpoint</value>
-            </choice>
-         </define>
-         <define name="m_group-alignment-list">
-            <list>
-               <oneOrMore>
-                  <ref name="m_group-alignment"/>
-               </oneOrMore>
-            </list>
-         </define>
-         <define name="m_group-alignment-list-list">
-            <data type="string">
-               <param name="pattern">(\s*\{\s*(left|center|right|decimalpoint)(\s+(left|center|right|decimalpoint))*\})*\s*</param>
-            </data>
-         </define>
-         <define name="m_positive-integer">
-            <data type="positiveInteger"/>
-         </define>
-         <define name="m_TokenExpression">
-            <choice>
-               <ref name="m_mi"/>
-               <ref name="m_mn"/>
-               <ref name="m_mo"/>
-               <ref name="m_mtext"/>
-               <ref name="m_mspace"/>
-               <ref name="m_ms"/>
-            </choice>
-         </define>
-         <define name="m_token.content">
-            <choice>
-               <ref name="m_mglyph"/>
-               <ref name="m_malignmark"/>
-               <text/>
-            </choice>
-         </define>
-         <define name="m_mi">
-            <element name="mi">
-               <ref name="m_mi.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_token.content"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mi.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <ref name="m_TokenAtt"/>
-         </define>
-         <define name="m_mn">
-            <element name="mn">
-               <ref name="m_mn.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_token.content"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mn.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <ref name="m_TokenAtt"/>
-         </define>
-         <define name="m_mo">
-            <element name="mo">
-               <ref name="m_mo.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_token.content"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mo.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <ref name="m_TokenAtt"/>
-            <optional>
-               <attribute name="form">
-                  <choice>
-                     <value>prefix</value>
-                     <value>infix</value>
-                     <value>postfix</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="fence">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="separator">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="lspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="stretchy">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="symmetric">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="maxsize">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>infinity</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="minsize">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="largeop">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="movablelimits">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="accent">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="linebreak">
-                  <choice>
-                     <value>auto</value>
-                     <value>newline</value>
-                     <value>nobreak</value>
-                     <value>goodbreak</value>
-                     <value>badbreak</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="lineleading">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="linebreakstyle">
-                  <choice>
-                     <value>before</value>
-                     <value>after</value>
-                     <value>duplicate</value>
-                     <value>infixlinebreakstyle</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="linebreakmultchar"/>
-            </optional>
-            <optional>
-               <attribute name="indentalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indenttarget">
-                  <ref name="m_idref"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalignfirst">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                     <value>indentalign</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshiftfirst">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>indentshift</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalignlast">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                     <value>indentalign</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshiftlast">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>indentshift</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mtext">
-            <element name="mtext">
-               <ref name="m_mtext.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_token.content"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mtext.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <ref name="m_TokenAtt"/>
-         </define>
-         <define name="m_mspace">
-            <element name="mspace">
-               <ref name="m_mspace.attributes"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_mspace.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <ref name="m_TokenAtt"/>
-            <optional>
-               <attribute name="width">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="height">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="depth">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="linebreak">
-                  <choice>
-                     <value>auto</value>
-                     <value>newline</value>
-                     <value>nobreak</value>
-                     <value>goodbreak</value>
-                     <value>badbreak</value>
-                     <value>indentingnewline</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indenttarget">
-                  <ref name="m_idref"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalignfirst">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                     <value>indentalign</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshiftfirst">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>indentshift</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalignlast">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                     <value>indentalign</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshiftlast">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>indentshift</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_ms">
-            <element name="ms">
-               <ref name="m_ms.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_token.content"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_ms.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <ref name="m_TokenAtt"/>
-            <optional>
-               <attribute name="lquote"/>
-            </optional>
-            <optional>
-               <attribute name="rquote"/>
-            </optional>
-         </define>
-         <define name="m_mglyph">
-            <element name="mglyph">
-               <ref name="m_mglyph.attributes"/>
-               <ref name="m_mglyph.deprecatedattributes"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_mglyph.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="src">
-                  <data type="anyURI"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="width">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="height">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="valign">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="alt"/>
-            </optional>
-         </define>
-         <define name="m_mglyph.deprecatedattributes">
-            <optional>
-               <attribute name="index">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mathvariant">
-                  <choice>
-                     <value>normal</value>
-                     <value>bold</value>
-                     <value>italic</value>
-                     <value>bold-italic</value>
-                     <value>double-struck</value>
-                     <value>bold-fraktur</value>
-                     <value>script</value>
-                     <value>bold-script</value>
-                     <value>fraktur</value>
-                     <value>sans-serif</value>
-                     <value>bold-sans-serif</value>
-                     <value>sans-serif-italic</value>
-                     <value>sans-serif-bold-italic</value>
-                     <value>monospace</value>
-                     <value>initial</value>
-                     <value>tailed</value>
-                     <value>looped</value>
-                     <value>stretched</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mathsize">
-                  <choice>
-                     <value>small</value>
-                     <value>normal</value>
-                     <value>big</value>
-                     <ref name="m_length"/>
-                  </choice>
-               </attribute>
-            </optional>
-            <ref name="m_DeprecatedTokenAtt"/>
-         </define>
-         <define name="m_msline">
-            <element name="msline">
-               <ref name="m_msline.attributes"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_msline.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="position">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="length">
-                  <ref name="m_unsigned-integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="leftoverhang">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rightoverhang">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mslinethickness">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>thin</value>
-                     <value>medium</value>
-                     <value>thick</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_none">
-            <element name="none">
-               <ref name="m_none.attributes"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_none.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-         </define>
-         <define name="m_mprescripts">
-            <element name="mprescripts">
-               <ref name="m_mprescripts.attributes"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_mprescripts.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-         </define>
-         <define name="m_CommonPresAtt">
-            <optional>
-               <attribute name="mathcolor">
-                  <ref name="m_color"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mathbackground">
-                  <choice>
-                     <ref name="m_color"/>
-                     <value>transparent</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_TokenAtt">
-            <optional>
-               <attribute name="mathvariant">
-                  <choice>
-                     <value>normal</value>
-                     <value>bold</value>
-                     <value>italic</value>
-                     <value>bold-italic</value>
-                     <value>double-struck</value>
-                     <value>bold-fraktur</value>
-                     <value>script</value>
-                     <value>bold-script</value>
-                     <value>fraktur</value>
-                     <value>sans-serif</value>
-                     <value>bold-sans-serif</value>
-                     <value>sans-serif-italic</value>
-                     <value>sans-serif-bold-italic</value>
-                     <value>monospace</value>
-                     <value>initial</value>
-                     <value>tailed</value>
-                     <value>looped</value>
-                     <value>stretched</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mathsize">
-                  <choice>
-                     <value>small</value>
-                     <value>normal</value>
-                     <value>big</value>
-                     <ref name="m_length"/>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="dir">
-                  <choice>
-                     <value>ltr</value>
-                     <value>rtl</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <ref name="m_DeprecatedTokenAtt"/>
-         </define>
-         <define name="m_DeprecatedTokenAtt">
-            <optional>
-               <attribute name="fontfamily"/>
-            </optional>
-            <optional>
-               <attribute name="fontweight">
-                  <choice>
-                     <value>normal</value>
-                     <value>bold</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="fontstyle">
-                  <choice>
-                     <value>normal</value>
-                     <value>italic</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="fontsize">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="color">
-                  <ref name="m_color"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="background">
-                  <choice>
-                     <ref name="m_color"/>
-                     <value>transparent</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_MalignExpression">
-            <choice>
-               <ref name="m_maligngroup"/>
-               <ref name="m_malignmark"/>
-            </choice>
-         </define>
-         <define name="m_malignmark">
-            <element name="malignmark">
-               <ref name="m_malignmark.attributes"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_malignmark.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="edge">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_maligngroup">
-            <element name="maligngroup">
-               <ref name="m_maligngroup.attributes"/>
-               <empty/>
-            </element>
-         </define>
-         <define name="m_maligngroup.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="groupalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>decimalpoint</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mrow">
-            <element name="mrow">
-               <ref name="m_mrow.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_MathExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mrow.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="dir">
-                  <choice>
-                     <value>ltr</value>
-                     <value>rtl</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mfrac">
-            <element name="mfrac">
-               <ref name="m_mfrac.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_mfrac.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="linethickness">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>thin</value>
-                     <value>medium</value>
-                     <value>thick</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="numalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="denomalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="bevelled">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_msqrt">
-            <element name="msqrt">
-               <ref name="m_msqrt.attributes"/>
-               <ref name="m_ImpliedMrow"/>
-            </element>
-         </define>
-         <define name="m_msqrt.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-         </define>
-         <define name="m_mroot">
-            <element name="mroot">
-               <ref name="m_mroot.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_mroot.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-         </define>
-         <define name="m_mstyle">
-            <element name="mstyle">
-               <ref name="m_mstyle.attributes"/>
-               <ref name="m_ImpliedMrow"/>
-            </element>
-         </define>
-         <define name="m_mstyle.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <ref name="m_mstyle.specificattributes"/>
-            <ref name="m_mstyle.generalattributes"/>
-            <ref name="m_mstyle.deprecatedattributes"/>
-         </define>
-         <define name="m_mstyle.specificattributes">
-            <optional>
-               <attribute name="scriptlevel">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="displaystyle">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="scriptsizemultiplier">
-                  <ref name="m_number"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="scriptminsize">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="infixlinebreakstyle">
-                  <choice>
-                     <value>before</value>
-                     <value>after</value>
-                     <value>duplicate</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="decimalpoint">
-                  <ref name="m_character"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mstyle.generalattributes">
-            <optional>
-               <attribute name="accent">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="accentunder">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="align">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                     <value>center</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="alignmentscope">
-                  <list>
-                     <oneOrMore>
-                        <choice>
-                           <value>true</value>
-                           <value>false</value>
-                        </choice>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="bevelled">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="charalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="charspacing">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>loose</value>
-                     <value>medium</value>
-                     <value>tight</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="close"/>
-            </optional>
-            <optional>
-               <attribute name="columnalign">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_columnalignstyle"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnlines">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_linestyle"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnspacing">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_length"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnspan">
-                  <ref name="m_positive-integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnwidth">
-                  <list>
-                     <oneOrMore>
-                        <choice>
-                           <value>auto</value>
-                           <ref name="m_length"/>
-                           <value>fit</value>
-                        </choice>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="crossout">
-                  <list>
-                     <zeroOrMore>
-                        <choice>
-                           <value>none</value>
-                           <value>updiagonalstrike</value>
-                           <value>downdiagonalstrike</value>
-                           <value>verticalstrike</value>
-                           <value>horizontalstrike</value>
-                        </choice>
-                     </zeroOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="denomalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="depth">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="dir">
-                  <choice>
-                     <value>ltr</value>
-                     <value>rtl</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="edge">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="equalcolumns">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="equalrows">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="fence">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="form">
-                  <choice>
-                     <value>prefix</value>
-                     <value>infix</value>
-                     <value>postfix</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="frame">
-                  <ref name="m_linestyle"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="framespacing">
-                  <list>
-                     <ref name="m_length"/>
-                     <ref name="m_length"/>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="groupalign">
-                  <ref name="m_group-alignment-list-list"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="height">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalignfirst">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                     <value>indentalign</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentalignlast">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>auto</value>
-                     <value>id</value>
-                     <value>indentalign</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshiftfirst">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>indentshift</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indentshiftlast">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>indentshift</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="indenttarget">
-                  <ref name="m_idref"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="largeop">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="leftoverhang">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="length">
-                  <ref name="m_unsigned-integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="linebreak">
-                  <choice>
-                     <value>auto</value>
-                     <value>newline</value>
-                     <value>nobreak</value>
-                     <value>goodbreak</value>
-                     <value>badbreak</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="linebreakmultchar"/>
-            </optional>
-            <optional>
-               <attribute name="linebreakstyle">
-                  <choice>
-                     <value>before</value>
-                     <value>after</value>
-                     <value>duplicate</value>
-                     <value>infixlinebreakstyle</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="lineleading">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="linethickness">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>thin</value>
-                     <value>medium</value>
-                     <value>thick</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="location">
-                  <choice>
-                     <value>w</value>
-                     <value>nw</value>
-                     <value>n</value>
-                     <value>ne</value>
-                     <value>e</value>
-                     <value>se</value>
-                     <value>s</value>
-                     <value>sw</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="longdivstyle">
-                  <choice>
-                     <value>lefttop</value>
-                     <value>stackedrightright</value>
-                     <value>mediumstackedrightright</value>
-                     <value>shortstackedrightright</value>
-                     <value>righttop</value>
-                     <value>left/\right</value>
-                     <value>left)(right</value>
-                     <value>:right=right</value>
-                     <value>stackedleftleft</value>
-                     <value>stackedleftlinetop</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="lquote"/>
-            </optional>
-            <optional>
-               <attribute name="lspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mathsize">
-                  <choice>
-                     <value>small</value>
-                     <value>normal</value>
-                     <value>big</value>
-                     <ref name="m_length"/>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mathvariant">
-                  <choice>
-                     <value>normal</value>
-                     <value>bold</value>
-                     <value>italic</value>
-                     <value>bold-italic</value>
-                     <value>double-struck</value>
-                     <value>bold-fraktur</value>
-                     <value>script</value>
-                     <value>bold-script</value>
-                     <value>fraktur</value>
-                     <value>sans-serif</value>
-                     <value>bold-sans-serif</value>
-                     <value>sans-serif-italic</value>
-                     <value>sans-serif-bold-italic</value>
-                     <value>monospace</value>
-                     <value>initial</value>
-                     <value>tailed</value>
-                     <value>looped</value>
-                     <value>stretched</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="maxsize">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>infinity</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="minlabelspacing">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="minsize">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="movablelimits">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mslinethickness">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>thin</value>
-                     <value>medium</value>
-                     <value>thick</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="notation"/>
-            </optional>
-            <optional>
-               <attribute name="numalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="open"/>
-            </optional>
-            <optional>
-               <attribute name="position">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rightoverhang">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowalign">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_verticalalign"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowlines">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_linestyle"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowspacing">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_length"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowspan">
-                  <ref name="m_positive-integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rquote"/>
-            </optional>
-            <optional>
-               <attribute name="rspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="selection">
-                  <ref name="m_positive-integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="separator">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="separators"/>
-            </optional>
-            <optional>
-               <attribute name="shift">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="side">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                     <value>leftoverlap</value>
-                     <value>rightoverlap</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="stackalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>decimalpoint</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="stretchy">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="subscriptshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="superscriptshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="symmetric">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="valign">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="width">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mstyle.deprecatedattributes">
-            <ref name="m_DeprecatedTokenAtt"/>
-            <optional>
-               <attribute name="veryverythinmathspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="verythinmathspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="thinmathspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="mediummathspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="thickmathspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="verythickmathspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="veryverythickmathspace">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_merror">
-            <element name="merror">
-               <ref name="m_merror.attributes"/>
-               <ref name="m_ImpliedMrow"/>
-            </element>
-         </define>
-         <define name="m_merror.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-         </define>
-         <define name="m_mpadded">
-            <element name="mpadded">
-               <ref name="m_mpadded.attributes"/>
-               <ref name="m_ImpliedMrow"/>
-            </element>
-         </define>
-         <define name="m_mpadded.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="height">
-                  <ref name="m_mpadded-length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="depth">
-                  <ref name="m_mpadded-length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="width">
-                  <ref name="m_mpadded-length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="lspace">
-                  <ref name="m_mpadded-length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="voffset">
-                  <ref name="m_mpadded-length"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mphantom">
-            <element name="mphantom">
-               <ref name="m_mphantom.attributes"/>
-               <ref name="m_ImpliedMrow"/>
-            </element>
-         </define>
-         <define name="m_mphantom.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-         </define>
-         <define name="m_mfenced">
-            <element name="mfenced">
-               <ref name="m_mfenced.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_MathExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mfenced.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="open"/>
-            </optional>
-            <optional>
-               <attribute name="close"/>
-            </optional>
-            <optional>
-               <attribute name="separators"/>
-            </optional>
-         </define>
-         <define name="m_menclose">
-            <element name="menclose">
-               <ref name="m_menclose.attributes"/>
-               <ref name="m_ImpliedMrow"/>
-            </element>
-         </define>
-         <define name="m_menclose.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="notation"/>
-            </optional>
-         </define>
-         <define name="m_msub">
-            <element name="msub">
-               <ref name="m_msub.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_msub.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="subscriptshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_msup">
-            <element name="msup">
-               <ref name="m_msup.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_msup.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="superscriptshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_msubsup">
-            <element name="msubsup">
-               <ref name="m_msubsup.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_msubsup.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="subscriptshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="superscriptshift">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_munder">
-            <element name="munder">
-               <ref name="m_munder.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_munder.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="accentunder">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="align">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                     <value>center</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mover">
-            <element name="mover">
-               <ref name="m_mover.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_mover.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="accent">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="align">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                     <value>center</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_munderover">
-            <element name="munderover">
-               <ref name="m_munderover.attributes"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-               <ref name="m_MathExpression"/>
-            </element>
-         </define>
-         <define name="m_munderover.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="accent">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="accentunder">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="align">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                     <value>center</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mmultiscripts">
-            <element name="mmultiscripts">
-               <ref name="m_mmultiscripts.attributes"/>
-               <ref name="m_MathExpression"/>
-               <zeroOrMore>
-                  <ref name="m_MultiScriptExpression"/>
-               </zeroOrMore>
-               <optional>
-                  <ref name="m_mprescripts"/>
-                  <zeroOrMore>
-                     <ref name="m_MultiScriptExpression"/>
-                  </zeroOrMore>
-               </optional>
-            </element>
-         </define>
-         <define name="m_mmultiscripts.attributes">
-            <ref name="m_msubsup.attributes"/>
-         </define>
-         <define name="m_mtable">
-            <element name="mtable">
-               <ref name="m_mtable.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_TableRowExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mtable.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="align">
-                  <data type="string">
-                     <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
-                  </data>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowalign">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_verticalalign"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnalign">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_columnalignstyle"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="groupalign">
-                  <ref name="m_group-alignment-list-list"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="alignmentscope">
-                  <list>
-                     <oneOrMore>
-                        <choice>
-                           <value>true</value>
-                           <value>false</value>
-                        </choice>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnwidth">
-                  <list>
-                     <oneOrMore>
-                        <choice>
-                           <value>auto</value>
-                           <ref name="m_length"/>
-                           <value>fit</value>
-                        </choice>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="width">
-                  <choice>
-                     <value>auto</value>
-                     <ref name="m_length"/>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowspacing">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_length"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnspacing">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_length"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowlines">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_linestyle"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnlines">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_linestyle"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="frame">
-                  <ref name="m_linestyle"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="framespacing">
-                  <list>
-                     <ref name="m_length"/>
-                     <ref name="m_length"/>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="equalrows">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="equalcolumns">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="displaystyle">
-                  <choice>
-                     <value>true</value>
-                     <value>false</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="side">
-                  <choice>
-                     <value>left</value>
-                     <value>right</value>
-                     <value>leftoverlap</value>
-                     <value>rightoverlap</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="minlabelspacing">
-                  <ref name="m_length"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mlabeledtr">
-            <element name="mlabeledtr">
-               <ref name="m_mlabeledtr.attributes"/>
-               <oneOrMore>
-                  <ref name="m_TableCellExpression"/>
-               </oneOrMore>
-            </element>
-         </define>
-         <define name="m_mlabeledtr.attributes">
-            <ref name="m_mtr.attributes"/>
-         </define>
-         <define name="m_mtr">
-            <element name="mtr">
-               <ref name="m_mtr.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_TableCellExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mtr.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="rowalign">
-                  <choice>
-                     <value>top</value>
-                     <value>bottom</value>
-                     <value>center</value>
-                     <value>baseline</value>
-                     <value>axis</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnalign">
-                  <list>
-                     <oneOrMore>
-                        <ref name="m_columnalignstyle"/>
-                     </oneOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="groupalign">
-                  <ref name="m_group-alignment-list-list"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mtd">
-            <element name="mtd">
-               <ref name="m_mtd.attributes"/>
-               <ref name="m_ImpliedMrow"/>
-            </element>
-         </define>
-         <define name="m_mtd.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="rowspan">
-                  <ref name="m_positive-integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnspan">
-                  <ref name="m_positive-integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="rowalign">
-                  <choice>
-                     <value>top</value>
-                     <value>bottom</value>
-                     <value>center</value>
-                     <value>baseline</value>
-                     <value>axis</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="columnalign">
-                  <ref name="m_columnalignstyle"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="groupalign">
-                  <ref name="m_group-alignment-list"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mstack">
-            <element name="mstack">
-               <ref name="m_mstack.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_MstackExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mstack.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="align">
-                  <data type="string">
-                     <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
-                  </data>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="stackalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                     <value>decimalpoint</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="charalign">
-                  <choice>
-                     <value>left</value>
-                     <value>center</value>
-                     <value>right</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="charspacing">
-                  <choice>
-                     <ref name="m_length"/>
-                     <value>loose</value>
-                     <value>medium</value>
-                     <value>tight</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mlongdiv">
-            <element name="mlongdiv">
-               <ref name="m_mlongdiv.attributes"/>
-               <ref name="m_MstackExpression"/>
-               <ref name="m_MstackExpression"/>
-               <oneOrMore>
-                  <ref name="m_MstackExpression"/>
-               </oneOrMore>
-            </element>
-         </define>
-         <define name="m_mlongdiv.attributes">
-            <ref name="m_msgroup.attributes"/>
-            <optional>
-               <attribute name="longdivstyle">
-                  <choice>
-                     <value>lefttop</value>
-                     <value>stackedrightright</value>
-                     <value>mediumstackedrightright</value>
-                     <value>shortstackedrightright</value>
-                     <value>righttop</value>
-                     <value>left/\right</value>
-                     <value>left)(right</value>
-                     <value>:right=right</value>
-                     <value>stackedleftleft</value>
-                     <value>stackedleftlinetop</value>
-                  </choice>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_msgroup">
-            <element name="msgroup">
-               <ref name="m_msgroup.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_MstackExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_msgroup.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="position">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="shift">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_msrow">
-            <element name="msrow">
-               <ref name="m_msrow.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_MsrowExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_msrow.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="position">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mscarries">
-            <element name="mscarries">
-               <ref name="m_mscarries.attributes"/>
-               <zeroOrMore>
-                  <choice>
-                     <ref name="m_MsrowExpression"/>
-                     <ref name="m_mscarry"/>
-                  </choice>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mscarries.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="position">
-                  <ref name="m_integer"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="location">
-                  <choice>
-                     <value>w</value>
-                     <value>nw</value>
-                     <value>n</value>
-                     <value>ne</value>
-                     <value>e</value>
-                     <value>se</value>
-                     <value>s</value>
-                     <value>sw</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="crossout">
-                  <list>
-                     <zeroOrMore>
-                        <choice>
-                           <value>none</value>
-                           <value>updiagonalstrike</value>
-                           <value>downdiagonalstrike</value>
-                           <value>verticalstrike</value>
-                           <value>horizontalstrike</value>
-                        </choice>
-                     </zeroOrMore>
-                  </list>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="scriptsizemultiplier">
-                  <ref name="m_number"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_mscarry">
-            <element name="mscarry">
-               <ref name="m_mscarry.attributes"/>
-               <zeroOrMore>
-                  <ref name="m_MsrowExpression"/>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_mscarry.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <optional>
-               <attribute name="location">
-                  <choice>
-                     <value>w</value>
-                     <value>nw</value>
-                     <value>n</value>
-                     <value>ne</value>
-                     <value>e</value>
-                     <value>se</value>
-                     <value>s</value>
-                     <value>sw</value>
-                  </choice>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="crossout">
-                  <list>
-                     <zeroOrMore>
-                        <choice>
-                           <value>none</value>
-                           <value>updiagonalstrike</value>
-                           <value>downdiagonalstrike</value>
-                           <value>verticalstrike</value>
-                           <value>horizontalstrike</value>
-                        </choice>
-                     </zeroOrMore>
-                  </list>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_maction">
-            <element name="maction">
-               <ref name="m_maction.attributes"/>
-               <oneOrMore>
-                  <ref name="m_MathExpression"/>
-               </oneOrMore>
-            </element>
-         </define>
-         <define name="m_maction.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_CommonPresAtt"/>
-            <attribute name="actiontype"/>
-            <optional>
-               <attribute name="selection">
-                  <ref name="m_positive-integer"/>
-               </attribute>
-            </optional>
-         </define>
-      </div>
-      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Presentation MathML</a:documentation>
-      <div ns="http://www.w3.org/1998/Math/MathML"
-           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-         <define name="m_MathExpression">
-            <ref name="m_semantics"/>
-         </define>
-         <define name="m_NonMathMLAtt">
-            <attribute>
-               <anyName>
-                  <except>
-                     <nsName ns=""/>
-                     <nsName/>
-                  </except>
-               </anyName>
-               <data type="string"/>
-            </attribute>
-         </define>
-         <define name="m_CommonDeprecatedAtt">
-            <optional>
-               <attribute name="other"/>
-            </optional>
-         </define>
-         <define name="m_CommonAtt">
-            <optional>
-               <attribute name="id">
-                  <data type="ID"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="xref"/>
-            </optional>
-            <optional>
-               <attribute name="class">
-                  <data type="NMTOKENS"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="style">
-                  <data type="string"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="href">
-                  <data type="anyURI"/>
-               </attribute>
-            </optional>
-            <ref name="m_CommonDeprecatedAtt"/>
-            <zeroOrMore>
-               <ref name="m_NonMathMLAtt"/>
-            </zeroOrMore>
-         </define>
-         <define name="m_math.deprecatedattributes">
-            <optional>
-               <attribute name="mode">
-                  <data type="string"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="macros">
-                  <data type="string"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_name">
-            <attribute name="name">
-               <data type="NCName"/>
-            </attribute>
-         </define>
-         <define name="m_cd">
-            <attribute name="cd">
-               <data type="NCName"/>
-            </attribute>
-         </define>
-         <define name="m_src">
-            <optional>
-               <attribute name="src">
-                  <data type="anyURI"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_annotation">
-            <element name="annotation">
-               <ref name="m_annotation.attributes"/>
-               <text/>
-            </element>
-         </define>
-         <define name="m_annotation-xml.model">
-            <zeroOrMore>
-               <choice>
-                  <ref name="m_MathExpression"/>
-                  <ref name="m_anyElement"/>
-               </choice>
-            </zeroOrMore>
-         </define>
-         <define name="m_anyElement">
-            <element>
-               <anyName>
-                  <except>
-                     <nsName/>
-                  </except>
-               </anyName>
-               <zeroOrMore>
-                  <choice>
-                     <attribute>
-                        <anyName/>
-                     </attribute>
-                     <text/>
-                     <ref name="m_anyElement"/>
-                  </choice>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_annotation-xml">
-            <element name="annotation-xml">
-               <ref name="m_annotation.attributes"/>
-               <ref name="m_annotation-xml.model"/>
-            </element>
-         </define>
-         <define name="m_annotation.attributes">
-            <ref name="m_CommonAtt"/>
-            <optional>
-               <ref name="m_cd"/>
-            </optional>
-            <optional>
-               <ref name="m_name"/>
-            </optional>
-            <ref name="m_DefEncAtt"/>
-            <optional>
-               <ref name="m_src"/>
-            </optional>
-         </define>
-         <define name="m_DefEncAtt">
-            <optional>
-               <attribute name="encoding">
-                  <data type="string"/>
-               </attribute>
-            </optional>
-            <optional>
-               <attribute name="definitionURL">
-                  <data type="anyURI"/>
-               </attribute>
-            </optional>
-         </define>
-         <define name="m_semantics">
-            <element name="semantics">
-               <ref name="m_semantics.attributes"/>
-               <ref name="m_MathExpression"/>
-               <zeroOrMore>
-                  <choice>
-                     <ref name="m_annotation"/>
-                     <ref name="m_annotation-xml"/>
-                  </choice>
-               </zeroOrMore>
-            </element>
-         </define>
-         <define name="m_semantics.attributes">
-            <ref name="m_CommonAtt"/>
-            <ref name="m_DefEncAtt"/>
-            <optional>
-               <ref name="m_cd"/>
-            </optional>
-            <optional>
-               <ref name="m_name"/>
-            </optional>
-         </define>
-         <define name="m_length">
-            <data type="string">
-               <param name="pattern">\s*((-?[0-9]*([0-9]\.?|\.[0-9])[0-9]*(e[mx]|in|cm|mm|p[xtc]|%)?)|(negative)?((very){0,2}thi(n|ck)|medium)mathspace)\s*</param>
-            </data>
-         </define>
-      </div>
-      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">math and semantics common to both Content and Presentation</a:documentation>
-      <define name="m_math">
-         <element name="math">
-            <ref name="m_math.attributes"/>
-            <zeroOrMore>
-               <ref name="m_MathExpression"/>
-            </zeroOrMore>
-         </element>
+            <group>
+              <ref name="m_lowlimit"/>
+              <optional>
+                <ref name="m_uplimit"/>
+              </optional>
+            </group>
+          </choice>
+        </zeroOrMore>
       </define>
-      <define name="m_math.attributes">
-         <ref name="m_CommonAtt"/>
-         <optional>
-            <attribute name="display">
-               <choice>
-                  <value>block</value>
-                  <value>inline</value>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="maxwidth">
-               <ref name="m_length"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="overflow">
-               <choice>
-                  <value>linebreak</value>
-                  <value>scroll</value>
-                  <value>elide</value>
-                  <value>truncate</value>
-                  <value>scale</value>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="altimg">
-               <data type="anyURI"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="altimg-width">
-               <ref name="m_length"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="altimg-height">
-               <ref name="m_length"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="altimg-valign">
-               <choice>
-                  <ref name="m_length"/>
-                  <value>top</value>
-                  <value>middle</value>
-                  <value>bottom</value>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="alttext"/>
-         </optional>
-         <optional>
-            <attribute name="cdgroup">
-               <data type="anyURI"/>
-            </attribute>
-         </optional>
-         <ref name="m_math.deprecatedattributes"/>
+      <define name="m_domainofapplication">
+        <element name="domainofapplication">
+          <ref name="m_ContExp"/>
+        </element>
       </define>
-   </div>
-   <define name="dhq_macro.paraContent">
-      <zeroOrMore>
-         <choice>
-            <text/>
-            <ref name="dhq_model.phrase"/>
-            <ref name="dhq_model.inter"/>
-            <ref name="dhq_model.global"/>
-            <ref name="dhq_lg"/>
-            <ref name="dhq_model.lLike"/>
-         </choice>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_macro.limitedContent">
-      <zeroOrMore>
-         <choice>
-            <text/>
-            <ref name="dhq_model.limitedPhrase"/>
-            <ref name="dhq_model.inter"/>
-         </choice>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_macro.phraseSeq">
-      <zeroOrMore>
-         <choice>
-            <text/>
-            <ref name="dhq_model.attributable"/>
-            <ref name="dhq_model.phrase"/>
-            <ref name="dhq_model.global"/>
-         </choice>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_macro.phraseSeq.limited">
-      <zeroOrMore>
-         <choice>
-            <text/>
-            <ref name="dhq_model.limitedPhrase"/>
-            <ref name="dhq_model.global"/>
-         </choice>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_macro.specialPara">
-      <zeroOrMore>
-         <choice>
-            <text/>
-            <ref name="dhq_model.phrase"/>
-            <ref name="dhq_model.inter"/>
-            <ref name="dhq_model.divPart"/>
-            <ref name="dhq_model.global"/>
-         </choice>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_teidata.word">
-      <data type="token">
-         <param name="pattern">[^\p{C}\p{Z}]+</param>
-      </data>
-   </define>
-   <define name="anyElement-xenoData">
-      <element>
-         <anyName>
-            <except>
-               <nsName ns="http://www.tei-c.org/ns/1.0"/>
-               <name ns="http://www.tei-c.org/ns/Examples">egXML</name>
-            </except>
-         </anyName>
-         <zeroOrMore>
-            <attribute>
-               <anyName/>
+      <define name="m_condition">
+        <element name="condition">
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_uplimit">
+        <element name="uplimit">
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_lowlimit">
+        <element name="lowlimit">
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_degree">
+        <element name="degree">
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_momentabout">
+        <element name="momentabout">
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_logbase">
+        <element name="logbase">
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_type">
+        <attribute name="type"/>
+      </define>
+      <define name="m_order">
+        <attribute name="order">
+          <choice>
+            <value>numeric</value>
+            <value>lexicographic</value>
+          </choice>
+        </attribute>
+      </define>
+      <define name="m_closure">
+        <attribute name="closure"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_piecewise"/>
+      </define>
+      <define name="m_piecewise">
+        <element name="piecewise">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <interleave>
+            <zeroOrMore>
+              <ref name="m_piece"/>
+            </zeroOrMore>
+            <optional>
+              <ref name="m_otherwise"/>
+            </optional>
+          </interleave>
+        </element>
+      </define>
+      <define name="m_piece">
+        <element name="piece">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <ref name="m_ContExp"/>
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_otherwise">
+        <element name="otherwise">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_DeprecatedContExp">
+        <choice>
+          <ref name="m_reln"/>
+          <ref name="m_fn"/>
+          <ref name="m_declare"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_DeprecatedContExp"/>
+      </define>
+      <define name="m_reln">
+        <element name="reln">
+          <zeroOrMore>
+            <ref name="m_ContExp"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_fn">
+        <element name="fn">
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_declare">
+        <element name="declare">
+          <optional>
+            <attribute name="type">
+              <data type="string"/>
             </attribute>
-         </zeroOrMore>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="anyElement-xenoData"/>
-            </choice>
-         </zeroOrMore>
-      </element>
-   </define>
-   <define name="anyElement-passThroughCode">
-      <element>
-         <anyName>
-            <except>
-               <nsName ns="http://www.tei-c.org/ns/1.0"/>
-               <name ns="http://www.tei-c.org/ns/Examples">egXML</name>
-            </except>
-         </anyName>
-         <zeroOrMore>
-            <attribute>
-               <anyName/>
+          </optional>
+          <optional>
+            <attribute name="scope">
+              <data type="string"/>
             </attribute>
-         </zeroOrMore>
-         <zeroOrMore>
+          </optional>
+          <optional>
+            <attribute name="nargs">
+              <data type="nonNegativeInteger"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="occurrence">
+              <choice>
+                <value>prefix</value>
+                <value>infix</value>
+                <value>function-model</value>
+              </choice>
+            </attribute>
+          </optional>
+          <ref name="m_DefEncAtt"/>
+          <oneOrMore>
+            <ref name="m_ContExp"/>
+          </oneOrMore>
+        </element>
+      </define>
+      <define name="m_interval.class">
+        <ref name="m_interval"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_interval.class"/>
+      </define>
+      <define name="m_interval">
+        <element name="interval">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <optional>
+            <ref name="m_closure"/>
+          </optional>
+          <ref name="m_ContExp"/>
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_unary-functional.class">
+        <choice>
+          <ref name="m_inverse"/>
+          <ref name="m_ident"/>
+          <ref name="m_domain"/>
+          <ref name="m_codomain"/>
+          <ref name="m_image"/>
+          <ref name="m_ln"/>
+          <ref name="m_log"/>
+          <ref name="m_moment"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_unary-functional.class"/>
+      </define>
+      <define name="m_inverse">
+        <element name="inverse">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_ident">
+        <element name="ident">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_domain">
+        <element name="domain">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_codomain">
+        <element name="codomain">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_image">
+        <element name="image">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_ln">
+        <element name="ln">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_log">
+        <element name="log">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_moment">
+        <element name="moment">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_lambda.class">
+        <ref name="m_lambda"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_lambda.class"/>
+      </define>
+      <define name="m_lambda">
+        <element name="lambda">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <ref name="m_BvarQ"/>
+          <ref name="m_DomainQ"/>
+          <ref name="m_ContExp"/>
+        </element>
+      </define>
+      <define name="m_nary-functional.class">
+        <ref name="m_compose"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-functional.class"/>
+      </define>
+      <define name="m_compose">
+        <element name="compose">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_binary-arith.class">
+        <choice>
+          <ref name="m_quotient"/>
+          <ref name="m_divide"/>
+          <ref name="m_minus"/>
+          <ref name="m_power"/>
+          <ref name="m_rem"/>
+          <ref name="m_root"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_binary-arith.class"/>
+      </define>
+      <define name="m_quotient">
+        <element name="quotient">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_divide">
+        <element name="divide">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_minus">
+        <element name="minus">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_power">
+        <element name="power">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_rem">
+        <element name="rem">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_root">
+        <element name="root">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_unary-arith.class">
+        <choice>
+          <ref name="m_factorial"/>
+          <ref name="m_minus"/>
+          <ref name="m_root"/>
+          <ref name="m_abs"/>
+          <ref name="m_conjugate"/>
+          <ref name="m_arg"/>
+          <ref name="m_real"/>
+          <ref name="m_imaginary"/>
+          <ref name="m_floor"/>
+          <ref name="m_ceiling"/>
+          <ref name="m_exp"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_unary-arith.class"/>
+      </define>
+      <define name="m_factorial">
+        <element name="factorial">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_abs">
+        <element name="abs">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_conjugate">
+        <element name="conjugate">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arg">
+        <element name="arg">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_real">
+        <element name="real">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_imaginary">
+        <element name="imaginary">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_floor">
+        <element name="floor">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_ceiling">
+        <element name="ceiling">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_exp">
+        <element name="exp">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-minmax.class">
+        <choice>
+          <ref name="m_max"/>
+          <ref name="m_min"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-minmax.class"/>
+      </define>
+      <define name="m_max">
+        <element name="max">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_min">
+        <element name="min">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-arith.class">
+        <choice>
+          <ref name="m_plus"/>
+          <ref name="m_times"/>
+          <ref name="m_gcd"/>
+          <ref name="m_lcm"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-arith.class"/>
+      </define>
+      <define name="m_plus">
+        <element name="plus">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_times">
+        <element name="times">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_gcd">
+        <element name="gcd">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_lcm">
+        <element name="lcm">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-logical.class">
+        <choice>
+          <ref name="m_and"/>
+          <ref name="m_or"/>
+          <ref name="m_xor"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-logical.class"/>
+      </define>
+      <define name="m_and">
+        <element name="and">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_or">
+        <element name="or">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_xor">
+        <element name="xor">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_unary-logical.class">
+        <ref name="m_not"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_unary-logical.class"/>
+      </define>
+      <define name="m_not">
+        <element name="not">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_binary-logical.class">
+        <choice>
+          <ref name="m_implies"/>
+          <ref name="m_equivalent"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_binary-logical.class"/>
+      </define>
+      <define name="m_implies">
+        <element name="implies">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_equivalent">
+        <element name="equivalent">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_quantifier.class">
+        <choice>
+          <ref name="m_forall"/>
+          <ref name="m_exists"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_quantifier.class"/>
+      </define>
+      <define name="m_forall">
+        <element name="forall">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_exists">
+        <element name="exists">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-reln.class">
+        <choice>
+          <ref name="m_eq"/>
+          <ref name="m_gt"/>
+          <ref name="m_lt"/>
+          <ref name="m_geq"/>
+          <ref name="m_leq"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-reln.class"/>
+      </define>
+      <define name="m_eq">
+        <element name="eq">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_gt">
+        <element name="gt">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_lt">
+        <element name="lt">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_geq">
+        <element name="geq">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_leq">
+        <element name="leq">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_binary-reln.class">
+        <choice>
+          <ref name="m_neq"/>
+          <ref name="m_approx"/>
+          <ref name="m_factorof"/>
+          <ref name="m_tendsto"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_binary-reln.class"/>
+      </define>
+      <define name="m_neq">
+        <element name="neq">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_approx">
+        <element name="approx">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_factorof">
+        <element name="factorof">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_tendsto">
+        <element name="tendsto">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <optional>
+            <ref name="m_type"/>
+          </optional>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_int.class">
+        <ref name="m_int"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_int.class"/>
+      </define>
+      <define name="m_int">
+        <element name="int">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_Differential-Operator.class">
+        <ref name="m_diff"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_Differential-Operator.class"/>
+      </define>
+      <define name="m_diff">
+        <element name="diff">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_partialdiff.class">
+        <ref name="m_partialdiff"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_partialdiff.class"/>
+      </define>
+      <define name="m_partialdiff">
+        <element name="partialdiff">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_unary-veccalc.class">
+        <choice>
+          <ref name="m_divergence"/>
+          <ref name="m_grad"/>
+          <ref name="m_curl"/>
+          <ref name="m_laplacian"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_unary-veccalc.class"/>
+      </define>
+      <define name="m_divergence">
+        <element name="divergence">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_grad">
+        <element name="grad">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_curl">
+        <element name="curl">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_laplacian">
+        <element name="laplacian">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-setlist-constructor.class">
+        <choice>
+          <ref name="m_set"/>
+          <ref name="m_list"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-setlist-constructor.class"/>
+      </define>
+      <define name="m_set">
+        <element name="set">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <optional>
+            <ref name="m_type"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="m_BvarQ"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="m_DomainQ"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="m_ContExp"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_list">
+        <element name="list">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <optional>
+            <ref name="m_order"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="m_BvarQ"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="m_DomainQ"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="m_ContExp"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_nary-set.class">
+        <choice>
+          <ref name="m_union"/>
+          <ref name="m_intersect"/>
+          <ref name="m_cartesianproduct"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-set.class"/>
+      </define>
+      <define name="m_union">
+        <element name="union">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_intersect">
+        <element name="intersect">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_cartesianproduct">
+        <element name="cartesianproduct">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_binary-set.class">
+        <choice>
+          <ref name="m_in"/>
+          <ref name="m_notin"/>
+          <ref name="m_notsubset"/>
+          <ref name="m_notprsubset"/>
+          <ref name="m_setdiff"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_binary-set.class"/>
+      </define>
+      <define name="m_in">
+        <element name="in">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_notin">
+        <element name="notin">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_notsubset">
+        <element name="notsubset">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_notprsubset">
+        <element name="notprsubset">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_setdiff">
+        <element name="setdiff">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-set-reln.class">
+        <choice>
+          <ref name="m_subset"/>
+          <ref name="m_prsubset"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-set-reln.class"/>
+      </define>
+      <define name="m_subset">
+        <element name="subset">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_prsubset">
+        <element name="prsubset">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_unary-set.class">
+        <ref name="m_card"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_unary-set.class"/>
+      </define>
+      <define name="m_card">
+        <element name="card">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_sum.class">
+        <ref name="m_sum"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_sum.class"/>
+      </define>
+      <define name="m_sum">
+        <element name="sum">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_product.class">
+        <ref name="m_product"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_product.class"/>
+      </define>
+      <define name="m_product">
+        <element name="product">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_limit.class">
+        <ref name="m_limit"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_limit.class"/>
+      </define>
+      <define name="m_limit">
+        <element name="limit">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_unary-elementary.class">
+        <choice>
+          <ref name="m_sin"/>
+          <ref name="m_cos"/>
+          <ref name="m_tan"/>
+          <ref name="m_sec"/>
+          <ref name="m_csc"/>
+          <ref name="m_cot"/>
+          <ref name="m_sinh"/>
+          <ref name="m_cosh"/>
+          <ref name="m_tanh"/>
+          <ref name="m_sech"/>
+          <ref name="m_csch"/>
+          <ref name="m_coth"/>
+          <ref name="m_arcsin"/>
+          <ref name="m_arccos"/>
+          <ref name="m_arctan"/>
+          <ref name="m_arccosh"/>
+          <ref name="m_arccot"/>
+          <ref name="m_arccoth"/>
+          <ref name="m_arccsc"/>
+          <ref name="m_arccsch"/>
+          <ref name="m_arcsec"/>
+          <ref name="m_arcsech"/>
+          <ref name="m_arcsinh"/>
+          <ref name="m_arctanh"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_unary-elementary.class"/>
+      </define>
+      <define name="m_sin">
+        <element name="sin">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_cos">
+        <element name="cos">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_tan">
+        <element name="tan">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_sec">
+        <element name="sec">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_csc">
+        <element name="csc">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_cot">
+        <element name="cot">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_sinh">
+        <element name="sinh">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_cosh">
+        <element name="cosh">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_tanh">
+        <element name="tanh">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_sech">
+        <element name="sech">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_csch">
+        <element name="csch">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_coth">
+        <element name="coth">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arcsin">
+        <element name="arcsin">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arccos">
+        <element name="arccos">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arctan">
+        <element name="arctan">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arccosh">
+        <element name="arccosh">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arccot">
+        <element name="arccot">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arccoth">
+        <element name="arccoth">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arccsc">
+        <element name="arccsc">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arccsch">
+        <element name="arccsch">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arcsec">
+        <element name="arcsec">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arcsech">
+        <element name="arcsech">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arcsinh">
+        <element name="arcsinh">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_arctanh">
+        <element name="arctanh">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-stats.class">
+        <choice>
+          <ref name="m_mean"/>
+          <ref name="m_sdev"/>
+          <ref name="m_variance"/>
+          <ref name="m_median"/>
+          <ref name="m_mode"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-stats.class"/>
+      </define>
+      <define name="m_mean">
+        <element name="mean">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_sdev">
+        <element name="sdev">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_variance">
+        <element name="variance">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_median">
+        <element name="median">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_mode">
+        <element name="mode">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-constructor.class">
+        <choice>
+          <ref name="m_vector"/>
+          <ref name="m_matrix"/>
+          <ref name="m_matrixrow"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-constructor.class"/>
+      </define>
+      <define name="m_vector">
+        <element name="vector">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <ref name="m_BvarQ"/>
+          <ref name="m_DomainQ"/>
+          <zeroOrMore>
+            <ref name="m_ContExp"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_matrix">
+        <element name="matrix">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <ref name="m_BvarQ"/>
+          <ref name="m_DomainQ"/>
+          <zeroOrMore>
+            <ref name="m_ContExp"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_matrixrow">
+        <element name="matrixrow">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <ref name="m_BvarQ"/>
+          <ref name="m_DomainQ"/>
+          <zeroOrMore>
+            <ref name="m_ContExp"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_unary-linalg.class">
+        <choice>
+          <ref name="m_determinant"/>
+          <ref name="m_transpose"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_unary-linalg.class"/>
+      </define>
+      <define name="m_determinant">
+        <element name="determinant">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_transpose">
+        <element name="transpose">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_nary-linalg.class">
+        <ref name="m_selector"/>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_nary-linalg.class"/>
+      </define>
+      <define name="m_selector">
+        <element name="selector">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_binary-linalg.class">
+        <choice>
+          <ref name="m_vectorproduct"/>
+          <ref name="m_scalarproduct"/>
+          <ref name="m_outerproduct"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_binary-linalg.class"/>
+      </define>
+      <define name="m_vectorproduct">
+        <element name="vectorproduct">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_scalarproduct">
+        <element name="scalarproduct">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_outerproduct">
+        <element name="outerproduct">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_constant-set.class">
+        <choice>
+          <ref name="m_integers"/>
+          <ref name="m_reals"/>
+          <ref name="m_rationals"/>
+          <ref name="m_naturalnumbers"/>
+          <ref name="m_complexes"/>
+          <ref name="m_primes"/>
+          <ref name="m_emptyset"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_constant-set.class"/>
+      </define>
+      <define name="m_integers">
+        <element name="integers">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_reals">
+        <element name="reals">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_rationals">
+        <element name="rationals">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_naturalnumbers">
+        <element name="naturalnumbers">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_complexes">
+        <element name="complexes">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_primes">
+        <element name="primes">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_emptyset">
+        <element name="emptyset">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_constant-arith.class">
+        <choice>
+          <ref name="m_exponentiale"/>
+          <ref name="m_imaginaryi"/>
+          <ref name="m_notanumber"/>
+          <ref name="m_true"/>
+          <ref name="m_false"/>
+          <ref name="m_pi"/>
+          <ref name="m_eulergamma"/>
+          <ref name="m_infinity"/>
+        </choice>
+      </define>
+      <define name="m_ContExp" combine="choice">
+        <ref name="m_constant-arith.class"/>
+      </define>
+      <define name="m_exponentiale">
+        <element name="exponentiale">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_imaginaryi">
+        <element name="imaginaryi">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_notanumber">
+        <element name="notanumber">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_true">
+        <element name="true">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_false">
+        <element name="false">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_pi">
+        <element name="pi">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_eulergamma">
+        <element name="eulergamma">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_infinity">
+        <element name="infinity">
+          <ref name="m_CommonAtt"/>
+          <ref name="m_DefEncAtt"/>
+          <empty/>
+        </element>
+      </define>
+    </div>
+    <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Content  MathML</a:documentation>
+    <div ns="http://www.w3.org/1998/Math/MathML" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+      <define name="m_MathExpression" combine="choice">
+        <ref name="m_PresentationExpression"/>
+      </define>
+      <define name="m_ImpliedMrow">
+        <zeroOrMore>
+          <ref name="m_MathExpression"/>
+        </zeroOrMore>
+      </define>
+      <define name="m_TableRowExpression">
+        <choice>
+          <ref name="m_mtr"/>
+          <ref name="m_mlabeledtr"/>
+        </choice>
+      </define>
+      <define name="m_TableCellExpression">
+        <ref name="m_mtd"/>
+      </define>
+      <define name="m_MstackExpression">
+        <choice>
+          <ref name="m_MathExpression"/>
+          <ref name="m_mscarries"/>
+          <ref name="m_msline"/>
+          <ref name="m_msrow"/>
+          <ref name="m_msgroup"/>
+        </choice>
+      </define>
+      <define name="m_MsrowExpression">
+        <choice>
+          <ref name="m_MathExpression"/>
+          <ref name="m_none"/>
+        </choice>
+      </define>
+      <define name="m_MultiScriptExpression">
+        <choice>
+          <ref name="m_MathExpression"/>
+          <ref name="m_none"/>
+        </choice>
+        <choice>
+          <ref name="m_MathExpression"/>
+          <ref name="m_none"/>
+        </choice>
+      </define>
+      <define name="m_mpadded-length">
+        <data type="string">
+          <param name="pattern">\s*([\+\-]?[0-9]*([0-9]\.?|\.[0-9])[0-9]*\s*((%?\s*(height|depth|width)?)|e[mx]|in|cm|mm|p[xtc]|((negative)?((very){0,2}thi(n|ck)|medium)mathspace))?)\s*</param>
+        </data>
+      </define>
+      <define name="m_linestyle">
+        <choice>
+          <value>none</value>
+          <value>solid</value>
+          <value>dashed</value>
+        </choice>
+      </define>
+      <define name="m_verticalalign">
+        <choice>
+          <value>top</value>
+          <value>bottom</value>
+          <value>center</value>
+          <value>baseline</value>
+          <value>axis</value>
+        </choice>
+      </define>
+      <define name="m_columnalignstyle">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </define>
+      <define name="m_idref">
+        <text/>
+      </define>
+      <define name="m_unsigned-integer">
+        <data type="unsignedLong"/>
+      </define>
+      <define name="m_integer">
+        <data type="integer"/>
+      </define>
+      <define name="m_number">
+        <data type="decimal"/>
+      </define>
+      <define name="m_character">
+        <data type="string">
+          <param name="pattern">\s*\S\s*</param>
+        </data>
+      </define>
+      <define name="m_color">
+        <data type="string">
+          <param name="pattern">\s*((#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?)|[aA][qQ][uU][aA]|[bB][lL][aA][cC][kK]|[bB][lL][uU][eE]|[fF][uU][cC][hH][sS][iI][aA]|[gG][rR][aA][yY]|[gG][rR][eE][eE][nN]|[lL][iI][mM][eE]|[mM][aA][rR][oO][oO][nN]|[nN][aA][vV][yY]|[oO][lL][iI][vV][eE]|[pP][uU][rR][pP][lL][eE]|[rR][eE][dD]|[sS][iI][lL][vV][eE][rR]|[tT][eE][aA][lL]|[wW][hH][iI][tT][eE]|[yY][eE][lL][lL][oO][wW])\s*</param>
+        </data>
+      </define>
+      <define name="m_group-alignment">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>decimalpoint</value>
+        </choice>
+      </define>
+      <define name="m_group-alignment-list">
+        <list>
+          <oneOrMore>
+            <ref name="m_group-alignment"/>
+          </oneOrMore>
+        </list>
+      </define>
+      <define name="m_group-alignment-list-list">
+        <data type="string">
+          <param name="pattern">(\s*\{\s*(left|center|right|decimalpoint)(\s+(left|center|right|decimalpoint))*\})*\s*</param>
+        </data>
+      </define>
+      <define name="m_positive-integer">
+        <data type="positiveInteger"/>
+      </define>
+      <define name="m_TokenExpression">
+        <choice>
+          <ref name="m_mi"/>
+          <ref name="m_mn"/>
+          <ref name="m_mo"/>
+          <ref name="m_mtext"/>
+          <ref name="m_mspace"/>
+          <ref name="m_ms"/>
+        </choice>
+      </define>
+      <define name="m_token.content">
+        <choice>
+          <ref name="m_mglyph"/>
+          <ref name="m_malignmark"/>
+          <text/>
+        </choice>
+      </define>
+      <define name="m_mi">
+        <element name="mi">
+          <ref name="m_mi.attributes"/>
+          <zeroOrMore>
+            <ref name="m_token.content"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mi.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <ref name="m_TokenAtt"/>
+      </define>
+      <define name="m_mn">
+        <element name="mn">
+          <ref name="m_mn.attributes"/>
+          <zeroOrMore>
+            <ref name="m_token.content"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mn.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <ref name="m_TokenAtt"/>
+      </define>
+      <define name="m_mo">
+        <element name="mo">
+          <ref name="m_mo.attributes"/>
+          <zeroOrMore>
+            <ref name="m_token.content"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mo.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <ref name="m_TokenAtt"/>
+        <optional>
+          <attribute name="form">
             <choice>
-               <text/>
-               <ref name="anyElement-passThroughCode"/>
+              <value>prefix</value>
+              <value>infix</value>
+              <value>postfix</value>
             </choice>
-         </zeroOrMore>
-      </element>
-   </define>
-   <define name="dhq_att.anchoring.attributes">
-      <ref name="dhq_att.anchoring.attribute.anchored"/>
-      <ref name="dhq_att.anchoring.attribute.targetEnd"/>
-   </define>
-   <define name="dhq_att.anchoring.attribute.anchored">
-      <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                    name="anchored"
-                    a:defaultValue="true">
-            <a:documentation>(anchored) indicates whether the copy text shows the exact place of reference for the note.</a:documentation>
-            <data type="boolean"/>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.anchoring.attribute.targetEnd">
-      <optional>
-         <attribute name="targetEnd">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(target end) points to the end of the span to which the note is attached, if the note is not embedded in the text at that point.</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="fence">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="separator">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="lspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="stretchy">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="symmetric">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="maxsize">
+            <choice>
+              <ref name="m_length"/>
+              <value>infinity</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="minsize">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="largeop">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="movablelimits">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="accent">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="linebreak">
+            <choice>
+              <value>auto</value>
+              <value>newline</value>
+              <value>nobreak</value>
+              <value>goodbreak</value>
+              <value>badbreak</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="lineleading">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="linebreakstyle">
+            <choice>
+              <value>before</value>
+              <value>after</value>
+              <value>duplicate</value>
+              <value>infixlinebreakstyle</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="linebreakmultchar"/>
+        </optional>
+        <optional>
+          <attribute name="indentalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indenttarget">
+            <ref name="m_idref"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalignfirst">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+              <value>indentalign</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshiftfirst">
+            <choice>
+              <ref name="m_length"/>
+              <value>indentshift</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalignlast">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+              <value>indentalign</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshiftlast">
+            <choice>
+              <ref name="m_length"/>
+              <value>indentshift</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mtext">
+        <element name="mtext">
+          <ref name="m_mtext.attributes"/>
+          <zeroOrMore>
+            <ref name="m_token.content"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mtext.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <ref name="m_TokenAtt"/>
+      </define>
+      <define name="m_mspace">
+        <element name="mspace">
+          <ref name="m_mspace.attributes"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_mspace.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <ref name="m_TokenAtt"/>
+        <optional>
+          <attribute name="width">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="height">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="depth">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="linebreak">
+            <choice>
+              <value>auto</value>
+              <value>newline</value>
+              <value>nobreak</value>
+              <value>goodbreak</value>
+              <value>badbreak</value>
+              <value>indentingnewline</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indenttarget">
+            <ref name="m_idref"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalignfirst">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+              <value>indentalign</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshiftfirst">
+            <choice>
+              <ref name="m_length"/>
+              <value>indentshift</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalignlast">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+              <value>indentalign</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshiftlast">
+            <choice>
+              <ref name="m_length"/>
+              <value>indentshift</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_ms">
+        <element name="ms">
+          <ref name="m_ms.attributes"/>
+          <zeroOrMore>
+            <ref name="m_token.content"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_ms.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <ref name="m_TokenAtt"/>
+        <optional>
+          <attribute name="lquote"/>
+        </optional>
+        <optional>
+          <attribute name="rquote"/>
+        </optional>
+      </define>
+      <define name="m_mglyph">
+        <element name="mglyph">
+          <ref name="m_mglyph.attributes"/>
+          <ref name="m_mglyph.deprecatedattributes"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_mglyph.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="src">
+            <data type="anyURI"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="width">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="height">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="valign">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="alt"/>
+        </optional>
+      </define>
+      <define name="m_mglyph.deprecatedattributes">
+        <optional>
+          <attribute name="index">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mathvariant">
+            <choice>
+              <value>normal</value>
+              <value>bold</value>
+              <value>italic</value>
+              <value>bold-italic</value>
+              <value>double-struck</value>
+              <value>bold-fraktur</value>
+              <value>script</value>
+              <value>bold-script</value>
+              <value>fraktur</value>
+              <value>sans-serif</value>
+              <value>bold-sans-serif</value>
+              <value>sans-serif-italic</value>
+              <value>sans-serif-bold-italic</value>
+              <value>monospace</value>
+              <value>initial</value>
+              <value>tailed</value>
+              <value>looped</value>
+              <value>stretched</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mathsize">
+            <choice>
+              <value>small</value>
+              <value>normal</value>
+              <value>big</value>
+              <ref name="m_length"/>
+            </choice>
+          </attribute>
+        </optional>
+        <ref name="m_DeprecatedTokenAtt"/>
+      </define>
+      <define name="m_msline">
+        <element name="msline">
+          <ref name="m_msline.attributes"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_msline.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="position">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="length">
+            <ref name="m_unsigned-integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="leftoverhang">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rightoverhang">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mslinethickness">
+            <choice>
+              <ref name="m_length"/>
+              <value>thin</value>
+              <value>medium</value>
+              <value>thick</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_none">
+        <element name="none">
+          <ref name="m_none.attributes"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_none.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+      </define>
+      <define name="m_mprescripts">
+        <element name="mprescripts">
+          <ref name="m_mprescripts.attributes"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_mprescripts.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+      </define>
+      <define name="m_CommonPresAtt">
+        <optional>
+          <attribute name="mathcolor">
+            <ref name="m_color"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mathbackground">
+            <choice>
+              <ref name="m_color"/>
+              <value>transparent</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_TokenAtt">
+        <optional>
+          <attribute name="mathvariant">
+            <choice>
+              <value>normal</value>
+              <value>bold</value>
+              <value>italic</value>
+              <value>bold-italic</value>
+              <value>double-struck</value>
+              <value>bold-fraktur</value>
+              <value>script</value>
+              <value>bold-script</value>
+              <value>fraktur</value>
+              <value>sans-serif</value>
+              <value>bold-sans-serif</value>
+              <value>sans-serif-italic</value>
+              <value>sans-serif-bold-italic</value>
+              <value>monospace</value>
+              <value>initial</value>
+              <value>tailed</value>
+              <value>looped</value>
+              <value>stretched</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mathsize">
+            <choice>
+              <value>small</value>
+              <value>normal</value>
+              <value>big</value>
+              <ref name="m_length"/>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="dir">
+            <choice>
+              <value>ltr</value>
+              <value>rtl</value>
+            </choice>
+          </attribute>
+        </optional>
+        <ref name="m_DeprecatedTokenAtt"/>
+      </define>
+      <define name="m_DeprecatedTokenAtt">
+        <optional>
+          <attribute name="fontfamily"/>
+        </optional>
+        <optional>
+          <attribute name="fontweight">
+            <choice>
+              <value>normal</value>
+              <value>bold</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="fontstyle">
+            <choice>
+              <value>normal</value>
+              <value>italic</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="fontsize">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="color">
+            <ref name="m_color"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="background">
+            <choice>
+              <ref name="m_color"/>
+              <value>transparent</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_MalignExpression">
+        <choice>
+          <ref name="m_maligngroup"/>
+          <ref name="m_malignmark"/>
+        </choice>
+      </define>
+      <define name="m_malignmark">
+        <element name="malignmark">
+          <ref name="m_malignmark.attributes"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_malignmark.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="edge">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_maligngroup">
+        <element name="maligngroup">
+          <ref name="m_maligngroup.attributes"/>
+          <empty/>
+        </element>
+      </define>
+      <define name="m_maligngroup.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="groupalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>decimalpoint</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mrow">
+        <element name="mrow">
+          <ref name="m_mrow.attributes"/>
+          <zeroOrMore>
+            <ref name="m_MathExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mrow.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="dir">
+            <choice>
+              <value>ltr</value>
+              <value>rtl</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mfrac">
+        <element name="mfrac">
+          <ref name="m_mfrac.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_mfrac.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="linethickness">
+            <choice>
+              <ref name="m_length"/>
+              <value>thin</value>
+              <value>medium</value>
+              <value>thick</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="numalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="denomalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="bevelled">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_msqrt">
+        <element name="msqrt">
+          <ref name="m_msqrt.attributes"/>
+          <ref name="m_ImpliedMrow"/>
+        </element>
+      </define>
+      <define name="m_msqrt.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+      </define>
+      <define name="m_mroot">
+        <element name="mroot">
+          <ref name="m_mroot.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_mroot.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+      </define>
+      <define name="m_mstyle">
+        <element name="mstyle">
+          <ref name="m_mstyle.attributes"/>
+          <ref name="m_ImpliedMrow"/>
+        </element>
+      </define>
+      <define name="m_mstyle.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <ref name="m_mstyle.specificattributes"/>
+        <ref name="m_mstyle.generalattributes"/>
+        <ref name="m_mstyle.deprecatedattributes"/>
+      </define>
+      <define name="m_mstyle.specificattributes">
+        <optional>
+          <attribute name="scriptlevel">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="displaystyle">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="scriptsizemultiplier">
+            <ref name="m_number"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="scriptminsize">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="infixlinebreakstyle">
+            <choice>
+              <value>before</value>
+              <value>after</value>
+              <value>duplicate</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="decimalpoint">
+            <ref name="m_character"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mstyle.generalattributes">
+        <optional>
+          <attribute name="accent">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="accentunder">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="align">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+              <value>center</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="alignmentscope">
             <list>
-               <oneOrMore>
-                  <data type="anyURI">
-                     <param name="pattern">\S+</param>
-                  </data>
-               </oneOrMore>
+              <oneOrMore>
+                <choice>
+                  <value>true</value>
+                  <value>false</value>
+                </choice>
+              </oneOrMore>
             </list>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.ascribed.attributes">
-      <ref name="dhq_att.ascribed.attribute.who"/>
-   </define>
-   <define name="dhq_att.ascribed.attribute.who">
-      <optional>
-         <attribute name="who">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the person, or group of people, to whom the element content is ascribed.</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="bevelled">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="charalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="charspacing">
+            <choice>
+              <ref name="m_length"/>
+              <value>loose</value>
+              <value>medium</value>
+              <value>tight</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="close"/>
+        </optional>
+        <optional>
+          <attribute name="columnalign">
             <list>
-               <oneOrMore>
-                  <data type="anyURI">
-                     <param name="pattern">\S+</param>
-                  </data>
-               </oneOrMore>
+              <oneOrMore>
+                <ref name="m_columnalignstyle"/>
+              </oneOrMore>
             </list>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.ascribed.directed.attributes">
-      <ref name="dhq_att.ascribed.attributes"/>
-      <ref name="dhq_att.ascribed.directed.attribute.toWhom"/>
-   </define>
-   <define name="dhq_att.ascribed.directed.attribute.toWhom">
-      <optional>
-         <attribute name="toWhom">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the person, or group of people, to whom a speech act or action is directed.</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnlines">
             <list>
-               <oneOrMore>
-                  <data type="anyURI">
-                     <param name="pattern">\S+</param>
-                  </data>
-               </oneOrMore>
+              <oneOrMore>
+                <ref name="m_linestyle"/>
+              </oneOrMore>
             </list>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.canonical.attributes">
-      <ref name="dhq_att.canonical.attribute.key"/>
-      <ref name="dhq_att.canonical.attribute.ref"/>
-   </define>
-   <define name="dhq_att.canonical.attribute.key">
-      <optional>
-         <attribute name="key">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides an externally-defined means of identifying the entity (or entities) being named, using a coded value of some kind.</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnspacing">
+            <list>
+              <oneOrMore>
+                <ref name="m_length"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnspan">
+            <ref name="m_positive-integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnwidth">
+            <list>
+              <oneOrMore>
+                <choice>
+                  <value>auto</value>
+                  <ref name="m_length"/>
+                  <value>fit</value>
+                </choice>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="crossout">
+            <list>
+              <zeroOrMore>
+                <choice>
+                  <value>none</value>
+                  <value>updiagonalstrike</value>
+                  <value>downdiagonalstrike</value>
+                  <value>verticalstrike</value>
+                  <value>horizontalstrike</value>
+                </choice>
+              </zeroOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="denomalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="depth">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="dir">
+            <choice>
+              <value>ltr</value>
+              <value>rtl</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="edge">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="equalcolumns">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="equalrows">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="fence">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="form">
+            <choice>
+              <value>prefix</value>
+              <value>infix</value>
+              <value>postfix</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="frame">
+            <ref name="m_linestyle"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="framespacing">
+            <list>
+              <ref name="m_length"/>
+              <ref name="m_length"/>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="groupalign">
+            <ref name="m_group-alignment-list-list"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="height">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalignfirst">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+              <value>indentalign</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentalignlast">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>auto</value>
+              <value>id</value>
+              <value>indentalign</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshiftfirst">
+            <choice>
+              <ref name="m_length"/>
+              <value>indentshift</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indentshiftlast">
+            <choice>
+              <ref name="m_length"/>
+              <value>indentshift</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="indenttarget">
+            <ref name="m_idref"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="largeop">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="leftoverhang">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="length">
+            <ref name="m_unsigned-integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="linebreak">
+            <choice>
+              <value>auto</value>
+              <value>newline</value>
+              <value>nobreak</value>
+              <value>goodbreak</value>
+              <value>badbreak</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="linebreakmultchar"/>
+        </optional>
+        <optional>
+          <attribute name="linebreakstyle">
+            <choice>
+              <value>before</value>
+              <value>after</value>
+              <value>duplicate</value>
+              <value>infixlinebreakstyle</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="lineleading">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="linethickness">
+            <choice>
+              <ref name="m_length"/>
+              <value>thin</value>
+              <value>medium</value>
+              <value>thick</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="location">
+            <choice>
+              <value>w</value>
+              <value>nw</value>
+              <value>n</value>
+              <value>ne</value>
+              <value>e</value>
+              <value>se</value>
+              <value>s</value>
+              <value>sw</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="longdivstyle">
+            <choice>
+              <value>lefttop</value>
+              <value>stackedrightright</value>
+              <value>mediumstackedrightright</value>
+              <value>shortstackedrightright</value>
+              <value>righttop</value>
+              <value>left/\right</value>
+              <value>left)(right</value>
+              <value>:right=right</value>
+              <value>stackedleftleft</value>
+              <value>stackedleftlinetop</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="lquote"/>
+        </optional>
+        <optional>
+          <attribute name="lspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mathsize">
+            <choice>
+              <value>small</value>
+              <value>normal</value>
+              <value>big</value>
+              <ref name="m_length"/>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mathvariant">
+            <choice>
+              <value>normal</value>
+              <value>bold</value>
+              <value>italic</value>
+              <value>bold-italic</value>
+              <value>double-struck</value>
+              <value>bold-fraktur</value>
+              <value>script</value>
+              <value>bold-script</value>
+              <value>fraktur</value>
+              <value>sans-serif</value>
+              <value>bold-sans-serif</value>
+              <value>sans-serif-italic</value>
+              <value>sans-serif-bold-italic</value>
+              <value>monospace</value>
+              <value>initial</value>
+              <value>tailed</value>
+              <value>looped</value>
+              <value>stretched</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="maxsize">
+            <choice>
+              <ref name="m_length"/>
+              <value>infinity</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="minlabelspacing">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="minsize">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="movablelimits">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mslinethickness">
+            <choice>
+              <ref name="m_length"/>
+              <value>thin</value>
+              <value>medium</value>
+              <value>thick</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="notation"/>
+        </optional>
+        <optional>
+          <attribute name="numalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="open"/>
+        </optional>
+        <optional>
+          <attribute name="position">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rightoverhang">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowalign">
+            <list>
+              <oneOrMore>
+                <ref name="m_verticalalign"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowlines">
+            <list>
+              <oneOrMore>
+                <ref name="m_linestyle"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowspacing">
+            <list>
+              <oneOrMore>
+                <ref name="m_length"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowspan">
+            <ref name="m_positive-integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rquote"/>
+        </optional>
+        <optional>
+          <attribute name="rspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="selection">
+            <ref name="m_positive-integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="separator">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="separators"/>
+        </optional>
+        <optional>
+          <attribute name="shift">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="side">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+              <value>leftoverlap</value>
+              <value>rightoverlap</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="stackalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>decimalpoint</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="stretchy">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="subscriptshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="superscriptshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="symmetric">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="valign">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="width">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mstyle.deprecatedattributes">
+        <ref name="m_DeprecatedTokenAtt"/>
+        <optional>
+          <attribute name="veryverythinmathspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="verythinmathspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="thinmathspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="mediummathspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="thickmathspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="verythickmathspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="veryverythickmathspace">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_merror">
+        <element name="merror">
+          <ref name="m_merror.attributes"/>
+          <ref name="m_ImpliedMrow"/>
+        </element>
+      </define>
+      <define name="m_merror.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+      </define>
+      <define name="m_mpadded">
+        <element name="mpadded">
+          <ref name="m_mpadded.attributes"/>
+          <ref name="m_ImpliedMrow"/>
+        </element>
+      </define>
+      <define name="m_mpadded.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="height">
+            <ref name="m_mpadded-length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="depth">
+            <ref name="m_mpadded-length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="width">
+            <ref name="m_mpadded-length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="lspace">
+            <ref name="m_mpadded-length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="voffset">
+            <ref name="m_mpadded-length"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mphantom">
+        <element name="mphantom">
+          <ref name="m_mphantom.attributes"/>
+          <ref name="m_ImpliedMrow"/>
+        </element>
+      </define>
+      <define name="m_mphantom.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+      </define>
+      <define name="m_mfenced">
+        <element name="mfenced">
+          <ref name="m_mfenced.attributes"/>
+          <zeroOrMore>
+            <ref name="m_MathExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mfenced.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="open"/>
+        </optional>
+        <optional>
+          <attribute name="close"/>
+        </optional>
+        <optional>
+          <attribute name="separators"/>
+        </optional>
+      </define>
+      <define name="m_menclose">
+        <element name="menclose">
+          <ref name="m_menclose.attributes"/>
+          <ref name="m_ImpliedMrow"/>
+        </element>
+      </define>
+      <define name="m_menclose.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="notation"/>
+        </optional>
+      </define>
+      <define name="m_msub">
+        <element name="msub">
+          <ref name="m_msub.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_msub.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="subscriptshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_msup">
+        <element name="msup">
+          <ref name="m_msup.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_msup.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="superscriptshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_msubsup">
+        <element name="msubsup">
+          <ref name="m_msubsup.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_msubsup.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="subscriptshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="superscriptshift">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_munder">
+        <element name="munder">
+          <ref name="m_munder.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_munder.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="accentunder">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="align">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+              <value>center</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mover">
+        <element name="mover">
+          <ref name="m_mover.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_mover.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="accent">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="align">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+              <value>center</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_munderover">
+        <element name="munderover">
+          <ref name="m_munderover.attributes"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+          <ref name="m_MathExpression"/>
+        </element>
+      </define>
+      <define name="m_munderover.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="accent">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="accentunder">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="align">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+              <value>center</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mmultiscripts">
+        <element name="mmultiscripts">
+          <ref name="m_mmultiscripts.attributes"/>
+          <ref name="m_MathExpression"/>
+          <zeroOrMore>
+            <ref name="m_MultiScriptExpression"/>
+          </zeroOrMore>
+          <optional>
+            <ref name="m_mprescripts"/>
+            <zeroOrMore>
+              <ref name="m_MultiScriptExpression"/>
+            </zeroOrMore>
+          </optional>
+        </element>
+      </define>
+      <define name="m_mmultiscripts.attributes">
+        <ref name="m_msubsup.attributes"/>
+      </define>
+      <define name="m_mtable">
+        <element name="mtable">
+          <ref name="m_mtable.attributes"/>
+          <zeroOrMore>
+            <ref name="m_TableRowExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mtable.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="align">
+            <data type="string">
+              <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
+            </data>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowalign">
+            <list>
+              <oneOrMore>
+                <ref name="m_verticalalign"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnalign">
+            <list>
+              <oneOrMore>
+                <ref name="m_columnalignstyle"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="groupalign">
+            <ref name="m_group-alignment-list-list"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="alignmentscope">
+            <list>
+              <oneOrMore>
+                <choice>
+                  <value>true</value>
+                  <value>false</value>
+                </choice>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnwidth">
+            <list>
+              <oneOrMore>
+                <choice>
+                  <value>auto</value>
+                  <ref name="m_length"/>
+                  <value>fit</value>
+                </choice>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="width">
+            <choice>
+              <value>auto</value>
+              <ref name="m_length"/>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowspacing">
+            <list>
+              <oneOrMore>
+                <ref name="m_length"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnspacing">
+            <list>
+              <oneOrMore>
+                <ref name="m_length"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowlines">
+            <list>
+              <oneOrMore>
+                <ref name="m_linestyle"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnlines">
+            <list>
+              <oneOrMore>
+                <ref name="m_linestyle"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="frame">
+            <ref name="m_linestyle"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="framespacing">
+            <list>
+              <ref name="m_length"/>
+              <ref name="m_length"/>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="equalrows">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="equalcolumns">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="displaystyle">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="side">
+            <choice>
+              <value>left</value>
+              <value>right</value>
+              <value>leftoverlap</value>
+              <value>rightoverlap</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="minlabelspacing">
+            <ref name="m_length"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mlabeledtr">
+        <element name="mlabeledtr">
+          <ref name="m_mlabeledtr.attributes"/>
+          <oneOrMore>
+            <ref name="m_TableCellExpression"/>
+          </oneOrMore>
+        </element>
+      </define>
+      <define name="m_mlabeledtr.attributes">
+        <ref name="m_mtr.attributes"/>
+      </define>
+      <define name="m_mtr">
+        <element name="mtr">
+          <ref name="m_mtr.attributes"/>
+          <zeroOrMore>
+            <ref name="m_TableCellExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mtr.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="rowalign">
+            <choice>
+              <value>top</value>
+              <value>bottom</value>
+              <value>center</value>
+              <value>baseline</value>
+              <value>axis</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnalign">
+            <list>
+              <oneOrMore>
+                <ref name="m_columnalignstyle"/>
+              </oneOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="groupalign">
+            <ref name="m_group-alignment-list-list"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mtd">
+        <element name="mtd">
+          <ref name="m_mtd.attributes"/>
+          <ref name="m_ImpliedMrow"/>
+        </element>
+      </define>
+      <define name="m_mtd.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="rowspan">
+            <ref name="m_positive-integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnspan">
+            <ref name="m_positive-integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="rowalign">
+            <choice>
+              <value>top</value>
+              <value>bottom</value>
+              <value>center</value>
+              <value>baseline</value>
+              <value>axis</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="columnalign">
+            <ref name="m_columnalignstyle"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="groupalign">
+            <ref name="m_group-alignment-list"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mstack">
+        <element name="mstack">
+          <ref name="m_mstack.attributes"/>
+          <zeroOrMore>
+            <ref name="m_MstackExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mstack.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="align">
+            <data type="string">
+              <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
+            </data>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="stackalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+              <value>decimalpoint</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="charalign">
+            <choice>
+              <value>left</value>
+              <value>center</value>
+              <value>right</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="charspacing">
+            <choice>
+              <ref name="m_length"/>
+              <value>loose</value>
+              <value>medium</value>
+              <value>tight</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mlongdiv">
+        <element name="mlongdiv">
+          <ref name="m_mlongdiv.attributes"/>
+          <ref name="m_MstackExpression"/>
+          <ref name="m_MstackExpression"/>
+          <oneOrMore>
+            <ref name="m_MstackExpression"/>
+          </oneOrMore>
+        </element>
+      </define>
+      <define name="m_mlongdiv.attributes">
+        <ref name="m_msgroup.attributes"/>
+        <optional>
+          <attribute name="longdivstyle">
+            <choice>
+              <value>lefttop</value>
+              <value>stackedrightright</value>
+              <value>mediumstackedrightright</value>
+              <value>shortstackedrightright</value>
+              <value>righttop</value>
+              <value>left/\right</value>
+              <value>left)(right</value>
+              <value>:right=right</value>
+              <value>stackedleftleft</value>
+              <value>stackedleftlinetop</value>
+            </choice>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_msgroup">
+        <element name="msgroup">
+          <ref name="m_msgroup.attributes"/>
+          <zeroOrMore>
+            <ref name="m_MstackExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_msgroup.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="position">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="shift">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_msrow">
+        <element name="msrow">
+          <ref name="m_msrow.attributes"/>
+          <zeroOrMore>
+            <ref name="m_MsrowExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_msrow.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="position">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mscarries">
+        <element name="mscarries">
+          <ref name="m_mscarries.attributes"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="m_MsrowExpression"/>
+              <ref name="m_mscarry"/>
+            </choice>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mscarries.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="position">
+            <ref name="m_integer"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="location">
+            <choice>
+              <value>w</value>
+              <value>nw</value>
+              <value>n</value>
+              <value>ne</value>
+              <value>e</value>
+              <value>se</value>
+              <value>s</value>
+              <value>sw</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="crossout">
+            <list>
+              <zeroOrMore>
+                <choice>
+                  <value>none</value>
+                  <value>updiagonalstrike</value>
+                  <value>downdiagonalstrike</value>
+                  <value>verticalstrike</value>
+                  <value>horizontalstrike</value>
+                </choice>
+              </zeroOrMore>
+            </list>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="scriptsizemultiplier">
+            <ref name="m_number"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_mscarry">
+        <element name="mscarry">
+          <ref name="m_mscarry.attributes"/>
+          <zeroOrMore>
+            <ref name="m_MsrowExpression"/>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_mscarry.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <optional>
+          <attribute name="location">
+            <choice>
+              <value>w</value>
+              <value>nw</value>
+              <value>n</value>
+              <value>ne</value>
+              <value>e</value>
+              <value>se</value>
+              <value>s</value>
+              <value>sw</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="crossout">
+            <list>
+              <zeroOrMore>
+                <choice>
+                  <value>none</value>
+                  <value>updiagonalstrike</value>
+                  <value>downdiagonalstrike</value>
+                  <value>verticalstrike</value>
+                  <value>horizontalstrike</value>
+                </choice>
+              </zeroOrMore>
+            </list>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_maction">
+        <element name="maction">
+          <ref name="m_maction.attributes"/>
+          <oneOrMore>
+            <ref name="m_MathExpression"/>
+          </oneOrMore>
+        </element>
+      </define>
+      <define name="m_maction.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_CommonPresAtt"/>
+        <attribute name="actiontype"/>
+        <optional>
+          <attribute name="selection">
+            <ref name="m_positive-integer"/>
+          </attribute>
+        </optional>
+      </define>
+    </div>
+    <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Presentation MathML</a:documentation>
+    <div ns="http://www.w3.org/1998/Math/MathML" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+      <define name="m_MathExpression">
+        <ref name="m_semantics"/>
+      </define>
+      <define name="m_NonMathMLAtt">
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName/>
+            </except>
+          </anyName>
+          <data type="string"/>
+        </attribute>
+      </define>
+      <define name="m_CommonDeprecatedAtt">
+        <optional>
+          <attribute name="other"/>
+        </optional>
+      </define>
+      <define name="m_CommonAtt">
+        <optional>
+          <attribute name="id">
+            <data type="ID"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="xref"/>
+        </optional>
+        <optional>
+          <attribute name="class">
+            <data type="NMTOKENS"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="style">
             <data type="string"/>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.canonical.attribute.ref">
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="href">
+            <data type="anyURI"/>
+          </attribute>
+        </optional>
+        <ref name="m_CommonDeprecatedAtt"/>
+        <zeroOrMore>
+          <ref name="m_NonMathMLAtt"/>
+        </zeroOrMore>
+      </define>
+      <define name="m_math.deprecatedattributes">
+        <optional>
+          <attribute name="mode">
+            <data type="string"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="macros">
+            <data type="string"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_name">
+        <attribute name="name">
+          <data type="NCName"/>
+        </attribute>
+      </define>
+      <define name="m_cd">
+        <attribute name="cd">
+          <data type="NCName"/>
+        </attribute>
+      </define>
+      <define name="m_src">
+        <optional>
+          <attribute name="src">
+            <data type="anyURI"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_annotation">
+        <element name="annotation">
+          <ref name="m_annotation.attributes"/>
+          <text/>
+        </element>
+      </define>
+      <define name="m_annotation-xml.model">
+        <zeroOrMore>
+          <choice>
+            <ref name="m_MathExpression"/>
+            <ref name="m_anyElement"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="m_anyElement">
+        <element>
+          <anyName>
+            <except>
+              <nsName/>
+            </except>
+          </anyName>
+          <zeroOrMore>
+            <choice>
+              <attribute>
+                <anyName/>
+              </attribute>
+              <text/>
+              <ref name="m_anyElement"/>
+            </choice>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_annotation-xml">
+        <element name="annotation-xml">
+          <ref name="m_annotation.attributes"/>
+          <ref name="m_annotation-xml.model"/>
+        </element>
+      </define>
+      <define name="m_annotation.attributes">
+        <ref name="m_CommonAtt"/>
+        <optional>
+          <ref name="m_cd"/>
+        </optional>
+        <optional>
+          <ref name="m_name"/>
+        </optional>
+        <ref name="m_DefEncAtt"/>
+        <optional>
+          <ref name="m_src"/>
+        </optional>
+      </define>
+      <define name="m_DefEncAtt">
+        <optional>
+          <attribute name="encoding">
+            <data type="string"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="definitionURL">
+            <data type="anyURI"/>
+          </attribute>
+        </optional>
+      </define>
+      <define name="m_semantics">
+        <element name="semantics">
+          <ref name="m_semantics.attributes"/>
+          <ref name="m_MathExpression"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="m_annotation"/>
+              <ref name="m_annotation-xml"/>
+            </choice>
+          </zeroOrMore>
+        </element>
+      </define>
+      <define name="m_semantics.attributes">
+        <ref name="m_CommonAtt"/>
+        <ref name="m_DefEncAtt"/>
+        <optional>
+          <ref name="m_cd"/>
+        </optional>
+        <optional>
+          <ref name="m_name"/>
+        </optional>
+      </define>
+      <define name="m_length">
+        <data type="string">
+          <param name="pattern">\s*((-?[0-9]*([0-9]\.?|\.[0-9])[0-9]*(e[mx]|in|cm|mm|p[xtc]|%)?)|(negative)?((very){0,2}thi(n|ck)|medium)mathspace)\s*</param>
+        </data>
+      </define>
+    </div>
+    <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">math and semantics common to both Content and Presentation</a:documentation>
+    <define name="m_math">
+      <element name="math">
+        <ref name="m_math.attributes"/>
+        <zeroOrMore>
+          <ref name="m_MathExpression"/>
+        </zeroOrMore>
+      </element>
+    </define>
+    <define name="m_math.attributes">
+      <ref name="m_CommonAtt"/>
       <optional>
-         <attribute name="ref">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) provides an explicit means of locating a full definition or identity for the entity being named by means of one or more URIs.</a:documentation>
-            <list>
-               <oneOrMore>
-                  <data type="anyURI">
-                     <param name="pattern">\S+</param>
-                  </data>
-               </oneOrMore>
-            </list>
-         </attribute>
+        <attribute name="display">
+          <choice>
+            <value>block</value>
+            <value>inline</value>
+          </choice>
+        </attribute>
       </optional>
-   </define>
-   <define name="dhq_att.written.attributes">
-      <ref name="dhq_att.written.attribute.hand"/>
-   </define>
-   <define name="dhq_att.written.attribute.hand">
       <optional>
-         <attribute name="hand">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a <code xmlns="http://www.w3.org/1999/xhtml">&lt;handNote&gt;</code> element describing the hand considered responsible for the content of the element concerned.</a:documentation>
+        <attribute name="maxwidth">
+          <ref name="m_length"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="overflow">
+          <choice>
+            <value>linebreak</value>
+            <value>scroll</value>
+            <value>elide</value>
+            <value>truncate</value>
+            <value>scale</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="altimg">
+          <data type="anyURI"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="altimg-width">
+          <ref name="m_length"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="altimg-height">
+          <ref name="m_length"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="altimg-valign">
+          <choice>
+            <ref name="m_length"/>
+            <value>top</value>
+            <value>middle</value>
+            <value>bottom</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="alttext"/>
+      </optional>
+      <optional>
+        <attribute name="cdgroup">
+          <data type="anyURI"/>
+        </attribute>
+      </optional>
+      <ref name="m_math.deprecatedattributes"/>
+    </define>
+  </div>
+  <define name="dhq_macro.paraContent">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="dhq_model.phrase"/>
+        <ref name="dhq_model.inter"/>
+        <ref name="dhq_model.global"/>
+        <ref name="dhq_lg"/>
+        <ref name="dhq_model.lLike"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_macro.limitedContent">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="dhq_model.limitedPhrase"/>
+        <ref name="dhq_model.inter"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_macro.phraseSeq">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="dhq_model.attributable"/>
+        <ref name="dhq_model.phrase"/>
+        <ref name="dhq_model.global"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_macro.phraseSeq.limited">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="dhq_model.limitedPhrase"/>
+        <ref name="dhq_model.global"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_macro.specialPara">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="dhq_model.phrase"/>
+        <ref name="dhq_model.inter"/>
+        <ref name="dhq_model.divPart"/>
+        <ref name="dhq_model.global"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_teidata.word">
+    <data type="token">
+      <param name="pattern">[^\p{C}\p{Z}]+</param>
+    </data>
+  </define>
+  <define name="anyElement-xenoData">
+    <element>
+      <anyName>
+        <except>
+          <nsName ns="http://www.tei-c.org/ns/1.0"/>
+          <name ns="http://www.tei-c.org/ns/Examples">egXML</name>
+        </except>
+      </anyName>
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="anyElement-xenoData"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="anyElement-passThroughCode">
+    <element>
+      <anyName>
+        <except>
+          <nsName ns="http://www.tei-c.org/ns/1.0"/>
+          <name ns="http://www.tei-c.org/ns/Examples">egXML</name>
+        </except>
+      </anyName>
+      <zeroOrMore>
+        <attribute>
+          <anyName/>
+        </attribute>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="anyElement-passThroughCode"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="dhq_att.anchoring.attributes">
+    <ref name="dhq_att.anchoring.attribute.anchored"/>
+    <ref name="dhq_att.anchoring.attribute.targetEnd"/>
+  </define>
+  <define name="dhq_att.anchoring.attribute.anchored">
+    <optional>
+      <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="anchored" a:defaultValue="true">
+        <a:documentation>(anchored) indicates whether the copy text shows the exact place of reference for the note.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.anchoring.attribute.targetEnd">
+    <optional>
+      <attribute name="targetEnd">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(target end) points to the end of the span to which the note is attached, if the note is not embedded in the text at that point.</a:documentation>
+        <list>
+          <oneOrMore>
             <data type="anyURI">
-               <param name="pattern">\S+</param>
+              <param name="pattern">\S+</param>
             </data>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.breaking.attributes">
-      <ref name="dhq_att.breaking.attribute.break"/>
-   </define>
-   <define name="dhq_att.breaking.attribute.break">
-      <optional>
-         <attribute name="break">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether or not the element bearing this attribute should be considered to mark the end of an orthographic token in the same way as whitespace.</a:documentation>
-            <data type="token">
-               <param name="pattern">[^\p{C}\p{Z}]+</param>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.ascribed.attributes">
+    <ref name="dhq_att.ascribed.attribute.who"/>
+  </define>
+  <define name="dhq_att.ascribed.attribute.who">
+    <optional>
+      <attribute name="who">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the person, or group of people, to whom the element content is ascribed.</a:documentation>
+        <list>
+          <oneOrMore>
+            <data type="anyURI">
+              <param name="pattern">\S+</param>
             </data>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.fragmentable.attributes">
-      <ref name="dhq_att.fragmentable.attribute.part"/>
-   </define>
-   <define name="dhq_att.fragmentable.attribute.part">
-      <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                    name="part"
-                    a:defaultValue="N">
-            <a:documentation>specifies whether or not its parent element is fragmented in some way, typically by some other overlapping structure: for example a speech which is divided between two or more verse stanzas, a paragraph which is split across a page division, a verse line which is divided between two speakers.</a:documentation>
-            <choice>
-               <value>Y</value>
-               <a:documentation>(yes) the element is fragmented in some (unspecified) respect</a:documentation>
-               <value>N</value>
-               <a:documentation>(no) the element is not fragmented, or no claim is made as to its completeness</a:documentation>
-               <value>I</value>
-               <a:documentation>(initial) this is the initial part of a fragmented element</a:documentation>
-               <value>M</value>
-               <a:documentation>(medial) this is a medial part of a fragmented element</a:documentation>
-               <value>F</value>
-               <a:documentation>(final) this is the final part of a fragmented element</a:documentation>
-            </choice>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.docStatus.attributes">
-      <ref name="dhq_att.docStatus.attribute.status"/>
-   </define>
-   <define name="dhq_att.docStatus.attribute.status">
-      <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                    name="status"
-                    a:defaultValue="draft">
-            <a:documentation>describes the status of a document either currently or, when associated with a dated element, at the time indicated.
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.ascribed.directed.attributes">
+    <ref name="dhq_att.ascribed.attributes"/>
+    <ref name="dhq_att.ascribed.directed.attribute.toWhom"/>
+  </define>
+  <define name="dhq_att.ascribed.directed.attribute.toWhom">
+    <optional>
+      <attribute name="toWhom">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the person, or group of people, to whom a speech act or action is directed.</a:documentation>
+        <list>
+          <oneOrMore>
+            <data type="anyURI">
+              <param name="pattern">\S+</param>
+            </data>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.canonical.attributes">
+    <ref name="dhq_att.canonical.attribute.key"/>
+    <ref name="dhq_att.canonical.attribute.ref"/>
+  </define>
+  <define name="dhq_att.canonical.attribute.key">
+    <optional>
+      <attribute name="key">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides an externally-defined means of identifying the entity (or entities) being named, using a coded value of some kind.</a:documentation>
+        <data type="string"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.canonical.attribute.ref">
+    <optional>
+      <attribute name="ref">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) provides an explicit means of locating a full definition or identity for the entity being named by means of one or more URIs.</a:documentation>
+        <list>
+          <oneOrMore>
+            <data type="anyURI">
+              <param name="pattern">\S+</param>
+            </data>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.written.attributes">
+    <ref name="dhq_att.written.attribute.hand"/>
+  </define>
+  <define name="dhq_att.written.attribute.hand">
+    <optional>
+      <attribute name="hand">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a <code xmlns="http://www.w3.org/1999/xhtml">&lt;handNote&gt;</code> element describing the hand considered responsible for the content of the element concerned.</a:documentation>
+        <data type="anyURI">
+          <param name="pattern">\S+</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.breaking.attributes">
+    <ref name="dhq_att.breaking.attribute.break"/>
+  </define>
+  <define name="dhq_att.breaking.attribute.break">
+    <optional>
+      <attribute name="break">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether or not the element bearing this attribute should be considered to mark the end of an orthographic token in the same way as whitespace.</a:documentation>
+        <data type="token">
+          <param name="pattern">[^\p{C}\p{Z}]+</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.fragmentable.attributes">
+    <ref name="dhq_att.fragmentable.attribute.part"/>
+  </define>
+  <define name="dhq_att.fragmentable.attribute.part">
+    <optional>
+      <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="part" a:defaultValue="N">
+        <a:documentation>specifies whether or not its parent element is fragmented in some way, typically by some other overlapping structure: for example a speech which is divided between two or more verse stanzas, a paragraph which is split across a page division, a verse line which is divided between two speakers.</a:documentation>
+        <choice>
+          <value>Y</value>
+          <a:documentation>(yes) the element is fragmented in some (unspecified) respect</a:documentation>
+          <value>N</value>
+          <a:documentation>(no) the element is not fragmented, or no claim is made as to its completeness</a:documentation>
+          <value>I</value>
+          <a:documentation>(initial) this is the initial part of a fragmented element</a:documentation>
+          <value>M</value>
+          <a:documentation>(medial) this is a medial part of a fragmented element</a:documentation>
+          <value>F</value>
+          <a:documentation>(final) this is the final part of a fragmented element</a:documentation>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.docStatus.attributes">
+    <ref name="dhq_att.docStatus.attribute.status"/>
+  </define>
+  <define name="dhq_att.docStatus.attribute.status">
+    <optional>
+      <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="status" a:defaultValue="draft">
+        <a:documentation>describes the status of a document either currently or, when associated with a dated element, at the time indicated.
 Sample values include: 1] approved; 2] candidate; 3] cleared; 4] deprecated; 5] draft; 6] embargoed; 7] expired; 8] frozen; 9] galley; 10] proposed; 11] published; 12] recommendation; 13] submitted; 14] unfinished; 15] withdrawn</a:documentation>
-            <data type="token">
-               <param name="pattern">[^\p{C}\p{Z}]+</param>
+        <data type="token">
+          <param name="pattern">[^\p{C}\p{Z}]+</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.global.rendition.attributes">
+    <ref name="dhq_att.global.rendition.attribute.style"/>
+  </define>
+  <define name="dhq_att.global.rendition.attribute.style">
+    <optional>
+      <attribute name="style">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an expression in some formal style definition language which defines the rendering or presentation used for this element in the source text</a:documentation>
+        <data type="string"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.global.source.attributes">
+    <ref name="dhq_att.global.source.attribute.source"/>
+  </define>
+  <define name="dhq_att.global.source.attribute.source">
+    <optional>
+      <attribute name="source">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the source from which some aspect of this element is drawn.</a:documentation>
+        <list>
+          <oneOrMore>
+            <data type="anyURI">
+              <param name="pattern">\S+</param>
             </data>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.global.rendition.attributes">
-      <ref name="dhq_att.global.rendition.attribute.style"/>
-   </define>
-   <define name="dhq_att.global.rendition.attribute.style">
-      <optional>
-         <attribute name="style">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an expression in some formal style definition language which defines the rendering or presentation used for this element in the source text</a:documentation>
-            <data type="string"/>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.global.source.attributes">
-      <ref name="dhq_att.global.source.attribute.source"/>
-   </define>
-   <define name="dhq_att.global.source.attribute.source">
-      <optional>
-         <attribute name="source">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the source from which some aspect of this element is drawn.</a:documentation>
-            <list>
-               <oneOrMore>
-                  <data type="anyURI">
-                     <param name="pattern">\S+</param>
-                  </data>
-               </oneOrMore>
-            </list>
-         </attribute>
-      </optional>
-   </define>
-   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="dhq-att.global.source-source-only_1_ODD_source-constraint-rule-1">
-      <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
-                xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                xmlns:xi="http://www.w3.org/2001/XInclude"
-                context="tei:*/@source">
-         <sch:let name="srcs" value="tokenize( normalize-space(.),' ')"/>
-         <sch:report test="( parent::tei:classRef                               | parent::tei:dataRef                               | parent::tei:elementRef                               | parent::tei:macroRef                               | parent::tei:moduleRef                               | parent::tei:schemaSpec )                               and                               $srcs[2]">
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-att.global.source-source-only_1_ODD_source-constraint-rule-1">
+    <sch:rule xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" context="tei:*/@source">
+      <sch:let name="srcs" value="tokenize( normalize-space(.),' ')"/>
+      <sch:report test="( parent::tei:classRef                               | parent::tei:dataRef                               | parent::tei:elementRef                               | parent::tei:macroRef                               | parent::tei:moduleRef                               | parent::tei:schemaSpec )                               and                               $srcs[2]">
               When used on a schema description element (like
               <sch:value-of select="name(..)"/>), the @source attribute
               should have only 1 value. (This one has <sch:value-of select="count($srcs)"/>.)
             </sch:report>
-      </sch:rule>
-   </pattern>
-   <define name="dhq_att.global.attributes">
-      <ref name="dhq_att.global.rendition.attributes"/>
-      <ref name="dhq_att.global.source.attributes"/>
-   </define>
-   <define name="dhq_att.internetMedia.attributes">
-      <ref name="dhq_att.internetMedia.attribute.mimeType"/>
-   </define>
-   <define name="dhq_att.internetMedia.attribute.mimeType">
-      <optional>
-         <attribute name="mimeType">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type</a:documentation>
-            <list>
-               <oneOrMore>
-                  <data type="token">
-                     <param name="pattern">[^\p{C}\p{Z}]+</param>
-                  </data>
-               </oneOrMore>
-            </list>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.media.attribute.scale">
-      <optional>
-         <attribute name="scale">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates a scale factor to be applied when generating the desired display size</a:documentation>
-            <choice>
-               <data type="double"/>
-               <data type="token">
-                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
-               </data>
-               <data type="decimal"/>
-            </choice>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.resourced.attributes">
-      <ref name="dhq_att.resourced.attribute.url"/>
-   </define>
-   <define name="dhq_att.resourced.attribute.url">
-      <attribute name="url">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(uniform resource locator) specifies the URL from which the media concerned may be obtained.</a:documentation>
-         <data type="anyURI">
-            <param name="pattern">\S+</param>
-         </data>
+    </sch:rule>
+  </pattern>
+  <define name="dhq_att.global.attributes">
+    <ref name="dhq_att.global.rendition.attributes"/>
+    <ref name="dhq_att.global.source.attributes"/>
+  </define>
+  <define name="dhq_att.internetMedia.attributes">
+    <ref name="dhq_att.internetMedia.attribute.mimeType"/>
+  </define>
+  <define name="dhq_att.internetMedia.attribute.mimeType">
+    <optional>
+      <attribute name="mimeType">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type</a:documentation>
+        <list>
+          <oneOrMore>
+            <data type="token">
+              <param name="pattern">[^\p{C}\p{Z}]+</param>
+            </data>
+          </oneOrMore>
+        </list>
       </attribute>
-   </define>
-   <define name="dhq_att.notated.attributes">
-      <ref name="dhq_att.notated.attribute.notation"/>
-   </define>
-   <define name="dhq_att.notated.attribute.notation">
-      <optional>
-         <attribute name="notation">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">names the notation used for the content of the element.</a:documentation>
+    </optional>
+  </define>
+  <define name="dhq_att.media.attribute.scale">
+    <optional>
+      <attribute name="scale">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates a scale factor to be applied when generating the desired display size</a:documentation>
+        <choice>
+          <data type="double"/>
+          <data type="token">
+            <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+          </data>
+          <data type="decimal"/>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.resourced.attributes">
+    <ref name="dhq_att.resourced.attribute.url"/>
+  </define>
+  <define name="dhq_att.resourced.attribute.url">
+    <attribute name="url">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(uniform resource locator) specifies the URL from which the media concerned may be obtained.</a:documentation>
+      <data type="anyURI">
+        <param name="pattern">\S+</param>
+      </data>
+    </attribute>
+  </define>
+  <define name="dhq_att.notated.attributes">
+    <ref name="dhq_att.notated.attribute.notation"/>
+  </define>
+  <define name="dhq_att.notated.attribute.notation">
+    <optional>
+      <attribute name="notation">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">names the notation used for the content of the element.</a:documentation>
+        <data type="token">
+          <param name="pattern">[^\p{C}\p{Z}]+</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.sortable.attributes">
+    <ref name="dhq_att.sortable.attribute.sortKey"/>
+  </define>
+  <define name="dhq_att.sortable.attribute.sortKey">
+    <optional>
+      <attribute name="sortKey">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the sort key for this element in an index, list or group which contains it.</a:documentation>
+        <data type="token">
+          <param name="pattern">[^\p{C}\p{Z}]+</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.edition.attributes">
+    <ref name="dhq_att.edition.attribute.ed"/>
+    <ref name="dhq_att.edition.attribute.edRef"/>
+  </define>
+  <define name="dhq_att.edition.attribute.ed">
+    <optional>
+      <attribute name="ed">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition) supplies a sigil or other arbitrary identifier for the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
+        <list>
+          <oneOrMore>
             <data type="token">
-               <param name="pattern">[^\p{C}\p{Z}]+</param>
+              <param name="pattern">[^\p{C}\p{Z}]+</param>
             </data>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.sortable.attributes">
-      <ref name="dhq_att.sortable.attribute.sortKey"/>
-   </define>
-   <define name="dhq_att.sortable.attribute.sortKey">
-      <optional>
-         <attribute name="sortKey">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the sort key for this element in an index, list or group which contains it.</a:documentation>
-            <data type="token">
-               <param name="pattern">[^\p{C}\p{Z}]+</param>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.edition.attribute.edRef">
+    <optional>
+      <attribute name="edRef">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition reference) provides a pointer to the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
+        <list>
+          <oneOrMore>
+            <data type="anyURI">
+              <param name="pattern">\S+</param>
             </data>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.edition.attributes">
-      <ref name="dhq_att.edition.attribute.ed"/>
-      <ref name="dhq_att.edition.attribute.edRef"/>
-   </define>
-   <define name="dhq_att.edition.attribute.ed">
-      <optional>
-         <attribute name="ed">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition) supplies a sigil or other arbitrary identifier for the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
-            <list>
-               <oneOrMore>
-                  <data type="token">
-                     <param name="pattern">[^\p{C}\p{Z}]+</param>
-                  </data>
-               </oneOrMore>
-            </list>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.edition.attribute.edRef">
-      <optional>
-         <attribute name="edRef">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition reference) provides a pointer to the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
-            <list>
-               <oneOrMore>
-                  <data type="anyURI">
-                     <param name="pattern">\S+</param>
-                  </data>
-               </oneOrMore>
-            </list>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.citing.attributes">
-      <ref name="dhq_att.citing.attribute.unit"/>
-      <ref name="dhq_att.citing.attribute.from"/>
-      <ref name="dhq_att.citing.attribute.to"/>
-   </define>
-   <define name="dhq_att.citing.attribute.unit">
-      <optional>
-         <attribute name="unit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the unit of information conveyed by the element, e.g. columns, pages, volume, entry.
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.citing.attributes">
+    <ref name="dhq_att.citing.attribute.unit"/>
+    <ref name="dhq_att.citing.attribute.from"/>
+    <ref name="dhq_att.citing.attribute.to"/>
+  </define>
+  <define name="dhq_att.citing.attribute.unit">
+    <optional>
+      <attribute name="unit">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the unit of information conveyed by the element, e.g. columns, pages, volume, entry.
 Suggested values include: 1] volume (volume); 2] issue; 3] page (page); 4] line; 5] chapter (chapter); 6] part; 7] column; 8] entry</a:documentation>
-            <choice>
-               <value>volume</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(volume) the element contains a volume number.</a:documentation>
-               <value>issue</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains an issue number, or volume and issue numbers.</a:documentation>
-               <value>page</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page) the element contains a page number or page range.</a:documentation>
-               <value>line</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a line number or line range.</a:documentation>
-               <value>chapter</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(chapter) the element contains a chapter indication (number and/or title)</a:documentation>
-               <value>part</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a part of a book or collection.</a:documentation>
-               <value>column</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a column.</a:documentation>
-               <value>entry</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies an entry number or label in a list of entries.</a:documentation>
-               <data type="token">
-                  <param name="pattern">[^\p{C}\p{Z}]+</param>
-               </data>
-            </choice>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.citing.attribute.from">
-      <optional>
-         <attribute name="from">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the starting point of the range of units indicated by the <code xmlns="http://www.w3.org/1999/xhtml">@unit</code> attribute.</a:documentation>
-            <data type="token">
-               <param name="pattern">[^\p{C}\p{Z}]+</param>
-            </data>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.citing.attribute.to">
-      <optional>
-         <attribute name="to">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the end-point of the range of units indicated by the <code xmlns="http://www.w3.org/1999/xhtml">@unit</code> attribute.</a:documentation>
-            <data type="token">
-               <param name="pattern">[^\p{C}\p{Z}]+</param>
-            </data>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_model.nameLike.agent">
-      <choice>
-         <ref name="dhq_name"/>
-      </choice>
-   </define>
-   <define name="dhq_model.nameLike.agent_alternation">
-      <choice>
-         <ref name="dhq_name"/>
-      </choice>
-   </define>
-   <define name="dhq_model.nameLike.agent_sequence">
+        <choice>
+          <value>volume</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(volume) the element contains a volume number.</a:documentation>
+          <value>issue</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains an issue number, or volume and issue numbers.</a:documentation>
+          <value>page</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page) the element contains a page number or page range.</a:documentation>
+          <value>line</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a line number or line range.</a:documentation>
+          <value>chapter</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(chapter) the element contains a chapter indication (number and/or title)</a:documentation>
+          <value>part</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a part of a book or collection.</a:documentation>
+          <value>column</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a column.</a:documentation>
+          <value>entry</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies an entry number or label in a list of entries.</a:documentation>
+          <data type="token">
+            <param name="pattern">[^\p{C}\p{Z}]+</param>
+          </data>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.citing.attribute.from">
+    <optional>
+      <attribute name="from">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the starting point of the range of units indicated by the <code xmlns="http://www.w3.org/1999/xhtml">@unit</code> attribute.</a:documentation>
+        <data type="token">
+          <param name="pattern">[^\p{C}\p{Z}]+</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.citing.attribute.to">
+    <optional>
+      <attribute name="to">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the end-point of the range of units indicated by the <code xmlns="http://www.w3.org/1999/xhtml">@unit</code> attribute.</a:documentation>
+        <data type="token">
+          <param name="pattern">[^\p{C}\p{Z}]+</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_model.nameLike.agent">
+    <choice>
       <ref name="dhq_name"/>
-   </define>
-   <define name="dhq_model.nameLike.agent_sequenceOptional">
-      <optional>
-         <ref name="dhq_name"/>
-      </optional>
-   </define>
-   <define name="dhq_model.nameLike.agent_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_name"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.nameLike.agent_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_name"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.segLike">
-      <choice>
-         <ref name="dhq_seg"/>
-      </choice>
-   </define>
-   <define name="dhq_model.hiLike">
-      <choice>
-         <ref name="dhq_hi"/>
-         <ref name="dhq_q"/>
-      </choice>
-   </define>
-   <define name="dhq_model.hiLike_alternation">
-      <choice>
-         <ref name="dhq_hi"/>
-         <ref name="dhq_q"/>
-      </choice>
-   </define>
-   <define name="dhq_model.hiLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.nameLike.agent_alternation">
+    <choice>
+      <ref name="dhq_name"/>
+    </choice>
+  </define>
+  <define name="dhq_model.nameLike.agent_sequence">
+    <ref name="dhq_name"/>
+  </define>
+  <define name="dhq_model.nameLike.agent_sequenceOptional">
+    <optional>
+      <ref name="dhq_name"/>
+    </optional>
+  </define>
+  <define name="dhq_model.nameLike.agent_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_name"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.nameLike.agent_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_name"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.segLike">
+    <choice>
+      <ref name="dhq_seg"/>
+    </choice>
+  </define>
+  <define name="dhq_model.hiLike">
+    <choice>
       <ref name="dhq_hi"/>
       <ref name="dhq_q"/>
-   </define>
-   <define name="dhq_model.hiLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_hi"/>
-      </optional>
-      <optional>
-         <ref name="dhq_q"/>
-      </optional>
-   </define>
-   <define name="dhq_model.hiLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_hi"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_q"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.hiLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_hi"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_q"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.emphLike">
-      <choice>
-         <ref name="dhq_foreign"/>
-         <ref name="dhq_emph"/>
-         <ref name="dhq_soCalled"/>
-         <ref name="dhq_term"/>
-         <ref name="dhq_title"/>
-         <ref name="dhq_code"/>
-      </choice>
-   </define>
-   <define name="dhq_model.emphLike_alternation">
-      <choice>
-         <ref name="dhq_foreign"/>
-         <ref name="dhq_emph"/>
-         <ref name="dhq_soCalled"/>
-         <ref name="dhq_term"/>
-         <ref name="dhq_title"/>
-         <ref name="dhq_code"/>
-      </choice>
-   </define>
-   <define name="dhq_model.emphLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.hiLike_alternation">
+    <choice>
+      <ref name="dhq_hi"/>
+      <ref name="dhq_q"/>
+    </choice>
+  </define>
+  <define name="dhq_model.hiLike_sequence">
+    <ref name="dhq_hi"/>
+    <ref name="dhq_q"/>
+  </define>
+  <define name="dhq_model.hiLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_hi"/>
+    </optional>
+    <optional>
+      <ref name="dhq_q"/>
+    </optional>
+  </define>
+  <define name="dhq_model.hiLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_hi"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_q"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.hiLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_hi"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_q"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.emphLike">
+    <choice>
       <ref name="dhq_foreign"/>
       <ref name="dhq_emph"/>
       <ref name="dhq_soCalled"/>
       <ref name="dhq_term"/>
       <ref name="dhq_title"/>
       <ref name="dhq_code"/>
-   </define>
-   <define name="dhq_model.emphLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_foreign"/>
-      </optional>
-      <optional>
-         <ref name="dhq_emph"/>
-      </optional>
-      <optional>
-         <ref name="dhq_soCalled"/>
-      </optional>
-      <optional>
-         <ref name="dhq_term"/>
-      </optional>
-      <optional>
-         <ref name="dhq_title"/>
-      </optional>
-      <optional>
-         <ref name="dhq_code"/>
-      </optional>
-   </define>
-   <define name="dhq_model.emphLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_foreign"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_emph"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_soCalled"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_term"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_title"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_code"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.emphLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_foreign"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_emph"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_soCalled"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_term"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_title"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_code"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.highlighted">
-      <choice>
-         <ref name="dhq_model.hiLike"/>
-         <ref name="dhq_model.emphLike"/>
-      </choice>
-   </define>
-   <define name="dhq_model.dateLike">
-      <choice>
-         <ref name="dhq_date"/>
-      </choice>
-   </define>
-   <define name="dhq_model.dateLike_alternation">
-      <choice>
-         <ref name="dhq_date"/>
-      </choice>
-   </define>
-   <define name="dhq_model.dateLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.emphLike_alternation">
+    <choice>
+      <ref name="dhq_foreign"/>
+      <ref name="dhq_emph"/>
+      <ref name="dhq_soCalled"/>
+      <ref name="dhq_term"/>
+      <ref name="dhq_title"/>
+      <ref name="dhq_code"/>
+    </choice>
+  </define>
+  <define name="dhq_model.emphLike_sequence">
+    <ref name="dhq_foreign"/>
+    <ref name="dhq_emph"/>
+    <ref name="dhq_soCalled"/>
+    <ref name="dhq_term"/>
+    <ref name="dhq_title"/>
+    <ref name="dhq_code"/>
+  </define>
+  <define name="dhq_model.emphLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_foreign"/>
+    </optional>
+    <optional>
+      <ref name="dhq_emph"/>
+    </optional>
+    <optional>
+      <ref name="dhq_soCalled"/>
+    </optional>
+    <optional>
+      <ref name="dhq_term"/>
+    </optional>
+    <optional>
+      <ref name="dhq_title"/>
+    </optional>
+    <optional>
+      <ref name="dhq_code"/>
+    </optional>
+  </define>
+  <define name="dhq_model.emphLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_foreign"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_emph"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_soCalled"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_term"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_title"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_code"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.emphLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_foreign"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_emph"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_soCalled"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_term"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_title"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_code"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.highlighted">
+    <choice>
+      <ref name="dhq_model.hiLike"/>
+      <ref name="dhq_model.emphLike"/>
+    </choice>
+  </define>
+  <define name="dhq_model.dateLike">
+    <choice>
       <ref name="dhq_date"/>
-   </define>
-   <define name="dhq_model.dateLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_date"/>
-      </optional>
-   </define>
-   <define name="dhq_model.dateLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_date"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.dateLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_date"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.measureLike">
-      <choice>
-         <ref name="dhq_unit"/>
-      </choice>
-   </define>
-   <define name="dhq_model.measureLike_alternation">
-      <choice>
-         <ref name="dhq_unit"/>
-      </choice>
-   </define>
-   <define name="dhq_model.measureLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.dateLike_alternation">
+    <choice>
+      <ref name="dhq_date"/>
+    </choice>
+  </define>
+  <define name="dhq_model.dateLike_sequence">
+    <ref name="dhq_date"/>
+  </define>
+  <define name="dhq_model.dateLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_date"/>
+    </optional>
+  </define>
+  <define name="dhq_model.dateLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_date"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.dateLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_date"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.measureLike">
+    <choice>
       <ref name="dhq_unit"/>
-   </define>
-   <define name="dhq_model.measureLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_unit"/>
-      </optional>
-   </define>
-   <define name="dhq_model.measureLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_unit"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.measureLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_unit"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.egLike">
-      <choice>
-         <ref name="dhq_eg"/>
-      </choice>
-   </define>
-   <define name="dhq_model.egLike_alternation">
-      <choice>
-         <ref name="dhq_eg"/>
-      </choice>
-   </define>
-   <define name="dhq_model.egLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.measureLike_alternation">
+    <choice>
+      <ref name="dhq_unit"/>
+    </choice>
+  </define>
+  <define name="dhq_model.measureLike_sequence">
+    <ref name="dhq_unit"/>
+  </define>
+  <define name="dhq_model.measureLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_unit"/>
+    </optional>
+  </define>
+  <define name="dhq_model.measureLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_unit"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.measureLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_unit"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.egLike">
+    <choice>
       <ref name="dhq_eg"/>
-   </define>
-   <define name="dhq_model.egLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_eg"/>
-      </optional>
-   </define>
-   <define name="dhq_model.egLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_eg"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.egLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_eg"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.graphicLike">
-      <choice>
-         <ref name="dhq_media"/>
-         <ref name="dhq_graphic"/>
-         <ref name="dhq_formula"/>
-         <ref name="dhq_passThroughCode"/>
-      </choice>
-   </define>
-   <define name="dhq_model.offsetLike">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.offsetLike_alternation">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.offsetLike_sequence">
-      <empty/>
-   </define>
-   <define name="dhq_model.offsetLike_sequenceOptional">
-      <empty/>
-   </define>
-   <define name="dhq_model.offsetLike_sequenceOptionalRepeatable">
-      <empty/>
-   </define>
-   <define name="dhq_model.offsetLike_sequenceRepeatable">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.pPart.msdesc">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.pPart.editorial">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.ptrLike">
-      <choice>
-         <ref name="dhq_ptr"/>
-         <ref name="dhq_ref"/>
-      </choice>
-   </define>
-   <define name="dhq_model.lPart">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.global.meta">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.milestoneLike">
-      <choice>
-         <ref name="dhq_gb"/>
-         <ref name="dhq_lb"/>
-         <ref name="dhq_anchor"/>
-      </choice>
-   </define>
-   <define name="dhq_model.oddDecl">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.oddDecl_alternation">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.oddDecl_sequence">
-      <empty/>
-   </define>
-   <define name="dhq_model.oddDecl_sequenceOptional">
-      <empty/>
-   </define>
-   <define name="dhq_model.oddDecl_sequenceOptionalRepeatable">
-      <empty/>
-   </define>
-   <define name="dhq_model.oddDecl_sequenceRepeatable">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.phrase.xml">
-      <choice>
-         <ref name="dhq_att"/>
-         <ref name="dhq_gi"/>
-         <ref name="dhq_val"/>
-      </choice>
-   </define>
-   <define name="dhq_model.specDescLike">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.biblLike">
-      <choice>
-         <ref name="dhq_bibl"/>
-         <ref name="dhq_listBibl"/>
-      </choice>
-   </define>
-   <define name="dhq_model.biblLike_alternation">
-      <choice>
-         <ref name="dhq_bibl"/>
-         <ref name="dhq_listBibl"/>
-      </choice>
-   </define>
-   <define name="dhq_model.biblLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.egLike_alternation">
+    <choice>
+      <ref name="dhq_eg"/>
+    </choice>
+  </define>
+  <define name="dhq_model.egLike_sequence">
+    <ref name="dhq_eg"/>
+  </define>
+  <define name="dhq_model.egLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_eg"/>
+    </optional>
+  </define>
+  <define name="dhq_model.egLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_eg"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.egLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_eg"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.graphicLike">
+    <choice>
+      <ref name="dhq_media"/>
+      <ref name="dhq_graphic"/>
+      <ref name="dhq_formula"/>
+      <ref name="dhq_passThroughCode"/>
+    </choice>
+  </define>
+  <define name="dhq_model.offsetLike">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.offsetLike_alternation">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.offsetLike_sequence">
+    <empty/>
+  </define>
+  <define name="dhq_model.offsetLike_sequenceOptional">
+    <empty/>
+  </define>
+  <define name="dhq_model.offsetLike_sequenceOptionalRepeatable">
+    <empty/>
+  </define>
+  <define name="dhq_model.offsetLike_sequenceRepeatable">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.pPart.msdesc">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.pPart.editorial">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.ptrLike">
+    <choice>
+      <ref name="dhq_ptr"/>
+      <ref name="dhq_ref"/>
+    </choice>
+  </define>
+  <define name="dhq_model.lPart">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.global.meta">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.milestoneLike">
+    <choice>
+      <ref name="dhq_gb"/>
+      <ref name="dhq_lb"/>
+      <ref name="dhq_anchor"/>
+    </choice>
+  </define>
+  <define name="dhq_model.oddDecl">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.oddDecl_alternation">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.oddDecl_sequence">
+    <empty/>
+  </define>
+  <define name="dhq_model.oddDecl_sequenceOptional">
+    <empty/>
+  </define>
+  <define name="dhq_model.oddDecl_sequenceOptionalRepeatable">
+    <empty/>
+  </define>
+  <define name="dhq_model.oddDecl_sequenceRepeatable">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.phrase.xml">
+    <choice>
+      <ref name="dhq_att"/>
+      <ref name="dhq_gi"/>
+      <ref name="dhq_val"/>
+    </choice>
+  </define>
+  <define name="dhq_model.specDescLike">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.biblLike">
+    <choice>
       <ref name="dhq_bibl"/>
       <ref name="dhq_listBibl"/>
-   </define>
-   <define name="dhq_model.biblLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_bibl"/>
-      </optional>
-      <optional>
-         <ref name="dhq_listBibl"/>
-      </optional>
-   </define>
-   <define name="dhq_model.biblLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_bibl"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_listBibl"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.biblLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_bibl"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_listBibl"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.headLike">
-      <choice>
-         <ref name="dhq_head"/>
-      </choice>
-   </define>
-   <define name="dhq_model.headLike_alternation">
-      <choice>
-         <ref name="dhq_head"/>
-      </choice>
-   </define>
-   <define name="dhq_model.headLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.biblLike_alternation">
+    <choice>
+      <ref name="dhq_bibl"/>
+      <ref name="dhq_listBibl"/>
+    </choice>
+  </define>
+  <define name="dhq_model.biblLike_sequence">
+    <ref name="dhq_bibl"/>
+    <ref name="dhq_listBibl"/>
+  </define>
+  <define name="dhq_model.biblLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_bibl"/>
+    </optional>
+    <optional>
+      <ref name="dhq_listBibl"/>
+    </optional>
+  </define>
+  <define name="dhq_model.biblLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_bibl"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_listBibl"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.biblLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_bibl"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_listBibl"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.headLike">
+    <choice>
       <ref name="dhq_head"/>
-   </define>
-   <define name="dhq_model.headLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_head"/>
-      </optional>
-   </define>
-   <define name="dhq_model.headLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_head"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.headLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_head"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.labelLike">
-      <choice>
-         <ref name="dhq_desc"/>
-         <ref name="dhq_label"/>
-      </choice>
-   </define>
-   <define name="dhq_model.listLike">
-      <choice>
-         <ref name="dhq_list"/>
-         <ref name="dhq_table"/>
-      </choice>
-   </define>
-   <define name="dhq_model.listLike_alternation">
-      <choice>
-         <ref name="dhq_list"/>
-         <ref name="dhq_table"/>
-      </choice>
-   </define>
-   <define name="dhq_model.listLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.headLike_alternation">
+    <choice>
+      <ref name="dhq_head"/>
+    </choice>
+  </define>
+  <define name="dhq_model.headLike_sequence">
+    <ref name="dhq_head"/>
+  </define>
+  <define name="dhq_model.headLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_head"/>
+    </optional>
+  </define>
+  <define name="dhq_model.headLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_head"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.headLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_head"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.labelLike">
+    <choice>
+      <ref name="dhq_desc"/>
+      <ref name="dhq_label"/>
+    </choice>
+  </define>
+  <define name="dhq_model.listLike">
+    <choice>
       <ref name="dhq_list"/>
       <ref name="dhq_table"/>
-   </define>
-   <define name="dhq_model.listLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_list"/>
-      </optional>
-      <optional>
-         <ref name="dhq_table"/>
-      </optional>
-   </define>
-   <define name="dhq_model.listLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_list"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_table"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.listLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_list"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_table"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.noteLike">
-      <choice>
-         <ref name="dhq_note"/>
-         <ref name="dhq_noteGrp"/>
-         <ref name="dhq_caption"/>
-      </choice>
-   </define>
-   <define name="dhq_model.lLike">
-      <choice>
-         <ref name="dhq_l"/>
-      </choice>
-   </define>
-   <define name="dhq_model.lLike_alternation">
-      <choice>
-         <ref name="dhq_l"/>
-      </choice>
-   </define>
-   <define name="dhq_model.lLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.listLike_alternation">
+    <choice>
+      <ref name="dhq_list"/>
+      <ref name="dhq_table"/>
+    </choice>
+  </define>
+  <define name="dhq_model.listLike_sequence">
+    <ref name="dhq_list"/>
+    <ref name="dhq_table"/>
+  </define>
+  <define name="dhq_model.listLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_list"/>
+    </optional>
+    <optional>
+      <ref name="dhq_table"/>
+    </optional>
+  </define>
+  <define name="dhq_model.listLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_list"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_table"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.listLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_list"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_table"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.noteLike">
+    <choice>
+      <ref name="dhq_note"/>
+      <ref name="dhq_noteGrp"/>
+      <ref name="dhq_caption"/>
+    </choice>
+  </define>
+  <define name="dhq_model.lLike">
+    <choice>
       <ref name="dhq_l"/>
-   </define>
-   <define name="dhq_model.lLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_l"/>
-      </optional>
-   </define>
-   <define name="dhq_model.lLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_l"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.lLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_l"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.pLike">
-      <choice>
-         <ref name="dhq_p"/>
-         <ref name="dhq_ab"/>
-      </choice>
-   </define>
-   <define name="dhq_model.pLike_alternation">
-      <choice>
-         <ref name="dhq_p"/>
-         <ref name="dhq_ab"/>
-      </choice>
-   </define>
-   <define name="dhq_model.pLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.lLike_alternation">
+    <choice>
+      <ref name="dhq_l"/>
+    </choice>
+  </define>
+  <define name="dhq_model.lLike_sequence">
+    <ref name="dhq_l"/>
+  </define>
+  <define name="dhq_model.lLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_l"/>
+    </optional>
+  </define>
+  <define name="dhq_model.lLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_l"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.lLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_l"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.pLike">
+    <choice>
       <ref name="dhq_p"/>
       <ref name="dhq_ab"/>
-   </define>
-   <define name="dhq_model.pLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_p"/>
-      </optional>
-      <optional>
-         <ref name="dhq_ab"/>
-      </optional>
-   </define>
-   <define name="dhq_model.pLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_p"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_ab"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.pLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_p"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_ab"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.stageLike">
-      <choice>
-         <ref name="dhq_stage"/>
-      </choice>
-   </define>
-   <define name="dhq_model.stageLike_alternation">
-      <choice>
-         <ref name="dhq_stage"/>
-      </choice>
-   </define>
-   <define name="dhq_model.stageLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.pLike_alternation">
+    <choice>
+      <ref name="dhq_p"/>
+      <ref name="dhq_ab"/>
+    </choice>
+  </define>
+  <define name="dhq_model.pLike_sequence">
+    <ref name="dhq_p"/>
+    <ref name="dhq_ab"/>
+  </define>
+  <define name="dhq_model.pLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_p"/>
+    </optional>
+    <optional>
+      <ref name="dhq_ab"/>
+    </optional>
+  </define>
+  <define name="dhq_model.pLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_p"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_ab"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.pLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_p"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_ab"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.stageLike">
+    <choice>
       <ref name="dhq_stage"/>
-   </define>
-   <define name="dhq_model.stageLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_stage"/>
-      </optional>
-   </define>
-   <define name="dhq_model.stageLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_stage"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.stageLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_stage"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.global.edit">
-      <choice>
-         <ref name="dhq_ellipsis"/>
-      </choice>
-   </define>
-   <define name="dhq_model.divPart">
-      <choice>
-         <ref name="dhq_model.lLike"/>
-         <ref name="dhq_model.pLike"/>
-         <ref name="dhq_lg"/>
-         <ref name="dhq_sp"/>
-      </choice>
-   </define>
-   <define name="dhq_model.placeNamePart">
-      <notAllowed/>
-   </define>
-   <define name="dhq_model.publicationStmtPart.agency">
-      <choice>
-         <ref name="dhq_publisher"/>
-      </choice>
-   </define>
-   <define name="dhq_model.publicationStmtPart.detail">
-      <choice>
-         <ref name="dhq_model.ptrLike"/>
-         <ref name="dhq_address"/>
-         <ref name="dhq_date"/>
-         <ref name="dhq_pubPlace"/>
-         <ref name="dhq_idno"/>
-         <ref name="dhq_availability"/>
-         <ref name="dhq_articleType"/>
-         <ref name="dhq_revisionNote"/>
-      </choice>
-   </define>
-   <define name="dhq_model.descLike">
-      <choice>
-         <ref name="dhq_desc"/>
-      </choice>
-   </define>
-   <define name="dhq_model.quoteLike">
-      <choice>
-         <ref name="dhq_quote"/>
-         <ref name="dhq_cit"/>
-      </choice>
-   </define>
-   <define name="dhq_model.quoteLike_alternation">
-      <choice>
-         <ref name="dhq_quote"/>
-         <ref name="dhq_cit"/>
-      </choice>
-   </define>
-   <define name="dhq_model.quoteLike_sequence">
+    </choice>
+  </define>
+  <define name="dhq_model.stageLike_alternation">
+    <choice>
+      <ref name="dhq_stage"/>
+    </choice>
+  </define>
+  <define name="dhq_model.stageLike_sequence">
+    <ref name="dhq_stage"/>
+  </define>
+  <define name="dhq_model.stageLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_stage"/>
+    </optional>
+  </define>
+  <define name="dhq_model.stageLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_stage"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.stageLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_stage"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.global.edit">
+    <choice>
+      <ref name="dhq_ellipsis"/>
+    </choice>
+  </define>
+  <define name="dhq_model.divPart">
+    <choice>
+      <ref name="dhq_model.lLike"/>
+      <ref name="dhq_model.pLike"/>
+      <ref name="dhq_lg"/>
+      <ref name="dhq_sp"/>
+    </choice>
+  </define>
+  <define name="dhq_model.placeNamePart">
+    <notAllowed/>
+  </define>
+  <define name="dhq_model.publicationStmtPart.agency">
+    <choice>
+      <ref name="dhq_publisher"/>
+    </choice>
+  </define>
+  <define name="dhq_model.publicationStmtPart.detail">
+    <choice>
+      <ref name="dhq_model.ptrLike"/>
+      <ref name="dhq_address"/>
+      <ref name="dhq_date"/>
+      <ref name="dhq_pubPlace"/>
+      <ref name="dhq_idno"/>
+      <ref name="dhq_availability"/>
+      <ref name="dhq_articleType"/>
+      <ref name="dhq_revisionNote"/>
+    </choice>
+  </define>
+  <define name="dhq_model.descLike">
+    <choice>
+      <ref name="dhq_desc"/>
+    </choice>
+  </define>
+  <define name="dhq_model.quoteLike">
+    <choice>
       <ref name="dhq_quote"/>
       <ref name="dhq_cit"/>
-   </define>
-   <define name="dhq_model.quoteLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_quote"/>
-      </optional>
-      <optional>
-         <ref name="dhq_cit"/>
-      </optional>
-   </define>
-   <define name="dhq_model.quoteLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_quote"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_cit"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.quoteLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_quote"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_cit"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.attributable">
-      <choice>
-         <ref name="dhq_model.quoteLike"/>
-         <ref name="dhq_said"/>
-         <ref name="dhq_floatingText"/>
-      </choice>
-   </define>
-   <define name="dhq_model.attributable_alternation">
-      <choice>
-         <ref name="dhq_model.quoteLike_alternation"/>
-         <ref name="dhq_said"/>
-         <ref name="dhq_floatingText"/>
-      </choice>
-   </define>
-   <define name="dhq_model.attributable_sequence">
-      <ref name="dhq_model.quoteLike_sequence"/>
+    </choice>
+  </define>
+  <define name="dhq_model.quoteLike_alternation">
+    <choice>
+      <ref name="dhq_quote"/>
+      <ref name="dhq_cit"/>
+    </choice>
+  </define>
+  <define name="dhq_model.quoteLike_sequence">
+    <ref name="dhq_quote"/>
+    <ref name="dhq_cit"/>
+  </define>
+  <define name="dhq_model.quoteLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_quote"/>
+    </optional>
+    <optional>
+      <ref name="dhq_cit"/>
+    </optional>
+  </define>
+  <define name="dhq_model.quoteLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_quote"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_cit"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.quoteLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_quote"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_cit"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.attributable">
+    <choice>
+      <ref name="dhq_model.quoteLike"/>
       <ref name="dhq_said"/>
       <ref name="dhq_floatingText"/>
-   </define>
-   <define name="dhq_model.attributable_sequenceOptional">
-      <optional>
-         <ref name="dhq_model.quoteLike_sequenceOptional"/>
-      </optional>
-      <optional>
-         <ref name="dhq_said"/>
-      </optional>
-      <optional>
-         <ref name="dhq_floatingText"/>
-      </optional>
-   </define>
-   <define name="dhq_model.attributable_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_model.quoteLike_sequenceOptionalRepeatable"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_said"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_floatingText"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.attributable_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_model.quoteLike_sequenceRepeatable"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_said"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_floatingText"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.respLike">
-      <choice>
-         <ref name="dhq_author"/>
-         <ref name="dhq_editor"/>
-         <ref name="dhq_meeting"/>
-         <ref name="dhq_sponsor"/>
-         <ref name="dhq_authorInfo"/>
-         <ref name="dhq_translatorInfo"/>
-      </choice>
-   </define>
-   <define name="dhq_model.divWrapper">
-      <choice>
-         <ref name="dhq_dateline"/>
-         <ref name="dhq_epigraph"/>
-         <ref name="dhq_salute"/>
-      </choice>
-   </define>
-   <define name="dhq_model.divTopPart">
-      <choice>
-         <ref name="dhq_model.headLike"/>
-         <ref name="dhq_signed"/>
-         <ref name="dhq_dedication"/>
-      </choice>
-   </define>
-   <define name="dhq_model.divTop">
-      <choice>
-         <ref name="dhq_model.divWrapper"/>
-         <ref name="dhq_model.divTopPart"/>
-      </choice>
-   </define>
-   <define name="dhq_model.divBottomPart">
-      <choice>
-         <ref name="dhq_trailer"/>
-         <ref name="dhq_signed"/>
-         <ref name="dhq_postscript"/>
-      </choice>
-   </define>
-   <define name="dhq_model.divBottom">
-      <choice>
-         <ref name="dhq_model.divWrapper"/>
-         <ref name="dhq_model.divBottomPart"/>
-      </choice>
-   </define>
-   <define name="dhq_model.imprintPart">
-      <choice>
-         <ref name="dhq_publisher"/>
-         <ref name="dhq_biblScope"/>
-         <ref name="dhq_pubPlace"/>
-      </choice>
-   </define>
-   <define name="dhq_model.addressLike">
-      <choice>
-         <ref name="dhq_email"/>
-         <ref name="dhq_address"/>
-      </choice>
-   </define>
-   <define name="dhq_model.nameLike">
-      <choice>
-         <ref name="dhq_model.nameLike.agent"/>
-         <ref name="dhq_model.offsetLike"/>
-         <ref name="dhq_idno"/>
-      </choice>
-   </define>
-   <define name="dhq_model.nameLike_alternation">
-      <choice>
-         <ref name="dhq_model.nameLike.agent_alternation"/>
-         <ref name="dhq_model.offsetLike_alternation"/>
-         <ref name="dhq_idno"/>
-      </choice>
-   </define>
-   <define name="dhq_model.nameLike_sequence">
-      <ref name="dhq_model.nameLike.agent_sequence"/>
-      <ref name="dhq_model.offsetLike_sequence"/>
+    </choice>
+  </define>
+  <define name="dhq_model.attributable_alternation">
+    <choice>
+      <ref name="dhq_model.quoteLike_alternation"/>
+      <ref name="dhq_said"/>
+      <ref name="dhq_floatingText"/>
+    </choice>
+  </define>
+  <define name="dhq_model.attributable_sequence">
+    <ref name="dhq_model.quoteLike_sequence"/>
+    <ref name="dhq_said"/>
+    <ref name="dhq_floatingText"/>
+  </define>
+  <define name="dhq_model.attributable_sequenceOptional">
+    <optional>
+      <ref name="dhq_model.quoteLike_sequenceOptional"/>
+    </optional>
+    <optional>
+      <ref name="dhq_said"/>
+    </optional>
+    <optional>
+      <ref name="dhq_floatingText"/>
+    </optional>
+  </define>
+  <define name="dhq_model.attributable_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_model.quoteLike_sequenceOptionalRepeatable"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_said"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_floatingText"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.attributable_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_model.quoteLike_sequenceRepeatable"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_said"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_floatingText"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.respLike">
+    <choice>
+      <ref name="dhq_author"/>
+      <ref name="dhq_editor"/>
+      <ref name="dhq_meeting"/>
+      <ref name="dhq_sponsor"/>
+      <ref name="dhq_authorInfo"/>
+      <ref name="dhq_translatorInfo"/>
+    </choice>
+  </define>
+  <define name="dhq_model.divWrapper">
+    <choice>
+      <ref name="dhq_dateline"/>
+      <ref name="dhq_epigraph"/>
+      <ref name="dhq_salute"/>
+    </choice>
+  </define>
+  <define name="dhq_model.divTopPart">
+    <choice>
+      <ref name="dhq_model.headLike"/>
+      <ref name="dhq_signed"/>
+      <ref name="dhq_dedication"/>
+    </choice>
+  </define>
+  <define name="dhq_model.divTop">
+    <choice>
+      <ref name="dhq_model.divWrapper"/>
+      <ref name="dhq_model.divTopPart"/>
+    </choice>
+  </define>
+  <define name="dhq_model.divBottomPart">
+    <choice>
+      <ref name="dhq_trailer"/>
+      <ref name="dhq_signed"/>
+      <ref name="dhq_postscript"/>
+    </choice>
+  </define>
+  <define name="dhq_model.divBottom">
+    <choice>
+      <ref name="dhq_model.divWrapper"/>
+      <ref name="dhq_model.divBottomPart"/>
+    </choice>
+  </define>
+  <define name="dhq_model.imprintPart">
+    <choice>
+      <ref name="dhq_publisher"/>
+      <ref name="dhq_biblScope"/>
+      <ref name="dhq_pubPlace"/>
+    </choice>
+  </define>
+  <define name="dhq_model.addressLike">
+    <choice>
+      <ref name="dhq_email"/>
+      <ref name="dhq_address"/>
+    </choice>
+  </define>
+  <define name="dhq_model.nameLike">
+    <choice>
+      <ref name="dhq_model.nameLike.agent"/>
+      <ref name="dhq_model.offsetLike"/>
       <ref name="dhq_idno"/>
-   </define>
-   <define name="dhq_model.nameLike_sequenceOptional">
-      <optional>
-         <ref name="dhq_model.nameLike.agent_sequenceOptional"/>
-      </optional>
-      <optional>
-         <ref name="dhq_model.offsetLike_sequenceOptional"/>
-      </optional>
-      <optional>
-         <ref name="dhq_idno"/>
-      </optional>
-   </define>
-   <define name="dhq_model.nameLike_sequenceOptionalRepeatable">
-      <zeroOrMore>
-         <ref name="dhq_model.nameLike.agent_sequenceOptionalRepeatable"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_model.offsetLike_sequenceOptionalRepeatable"/>
-      </zeroOrMore>
-      <zeroOrMore>
-         <ref name="dhq_idno"/>
-      </zeroOrMore>
-   </define>
-   <define name="dhq_model.nameLike_sequenceRepeatable">
-      <oneOrMore>
-         <ref name="dhq_model.nameLike.agent_sequenceRepeatable"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_model.offsetLike_sequenceRepeatable"/>
-      </oneOrMore>
-      <oneOrMore>
-         <ref name="dhq_idno"/>
-      </oneOrMore>
-   </define>
-   <define name="dhq_model.global">
-      <choice>
-         <ref name="dhq_model.global.meta"/>
-         <ref name="dhq_model.global.edit"/>
-         <ref name="dhq_notatedMusic"/>
-         <ref name="dhq_figure"/>
-      </choice>
-   </define>
-   <define name="dhq_model.biblPart">
-      <choice>
-         <ref name="dhq_model.respLike"/>
-         <ref name="dhq_model.imprintPart"/>
-         <ref name="dhq_series"/>
-         <ref name="dhq_citedRange"/>
-         <ref name="dhq_bibl"/>
-         <ref name="dhq_textLang"/>
-         <ref name="dhq_availability"/>
-      </choice>
-   </define>
-   <define name="dhq_model.addrPart">
-      <choice>
-         <ref name="dhq_model.nameLike"/>
-      </choice>
-   </define>
-   <define name="dhq_model.pPart.data">
-      <choice>
-         <ref name="dhq_model.dateLike"/>
-         <ref name="dhq_model.measureLike"/>
-         <ref name="dhq_model.nameLike"/>
-      </choice>
-   </define>
-   <define name="dhq_model.inter">
-      <choice>
-         <ref name="dhq_model.egLike"/>
-         <ref name="dhq_model.oddDecl"/>
-         <ref name="dhq_model.biblLike"/>
-         <ref name="dhq_model.listLike"/>
-         <ref name="dhq_model.stageLike"/>
-         <ref name="dhq_model.attributable"/>
-         <ref name="dhq_passThroughCode"/>
-         <ref name="dhq_example"/>
-      </choice>
-   </define>
-   <define name="dhq_model.common">
-      <choice>
-         <ref name="dhq_model.divPart"/>
-         <ref name="dhq_model.inter"/>
-         <ref name="dhq_q"/>
-         <ref name="dhq_note"/>
-      </choice>
-   </define>
-   <define name="dhq_model.phrase">
-      <choice>
-         <ref name="dhq_model.segLike"/>
-         <ref name="dhq_model.highlighted"/>
-         <ref name="dhq_model.graphicLike"/>
-         <ref name="dhq_model.pPart.msdesc"/>
-         <ref name="dhq_model.ptrLike"/>
-         <ref name="dhq_model.lPart"/>
-         <ref name="dhq_model.milestoneLike"/>
-         <ref name="dhq_model.phrase.xml"/>
-         <ref name="dhq_model.specDescLike"/>
-         <ref name="dhq_model.labelLike"/>
-         <ref name="dhq_model.noteLike"/>
-         <ref name="dhq_model.pPart.data"/>
-         <ref name="dhq_q"/>
-         <ref name="dhq_ruby"/>
-      </choice>
-   </define>
-   <define name="dhq_model.limitedPhrase">
-      <choice>
-         <ref name="dhq_model.hiLike"/>
-         <ref name="dhq_model.emphLike"/>
-         <ref name="dhq_model.pPart.msdesc"/>
-         <ref name="dhq_model.pPart.editorial"/>
-         <ref name="dhq_model.ptrLike"/>
-         <ref name="dhq_model.phrase.xml"/>
-         <ref name="dhq_model.pPart.data"/>
-      </choice>
-   </define>
-   <define name="dhq_model.divLike">
-      <choice>
-         <ref name="dhq_div"/>
-         <ref name="dhq_abstract"/>
-         <ref name="dhq_teaser"/>
-      </choice>
-   </define>
-   <define name="dhq_model.annotationLike">
-      <choice>
-         <ref name="dhq_note"/>
-         <ref name="dhq_annotation"/>
-      </choice>
-   </define>
-   <define name="dhq_model.annotationPart.body">
-      <choice>
-         <ref name="dhq_ptr"/>
-         <ref name="dhq_ref"/>
-         <ref name="dhq_note"/>
-      </choice>
-   </define>
-   <define name="dhq_model.teiHeaderPart">
-      <choice>
-         <ref name="dhq_encodingDesc"/>
-         <ref name="dhq_profileDesc"/>
-         <ref name="dhq_xenoData"/>
-      </choice>
-   </define>
-   <define name="dhq_model.encodingDescPart">
-      <choice>
-         <ref name="dhq_schemaRef"/>
-         <ref name="dhq_listPrefixDef"/>
-         <ref name="dhq_classDecl"/>
-         <ref name="dhq_unitDecl"/>
-      </choice>
-   </define>
-   <define name="dhq_model.profileDescPart">
-      <choice>
-         <ref name="dhq_creation"/>
-         <ref name="dhq_langUsage"/>
-         <ref name="dhq_textClass"/>
-         <ref name="dhq_calendarDesc"/>
-         <ref name="dhq_correspDesc"/>
-      </choice>
-   </define>
-   <define name="dhq_model.standOffPart">
-      <choice>
-         <ref name="dhq_model.global.meta"/>
-         <ref name="dhq_model.biblLike"/>
-         <ref name="dhq_model.listLike"/>
-         <ref name="dhq_model.annotationLike"/>
-         <ref name="dhq_listChange"/>
-         <ref name="dhq_seg"/>
-         <ref name="dhq_listAnnotation"/>
-      </choice>
-   </define>
-   <define name="dhq_att.formula.attributes">
-      <ref name="dhq_att.formula.attribute.formula"/>
-   </define>
-   <define name="dhq_att.formula.attribute.formula">
-      <optional>
-         <attribute name="formula">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A <code xmlns="http://www.w3.org/1999/xhtml">@formula</code> is provided to describe a mathematical calculation such as a conversion between measurement systems.</a:documentation>
-            <text/>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_att.locatable.attributes">
-      <ref name="dhq_att.locatable.attribute.where"/>
-   </define>
-   <define name="dhq_att.locatable.attribute.where">
-      <optional>
-         <attribute name="where">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates one or more locations by pointing to a <code xmlns="http://www.w3.org/1999/xhtml">&lt;place&gt;</code> element or other canonical description.</a:documentation>
-            <list>
-               <oneOrMore>
-                  <data type="anyURI">
-                     <param name="pattern">\S+</param>
-                  </data>
-               </oneOrMore>
-            </list>
-         </attribute>
-      </optional>
-   </define>
-   <define name="dhq_model.correspActionPart">
-      <choice>
-         <ref name="dhq_model.dateLike"/>
-         <ref name="dhq_model.addressLike"/>
-         <ref name="dhq_model.nameLike"/>
-         <ref name="dhq_note"/>
-         <ref name="dhq_noteGrp"/>
-      </choice>
-   </define>
-   <define name="dhq_model.correspContextPart">
-      <choice>
-         <ref name="dhq_model.ptrLike"/>
-         <ref name="dhq_model.pLike"/>
-         <ref name="dhq_note"/>
-         <ref name="dhq_noteGrp"/>
-      </choice>
-   </define>
-   <define name="dhq_model.correspDescPart">
-      <choice>
-         <ref name="dhq_note"/>
-         <ref name="dhq_noteGrp"/>
-         <ref name="dhq_correspAction"/>
-         <ref name="dhq_correspContext"/>
-      </choice>
-   </define>
-   <define name="dhq_model.resource">
-      <choice>
-         <ref name="dhq_text"/>
-         <ref name="dhq_standOff"/>
-      </choice>
-   </define>
-   <define name="dhq_p">
-      <element name="p">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(paragraph) marks paragraphs in prose. [3.1. Paragraphs 7.2.5. Speech Contents]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-p-abstractModel-structure-p-in-ab-or-p-constraint-report-2">
-            <rule context="tei:p">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="    (ancestor::tei:ab or ancestor::tei:p)                          and not( ancestor::tei:floatingText                                 |parent::tei:exemplum                                 |parent::tei:item                                 |parent::tei:note                                 |parent::tei:q                                 |parent::tei:quote                                 |parent::tei:remarks                                 |parent::tei:said                                 |parent::tei:sp                                 |parent::tei:stage                                 |parent::tei:cell                                 |parent::tei:figure                                )">
+    </choice>
+  </define>
+  <define name="dhq_model.nameLike_alternation">
+    <choice>
+      <ref name="dhq_model.nameLike.agent_alternation"/>
+      <ref name="dhq_model.offsetLike_alternation"/>
+      <ref name="dhq_idno"/>
+    </choice>
+  </define>
+  <define name="dhq_model.nameLike_sequence">
+    <ref name="dhq_model.nameLike.agent_sequence"/>
+    <ref name="dhq_model.offsetLike_sequence"/>
+    <ref name="dhq_idno"/>
+  </define>
+  <define name="dhq_model.nameLike_sequenceOptional">
+    <optional>
+      <ref name="dhq_model.nameLike.agent_sequenceOptional"/>
+    </optional>
+    <optional>
+      <ref name="dhq_model.offsetLike_sequenceOptional"/>
+    </optional>
+    <optional>
+      <ref name="dhq_idno"/>
+    </optional>
+  </define>
+  <define name="dhq_model.nameLike_sequenceOptionalRepeatable">
+    <zeroOrMore>
+      <ref name="dhq_model.nameLike.agent_sequenceOptionalRepeatable"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_model.offsetLike_sequenceOptionalRepeatable"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="dhq_idno"/>
+    </zeroOrMore>
+  </define>
+  <define name="dhq_model.nameLike_sequenceRepeatable">
+    <oneOrMore>
+      <ref name="dhq_model.nameLike.agent_sequenceRepeatable"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_model.offsetLike_sequenceRepeatable"/>
+    </oneOrMore>
+    <oneOrMore>
+      <ref name="dhq_idno"/>
+    </oneOrMore>
+  </define>
+  <define name="dhq_model.global">
+    <choice>
+      <ref name="dhq_model.global.meta"/>
+      <ref name="dhq_model.global.edit"/>
+      <ref name="dhq_notatedMusic"/>
+      <ref name="dhq_figure"/>
+    </choice>
+  </define>
+  <define name="dhq_model.biblPart">
+    <choice>
+      <ref name="dhq_model.respLike"/>
+      <ref name="dhq_model.imprintPart"/>
+      <ref name="dhq_series"/>
+      <ref name="dhq_citedRange"/>
+      <ref name="dhq_bibl"/>
+      <ref name="dhq_textLang"/>
+      <ref name="dhq_availability"/>
+    </choice>
+  </define>
+  <define name="dhq_model.addrPart">
+    <choice>
+      <ref name="dhq_model.nameLike"/>
+    </choice>
+  </define>
+  <define name="dhq_model.pPart.data">
+    <choice>
+      <ref name="dhq_model.dateLike"/>
+      <ref name="dhq_model.measureLike"/>
+      <ref name="dhq_model.nameLike"/>
+    </choice>
+  </define>
+  <define name="dhq_model.inter">
+    <choice>
+      <ref name="dhq_model.egLike"/>
+      <ref name="dhq_model.oddDecl"/>
+      <ref name="dhq_model.biblLike"/>
+      <ref name="dhq_model.listLike"/>
+      <ref name="dhq_model.stageLike"/>
+      <ref name="dhq_model.attributable"/>
+      <ref name="dhq_passThroughCode"/>
+      <ref name="dhq_example"/>
+    </choice>
+  </define>
+  <define name="dhq_model.common">
+    <choice>
+      <ref name="dhq_model.divPart"/>
+      <ref name="dhq_model.inter"/>
+      <ref name="dhq_q"/>
+      <ref name="dhq_note"/>
+    </choice>
+  </define>
+  <define name="dhq_model.phrase">
+    <choice>
+      <ref name="dhq_model.segLike"/>
+      <ref name="dhq_model.highlighted"/>
+      <ref name="dhq_model.graphicLike"/>
+      <ref name="dhq_model.pPart.msdesc"/>
+      <ref name="dhq_model.ptrLike"/>
+      <ref name="dhq_model.lPart"/>
+      <ref name="dhq_model.milestoneLike"/>
+      <ref name="dhq_model.phrase.xml"/>
+      <ref name="dhq_model.specDescLike"/>
+      <ref name="dhq_model.labelLike"/>
+      <ref name="dhq_model.noteLike"/>
+      <ref name="dhq_model.pPart.data"/>
+      <ref name="dhq_q"/>
+      <ref name="dhq_ruby"/>
+    </choice>
+  </define>
+  <define name="dhq_model.limitedPhrase">
+    <choice>
+      <ref name="dhq_model.hiLike"/>
+      <ref name="dhq_model.emphLike"/>
+      <ref name="dhq_model.pPart.msdesc"/>
+      <ref name="dhq_model.pPart.editorial"/>
+      <ref name="dhq_model.ptrLike"/>
+      <ref name="dhq_model.phrase.xml"/>
+      <ref name="dhq_model.pPart.data"/>
+    </choice>
+  </define>
+  <define name="dhq_model.divLike">
+    <choice>
+      <ref name="dhq_div"/>
+      <ref name="dhq_abstract"/>
+      <ref name="dhq_teaser"/>
+    </choice>
+  </define>
+  <define name="dhq_model.annotationLike">
+    <choice>
+      <ref name="dhq_note"/>
+      <ref name="dhq_annotation"/>
+    </choice>
+  </define>
+  <define name="dhq_model.annotationPart.body">
+    <choice>
+      <ref name="dhq_ptr"/>
+      <ref name="dhq_ref"/>
+      <ref name="dhq_note"/>
+    </choice>
+  </define>
+  <define name="dhq_model.teiHeaderPart">
+    <choice>
+      <ref name="dhq_encodingDesc"/>
+      <ref name="dhq_profileDesc"/>
+      <ref name="dhq_xenoData"/>
+    </choice>
+  </define>
+  <define name="dhq_model.encodingDescPart">
+    <choice>
+      <ref name="dhq_schemaRef"/>
+      <ref name="dhq_listPrefixDef"/>
+      <ref name="dhq_classDecl"/>
+      <ref name="dhq_unitDecl"/>
+    </choice>
+  </define>
+  <define name="dhq_model.profileDescPart">
+    <choice>
+      <ref name="dhq_creation"/>
+      <ref name="dhq_langUsage"/>
+      <ref name="dhq_textClass"/>
+      <ref name="dhq_calendarDesc"/>
+      <ref name="dhq_correspDesc"/>
+    </choice>
+  </define>
+  <define name="dhq_model.standOffPart">
+    <choice>
+      <ref name="dhq_model.global.meta"/>
+      <ref name="dhq_model.biblLike"/>
+      <ref name="dhq_model.listLike"/>
+      <ref name="dhq_model.annotationLike"/>
+      <ref name="dhq_listChange"/>
+      <ref name="dhq_seg"/>
+      <ref name="dhq_listAnnotation"/>
+    </choice>
+  </define>
+  <define name="dhq_att.formula.attributes">
+    <ref name="dhq_att.formula.attribute.formula"/>
+  </define>
+  <define name="dhq_att.formula.attribute.formula">
+    <optional>
+      <attribute name="formula">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A <code xmlns="http://www.w3.org/1999/xhtml">@formula</code> is provided to describe a mathematical calculation such as a conversion between measurement systems.</a:documentation>
+        <text/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.locatable.attributes">
+    <ref name="dhq_att.locatable.attribute.where"/>
+  </define>
+  <define name="dhq_att.locatable.attribute.where">
+    <optional>
+      <attribute name="where">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates one or more locations by pointing to a <code xmlns="http://www.w3.org/1999/xhtml">&lt;place&gt;</code> element or other canonical description.</a:documentation>
+        <list>
+          <oneOrMore>
+            <data type="anyURI">
+              <param name="pattern">\S+</param>
+            </data>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_model.correspActionPart">
+    <choice>
+      <ref name="dhq_model.dateLike"/>
+      <ref name="dhq_model.addressLike"/>
+      <ref name="dhq_model.nameLike"/>
+      <ref name="dhq_note"/>
+      <ref name="dhq_noteGrp"/>
+    </choice>
+  </define>
+  <define name="dhq_model.correspContextPart">
+    <choice>
+      <ref name="dhq_model.ptrLike"/>
+      <ref name="dhq_model.pLike"/>
+      <ref name="dhq_note"/>
+      <ref name="dhq_noteGrp"/>
+    </choice>
+  </define>
+  <define name="dhq_model.correspDescPart">
+    <choice>
+      <ref name="dhq_note"/>
+      <ref name="dhq_noteGrp"/>
+      <ref name="dhq_correspAction"/>
+      <ref name="dhq_correspContext"/>
+    </choice>
+  </define>
+  <define name="dhq_model.resource">
+    <choice>
+      <ref name="dhq_text"/>
+      <ref name="dhq_standOff"/>
+    </choice>
+  </define>
+  <define name="dhq_p">
+    <element name="p">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(paragraph) marks paragraphs in prose. [3.1. Paragraphs 7.2.5. Speech Contents]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-p-abstractModel-structure-p-in-ab-or-p-constraint-report-2">
+        <rule context="tei:p">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="    (ancestor::tei:ab or ancestor::tei:p)                          and not( ancestor::tei:floatingText                                 |parent::tei:exemplum                                 |parent::tei:item                                 |parent::tei:note                                 |parent::tei:q                                 |parent::tei:quote                                 |parent::tei:remarks                                 |parent::tei:said                                 |parent::tei:sp                                 |parent::tei:stage                                 |parent::tei:cell                                 |parent::tei:figure                                )">
         Abstract model violation: Paragraphs may not occur inside other paragraphs or ab elements.
       </sch:report>
-            </rule>
-         </pattern>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-p-abstractModel-structure-p-in-l-or-lg-constraint-report-3">
-            <rule context="tei:p">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="    (ancestor::tei:l or ancestor::tei:lg)                          and not( ancestor::tei:floatingText                                 |parent::tei:figure                                 |parent::tei:note                                )">
+        </rule>
+      </pattern>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-p-abstractModel-structure-p-in-l-or-lg-constraint-report-3">
+        <rule context="tei:p">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="    (ancestor::tei:l or ancestor::tei:lg)                          and not( ancestor::tei:floatingText                                 |parent::tei:figure                                 |parent::tei:note                                )">
         Abstract model violation: Lines may not contain higher-level structural elements such as div, p, or ab, unless p is a child of figure or note, or is a descendant of floatingText.
       </sch:report>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.fragmentable.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_foreign">
-      <element name="foreign">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(foreign) identifies a word or phrase as belonging to some language other than that of the surrounding text. [3.3.2.1. Foreign Words or Expressions]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_emph">
-      <element name="emph">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(emphasized) marks words or phrases which are stressed or emphasized for linguistic or rhetorical effect. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_hi">
-      <element name="hi">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(highlighted) marks a word or phrase as graphically distinct from the surrounding text, for reasons concerning which no claim is made. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of the highlighted material.</a:documentation>
-               <choice>
-                  <value>bold</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in bold type.</a:documentation>
-                  <value>italic</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in italic type.</a:documentation>
-                  <value>monospace</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in monospace type.</a:documentation>
-                  <value>quotes</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered within quotation marks. The nesting of single and double quotation marks will be handled by the stylesheet.</a:documentation>
-                  <value>smcaps</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in small capital letters.</a:documentation>
-                  <value>subscript</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered as a subscript.</a:documentation>
-                  <value>superscript</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered as a superscript.</a:documentation>
-                  <value>underlined</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered with an underline.</a:documentation>
-                  <value>strikethrough</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered with a strikethrough.</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_said">
-      <element name="said">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(speech or thought) indicates passages thought or spoken aloud, whether explicitly indicated in the source or not, whether directly or indirectly reported, whether by real people or fictional characters. [3.3.3. Quotation]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.ascribed.directed.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_quote">
-      <element name="quote">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(quotation) contains a phrase or passage attributed by the narrator or author to some agency external to the text. [3.3.3. Quotation 4.3.1. Grouped Texts]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.notated.attributes"/>
-         <attribute name="rend">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of the quoted material, whether inline or set as a block.</a:documentation>
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.fragmentable.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_foreign">
+    <element name="foreign">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(foreign) identifies a word or phrase as belonging to some language other than that of the surrounding text. [3.3.2.1. Foreign Words or Expressions]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_emph">
+    <element name="emph">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(emphasized) marks words or phrases which are stressed or emphasized for linguistic or rhetorical effect. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_hi">
+    <element name="hi">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(highlighted) marks a word or phrase as graphically distinct from the surrounding text, for reasons concerning which no claim is made. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <optional>
+        <attribute name="rend">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of the highlighted material.</a:documentation>
+          <choice>
+            <value>bold</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in bold type.</a:documentation>
+            <value>italic</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in italic type.</a:documentation>
+            <value>monospace</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in monospace type.</a:documentation>
+            <value>quotes</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered within quotation marks. The nesting of single and double quotation marks will be handled by the stylesheet.</a:documentation>
+            <value>smcaps</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered in small capital letters.</a:documentation>
+            <value>subscript</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered as a subscript.</a:documentation>
+            <value>superscript</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered as a superscript.</a:documentation>
+            <value>underlined</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered with an underline.</a:documentation>
+            <value>strikethrough</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The designated content is intended to be rendered with a strikethrough.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_said">
+    <element name="said">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(speech or thought) indicates passages thought or spoken aloud, whether explicitly indicated in the source or not, whether directly or indirectly reported, whether by real people or fictional characters. [3.3.3. Quotation]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.ascribed.directed.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_quote">
+    <element name="quote">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(quotation) contains a phrase or passage attributed by the narrator or author to some agency external to the text. [3.3.3. Quotation 4.3.1. Grouped Texts]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.notated.attributes"/>
+      <attribute name="rend">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of the quoted material, whether inline or set as a block.</a:documentation>
+        <choice>
+          <value>inline</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates an inline quotation (i.e. one that is flowed into the surrounding text rather than set off from it), typically containing text and inline elements.</a:documentation>
+          <value>block</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates a block quotation, typically containing one or more paragraphs or other chunky things.</a:documentation>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_q">
+    <element name="q">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(quoted) contains material which is distinguished from the surrounding text using quotation marks or a similar method, for any one of a variety of reasons including, but not limited to: direct speech or thought, technical terms or jargon, authorial distance, quotations from elsewhere, and passages that are mentioned but not used. [3.3.3. Quotation]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.ascribed.directed.attributes"/>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_cit">
+    <element name="cit">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cited quotation) contains a quotation from some other document, together with a bibliographic reference to its source. In a dictionary it may contain an example text with at least one occurrence of the word form, used in the sense being described, or a translation of the headword, or an example. [3.3.3. Quotation 4.3.1. Grouped Texts 9.3.5.1. Examples]</a:documentation>
+      <group>
+        <ref name="dhq_quote"/>
+        <choice>
+          <ref name="dhq_citRef"/>
+          <zeroOrMore>
             <choice>
-               <value>inline</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates an inline quotation (i.e. one that is flowed into the surrounding text rather than set off from it), typically containing text and inline elements.</a:documentation>
-               <value>block</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates a block quotation, typically containing one or more paragraphs or other chunky things.</a:documentation>
+              <ref name="dhq_ptr"/>
+              <ref name="dhq_ref"/>
+              <ref name="dhq_bibl"/>
+              <text/>
             </choice>
-         </attribute>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_q">
-      <element name="q">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(quoted) contains material which is distinguished from the surrounding text using quotation marks or a similar method, for any one of a variety of reasons including, but not limited to: direct speech or thought, technical terms or jargon, authorial distance, quotations from elsewhere, and passages that are mentioned but not used. [3.3.3. Quotation]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.ascribed.directed.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_cit">
-      <element name="cit">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cited quotation) contains a quotation from some other document, together with a bibliographic reference to its source. In a dictionary it may contain an example text with at least one occurrence of the word form, used in the sense being described, or a translation of the headword, or an example. [3.3.3. Quotation 4.3.1. Grouped Texts 9.3.5.1. Examples]</a:documentation>
-         <group>
-            <ref name="dhq_quote"/>
-            <choice>
-               <ref name="dhq_citRef"/>
-               <zeroOrMore>
-                  <choice>
-                     <ref name="dhq_ptr"/>
-                     <ref name="dhq_ref"/>
-                     <ref name="dhq_bibl"/>
-                     <text/>
-                  </choice>
-               </zeroOrMore>
-            </choice>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_soCalled">
-      <element name="soCalled">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(so called) contains a word or phrase for which the author or narrator indicates a disclaiming of responsibility, for example by the use of scare quotes or italics. [3.3.3. Quotation]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_desc">
-      <element name="desc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description) contains a short description of the purpose, function, or use of its parent element, or when the parent is a documentation element, describes or defines the object being documented.  [22.4.1. Description of Components]</a:documentation>
-         <ref name="dhq_macro.limitedContent"/>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-desc-deprecationInfo-only-in-deprecated-constraint-rule-2">
-            <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
-                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                      xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                      context="tei:desc[ @type eq 'deprecationInfo']">
-               <sch:assert test="../@validUntil">Information about a
+          </zeroOrMore>
+        </choice>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_soCalled">
+    <element name="soCalled">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(so called) contains a word or phrase for which the author or narrator indicates a disclaiming of responsibility, for example by the use of scare quotes or italics. [3.3.3. Quotation]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_desc">
+    <element name="desc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description) contains a short description of the purpose, function, or use of its parent element, or when the parent is a documentation element, describes or defines the object being documented.  [22.4.1. Description of Components]</a:documentation>
+      <ref name="dhq_macro.limitedContent"/>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-desc-deprecationInfo-only-in-deprecated-constraint-rule-2">
+        <sch:rule xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" context="tei:desc[ @type eq 'deprecationInfo']">
+          <sch:assert test="../@validUntil">Information about a
         deprecation should only be present in a specification element
         that is being deprecated: that is, only an element that has a
         @validUntil attribute should have a child &lt;desc
         type="deprecationInfo"&gt;.</sch:assert>
-            </sch:rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_term">
-      <element name="term">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(term) contains a single-word, multi-word, or symbolic designation which is regarded as a technical term. [3.4.1. Terms and Glosses]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.canonical.attributes"/>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="corresp">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>#access</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#annotation</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#anthropology</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#ar</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#archaeology</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#archives</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#area_studies</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#citation</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#classics</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#code_studies</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#collaboration</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#comics</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#communications</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#content_analysis</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#corpora</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#cs</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#cultural_criticism</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#cultural_heritage</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#data_analytics</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#data_curation</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#data_modeling</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#data_visualization</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#databases</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#dh</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#digital</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#digital_libraries</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#digital_literacy</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#digitization</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#editing</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#elit</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#ecocriticism</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#ethics</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#games</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#gender</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#geospatial</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#glam</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#globalDH</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#graphic_design</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#history</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#hypertext</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#images</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#indigenous</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#info_architecture</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#informatics</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#information_retrieval</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#infrastructure</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#interdisciplinarity</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#language_studies</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#linguistics</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#literary_studies</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#machine_learning</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#manuscripts</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#markup</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#materialisms</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#media_history</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#media_studies</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#medieval</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#metadata</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#minimal_computing</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#mobile</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#moving_images</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#music</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#network</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#nlp</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#oral_history</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#pedagogy</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#performance</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#philosophy</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#project_management</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#project_report</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#public_history</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#publishing</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#race</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#reading</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#religion</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#rhetoric</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#semantic_web</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#social_justice</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#social_media</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#sound</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#standards</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#stylistics</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#tools</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#transcription</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#translation</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#users</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#visual_art</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>#web</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_ruby">
-      <element name="ruby">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ruby container) contains a passage of base text along with its associated ruby gloss(es). [3.4.2. Ruby Annotations]</a:documentation>
-         <group>
-            <ref name="dhq_rb"/>
-            <oneOrMore>
-               <ref name="dhq_rt"/>
-            </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_rb">
-      <element name="rb">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ruby base) contains the base text annotated by a ruby gloss. [3.4.2. Ruby Annotations]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_rt">
-      <element name="rt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ruby text) contains a ruby text, an annotation closely associated with a passage of the main text. [3.4.2. Ruby Annotations]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="target">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to the base being glossed by this ruby text.</a:documentation>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-rt-target-rt-target-not-span-constraint-report-4">
-            <rule context="tei:rt/@target">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="../@from | ../@to">When target= is
+        </sch:rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_term">
+    <element name="term">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(term) contains a single-word, multi-word, or symbolic designation which is regarded as a technical term. [3.4.1. Terms and Glosses]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.canonical.attributes"/>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="corresp">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>#access</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#annotation</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#anthropology</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#ar</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#archaeology</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#archives</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#area_studies</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#citation</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#classics</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#code_studies</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#collaboration</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#comics</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#communications</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#content_analysis</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#corpora</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#cs</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#cultural_criticism</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#cultural_heritage</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#data_analytics</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#data_curation</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#data_modeling</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#data_visualization</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#databases</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#dh</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#digital</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#digital_libraries</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#digital_literacy</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#digitization</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#editing</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#elit</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#ecocriticism</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#ethics</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#games</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#gender</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#geospatial</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#glam</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#globalDH</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#graphic_design</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#history</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#hypertext</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#images</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#indigenous</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#info_architecture</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#informatics</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#information_retrieval</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#infrastructure</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#interdisciplinarity</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#language_studies</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#linguistics</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#literary_studies</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#machine_learning</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#manuscripts</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#markup</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#materialisms</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#media_history</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#media_studies</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#medieval</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#metadata</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#minimal_computing</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#mobile</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#moving_images</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#music</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#network</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#nlp</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#oral_history</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#pedagogy</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#performance</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#philosophy</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#project_management</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#project_report</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#public_history</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#publishing</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#race</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#reading</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#religion</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#rhetoric</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#semantic_web</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#social_justice</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#social_media</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#sound</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#standards</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#stylistics</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#tools</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#transcription</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#translation</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#users</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#visual_art</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>#web</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_ruby">
+    <element name="ruby">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ruby container) contains a passage of base text along with its associated ruby gloss(es). [3.4.2. Ruby Annotations]</a:documentation>
+      <group>
+        <ref name="dhq_rb"/>
+        <oneOrMore>
+          <ref name="dhq_rt"/>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_rb">
+    <element name="rb">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ruby base) contains the base text annotated by a ruby gloss. [3.4.2. Ruby Annotations]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_rt">
+    <element name="rt">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ruby text) contains a ruby text, an annotation closely associated with a passage of the main text. [3.4.2. Ruby Annotations]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="target">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to the base being glossed by this ruby text.</a:documentation>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-rt-target-rt-target-not-span-constraint-report-4">
+        <rule context="tei:rt/@target">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="../@from | ../@to">When target= is
             present, neither from= nor to= should be.</sch:report>
-            </rule>
-         </pattern>
-         <optional>
-            <attribute name="from">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the starting point of the span of text being glossed by this ruby text.</a:documentation>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-rt-from-rt-from-constraint-assert-2">
-            <rule context="tei:rt/@from">
-               <sch:assert xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="../@to">When from= is present, the to=
+        </rule>
+      </pattern>
+      <optional>
+        <attribute name="from">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the starting point of the span of text being glossed by this ruby text.</a:documentation>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-rt-from-rt-from-constraint-assert-2">
+        <rule context="tei:rt/@from">
+          <sch:assert xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="../@to">When from= is present, the to=
             attribute of <sch:name/> is required.</sch:assert>
-            </rule>
-         </pattern>
-         <optional>
-            <attribute name="to">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the ending point of the span of text being glossed.</a:documentation>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-rt-to-rt-to-constraint-assert-3">
-            <rule context="tei:rt/@to">
-               <sch:assert xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="../@from">When to= is present, the from=
+        </rule>
+      </pattern>
+      <optional>
+        <attribute name="to">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the ending point of the span of text being glossed.</a:documentation>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-rt-to-rt-to-constraint-assert-3">
+        <rule context="tei:rt/@to">
+          <sch:assert xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="../@from">When to= is present, the from=
             attribute of <sch:name/> is required.</sch:assert>
-            </rule>
-         </pattern>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_ellipsis">
-      <element name="ellipsis">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deliberately marked omission) indicates a purposeful marking in the source document signalling that content has been omitted, and may also supply or describe the omitted content. [3.5.3. Additions, Deletions, and Omissions]</a:documentation>
-         <group>
-            <optional>
-               <ref name="dhq_model.descLike"/>
-            </optional>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_name">
-      <element name="name">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name, proper noun) contains a proper noun or noun phrase. [3.6.1. Referring Strings]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="role">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the role of the person named in relation to the bibliographic object.
+        </rule>
+      </pattern>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_ellipsis">
+    <element name="ellipsis">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deliberately marked omission) indicates a purposeful marking in the source document signalling that content has been omitted, and may also supply or describe the omitted content. [3.5.3. Additions, Deletions, and Omissions]</a:documentation>
+      <group>
+        <optional>
+          <ref name="dhq_model.descLike"/>
+        </optional>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_name">
+    <element name="name">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name, proper noun) contains a proper noun or noun phrase. [3.6.1. Referring Strings]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="role">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the role of the person named in relation to the bibliographic object.
 Suggested values include: 1] translator; 2] editor; 3] illustrator; 4] annotator; 5] programmer</a:documentation>
-               <choice>
-                  <value>translator</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>editor</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>illustrator</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>annotator</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>programmer</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <data type="Name"/>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_email">
-      <element name="email">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(electronic mail address) contains an email address identifying a location to which email messages can be delivered. [3.6.2. Addresses]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_address">
-      <element name="address">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(address) contains a postal address, for example of a publisher, an organization, or an individual. [3.6.2. Addresses 2.2.4. Publication, Distribution, Licensing, etc. 3.12.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
-         <group>
+          <choice>
+            <value>translator</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>editor</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>illustrator</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>annotator</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>programmer</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <data type="Name"/>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_email">
+    <element name="email">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(electronic mail address) contains an email address identifying a location to which email messages can be delivered. [3.6.2. Addresses]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_address">
+    <element name="address">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(address) contains a postal address, for example of a publisher, an organization, or an individual. [3.6.2. Addresses 2.2.4. Publication, Distribution, Licensing, etc. 3.12.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.global"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <group>
+            <ref name="dhq_model.addrPart"/>
             <zeroOrMore>
-               <ref name="dhq_model.global"/>
+              <ref name="dhq_model.global"/>
             </zeroOrMore>
-            <oneOrMore>
-               <group>
-                  <ref name="dhq_model.addrPart"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_unit">
-      <element name="unit">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a symbol, a word or a phrase referring to a unit of measurement in any kind of formal or informal system. [3.6.3. Numbers and
+          </group>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_unit">
+    <element name="unit">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a symbol, a word or a phrase referring to a unit of measurement in any kind of formal or informal system. [3.6.3. Numbers and
 Measures]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_date">
-      <element name="date">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(date) contains a date in any format. [3.6.4. Dates and Times 2.2.4. Publication, Distribution, Licensing, etc. 2.6. The Revision Description 3.12.2.4. Imprint, Size of a Document, and Reprint Information 15.2.3. The Setting Description 13.4. Dates]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_model.phrase"/>
-               <ref name="dhq_model.global"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.canonical.attributes"/>
-         <optional>
-            <attribute name="when">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a date in regularized format.</a:documentation>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_ptr">
-      <element name="ptr">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pointer) defines a pointer to another location. [3.7. Simple Links and Cross-References 16.1. Links]</a:documentation>
-         <empty/>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-ptr-ptrAtts-constraint-report-5">
-            <rule context="tei:ptr">
-               <report xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                       xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                       test="@target and @cRef">Only one of the
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_date">
+    <element name="date">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(date) contains a date in any format. [3.6.4. Dates and Times 2.2.4. Publication, Distribution, Licensing, etc. 2.6. The Revision Description 3.12.2.4. Imprint, Size of a Document, and Reprint Information 15.2.3. The Setting Description 13.4. Dates]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_model.phrase"/>
+          <ref name="dhq_model.global"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.canonical.attributes"/>
+      <optional>
+        <attribute name="when">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a date in regularized format.</a:documentation>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_ptr">
+    <element name="ptr">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pointer) defines a pointer to another location. [3.7. Simple Links and Cross-References 16.1. Links]</a:documentation>
+      <empty/>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-ptr-ptrAtts-constraint-report-5">
+        <rule context="tei:ptr">
+          <report xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@target and @cRef">Only one of the
 attributes @target and @cRef may be supplied on <name/>.</report>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.internetMedia.attributes"/>
-         <optional>
-            <attribute name="target">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a pointer to a bibliographic citation.</a:documentation>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="loc">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The value will typically be either a numeric page reference or page range, or else a section number (which may be numeric or alphabetic, or may conceivably use some other ordering system)</a:documentation>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Permits specialized types of pointers to be identified (e.g. those pointing to video or audio files).</a:documentation>
-               <choice>
-                  <value>dhq-annex-embed</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the pointer references an embedded feed from the DHQ annex.</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_ref">
-      <element name="ref">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) defines a reference to another location, possibly modified by additional text or comment. [3.7. Simple Links and Cross-References 16.1. Links]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-ref-refAtts-constraint-report-6">
-            <rule context="tei:ref">
-               <report xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                       xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                       test="@target and @cRef">Only one of the
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.internetMedia.attributes"/>
+      <optional>
+        <attribute name="target">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a pointer to a bibliographic citation.</a:documentation>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="loc">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The value will typically be either a numeric page reference or page range, or else a section number (which may be numeric or alphabetic, or may conceivably use some other ordering system)</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Permits specialized types of pointers to be identified (e.g. those pointing to video or audio files).</a:documentation>
+          <choice>
+            <value>dhq-annex-embed</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the pointer references an embedded feed from the DHQ annex.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_ref">
+    <element name="ref">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) defines a reference to another location, possibly modified by additional text or comment. [3.7. Simple Links and Cross-References 16.1. Links]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-ref-refAtts-constraint-report-6">
+        <rule context="tei:ref">
+          <report xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@target and @cRef">Only one of the
 	attributes @target' and @cRef' may be supplied on <name/>
                </report>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.internetMedia.attributes"/>
-         <optional>
-            <attribute name="target">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a pointer to a bibliographic citation.</a:documentation>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="loc">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The value will typically be either a numeric page reference or page range, or else a section number (which may be numeric or alphabetic, or may conceivably use some other ordering system)</a:documentation>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a classification of the reference</a:documentation>
-               <choice>
-                  <value>offline</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the reference in question does not have a linked target.</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_list">
-      <element name="list">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list) contains any sequence of items organized as a list. [3.8. Lists]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_model.divTop"/>
-            </zeroOrMore>
-            <oneOrMore>
-               <ref name="dhq_item"/>
-            </oneOrMore>
-         </group>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-list-gloss-list-must-have-labels-constraint-rule-3">
-            <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
-                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                      xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                      context="tei:list[@type='gloss']">
-               <sch:assert test="tei:label">The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element</sch:assert>
-            </sch:rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.sortable.attributes"/>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Classifies the element.</a:documentation>
-               <choice>
-                  <value>ordered</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A numbered list</a:documentation>
-                  <value>unordered</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A bulleted list</a:documentation>
-                  <value>simple</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A list with no numbering or bullets</a:documentation>
-                  <value>gloss</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A gloss list, assumes the presence of a label preceding the item.</a:documentation>
-                  <value>annotated_bibliography</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An annotated bibliography, assumes the presence of a <code xmlns="http://www.w3.org/1999/xhtml">&lt;bibl&gt;</code> within <code xmlns="http://www.w3.org/1999/xhtml">&lt;label&gt;</code>.</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_item">
-      <element name="item">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(item) contains one component of a list. [3.8. Lists 2.6. The Revision Description]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.sortable.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_label">
-      <element name="label">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(label) contains any label or heading used to identify part of a text, typically but not exclusively in a list or glossary. [3.8. Lists]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <ref name="dhq_macro.phraseSeq"/>
-               <ref name="dhq_bibl"/>
-               <ref name="dhq_q"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_head">
-      <element name="head">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(heading) contains any type of heading, for example the title of a section, or the heading of a list, glossary, manuscript description, etc. [4.2.1. Headings and Trailers]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_model.hiLike"/>
-               <ref name="dhq_model.dateLike"/>
-               <ref name="dhq_model.nameLike"/>
-               <ref name="dhq_model.emphLike"/>
-               <ref name="dhq_model.phrase.xml"/>
-               <ref name="dhq_model.ptrLike"/>
-               <ref name="dhq_model.inter"/>
-               <ref name="dhq_quote"/>
-               <ref name="dhq_said"/>
-               <ref name="dhq_q"/>
-               <ref name="dhq_note"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_note">
-      <element name="note">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(note) contains a note or annotation. [3.9.1. Notes and Simple Annotation 2.2.6. The Notes Statement 3.12.2.8. Notes and Statement of Language 9.3.5.4. Notes within Entries]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the note</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_noteGrp">
-      <element name="noteGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a group of notes [3.9.1.1. Encoding Grouped Notes]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_desc"/>
-            </zeroOrMore>
-            <oneOrMore>
-               <choice>
-                  <ref name="dhq_note"/>
-                  <ref name="dhq_noteGrp"/>
-               </choice>
-            </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <ref name="dhq_att.anchoring.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_media">
-      <element name="media">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of any form of external media such as an audio or video clip etc. [3.10. Graphics and Other Non-textual Components]</a:documentation>
-         <zeroOrMore>
-            <ref name="dhq_model.descLike"/>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.media.attribute.scale"/>
-         <ref name="dhq_att.resourced.attributes"/>
-         <optional>
-            <attribute name="width">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="integer"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="height">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="integer"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="mimeType">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>audio/wav</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Waveform audio format (.wav)</a:documentation>
-                  <value>audio/mpeg</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MP3 audio files (.mp3)</a:documentation>
-                  <value>image/svg+xml</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SVG file (.svg)</a:documentation>
-                  <value>video/quicktime</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quicktime videos (.mov)</a:documentation>
-                  <value>video/mp4</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MP4 audio/video (.mp4)</a:documentation>
-                  <value>audio/x-ms-wma</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">WMA files (.wma)</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="poster">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A pointer to an image that serves as a "poster": a static image that displays when the media is not playing.</a:documentation>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_graphic">
-      <element name="graphic">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(graphic) indicates the location of a graphic or illustration, either forming part of a text, or providing an image of it. [3.10. Graphics and Other Non-textual Components 11.1. Digital Facsimiles]</a:documentation>
-         <zeroOrMore>
-            <ref name="dhq_model.descLike"/>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.internetMedia.attribute.mimeType"/>
-         <ref name="dhq_att.resourced.attributes"/>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Classifies the type of graphic object.</a:documentation>
-               <choice>
-                  <value>video</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A link to a video file</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_gb">
-      <element name="gb">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(gathering beginning) marks the beginning of a new gathering or quire in a transcribed codex. [3.11.3. Milestone
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.internetMedia.attributes"/>
+      <optional>
+        <attribute name="target">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a pointer to a bibliographic citation.</a:documentation>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="loc">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The value will typically be either a numeric page reference or page range, or else a section number (which may be numeric or alphabetic, or may conceivably use some other ordering system)</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a classification of the reference</a:documentation>
+          <choice>
+            <value>offline</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the reference in question does not have a linked target.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_list">
+    <element name="list">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list) contains any sequence of items organized as a list. [3.8. Lists]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.divTop"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="dhq_item"/>
+        </oneOrMore>
+      </group>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-list-gloss-list-must-have-labels-constraint-rule-3">
+        <sch:rule xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" context="tei:list[@type='gloss']">
+          <sch:assert test="tei:label">The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element</sch:assert>
+        </sch:rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.sortable.attributes"/>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Classifies the element.</a:documentation>
+          <choice>
+            <value>ordered</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A numbered list</a:documentation>
+            <value>unordered</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A bulleted list</a:documentation>
+            <value>simple</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A list with no numbering or bullets</a:documentation>
+            <value>gloss</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A gloss list, assumes the presence of a label preceding the item.</a:documentation>
+            <value>annotated_bibliography</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An annotated bibliography, assumes the presence of a <code xmlns="http://www.w3.org/1999/xhtml">&lt;bibl&gt;</code> within <code xmlns="http://www.w3.org/1999/xhtml">&lt;label&gt;</code>.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_item">
+    <element name="item">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(item) contains one component of a list. [3.8. Lists 2.6. The Revision Description]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.sortable.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_label">
+    <element name="label">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(label) contains any label or heading used to identify part of a text, typically but not exclusively in a list or glossary. [3.8. Lists]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <ref name="dhq_macro.phraseSeq"/>
+          <ref name="dhq_bibl"/>
+          <ref name="dhq_q"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_head">
+    <element name="head">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(heading) contains any type of heading, for example the title of a section, or the heading of a list, glossary, manuscript description, etc. [4.2.1. Headings and Trailers]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_model.hiLike"/>
+          <ref name="dhq_model.dateLike"/>
+          <ref name="dhq_model.nameLike"/>
+          <ref name="dhq_model.emphLike"/>
+          <ref name="dhq_model.phrase.xml"/>
+          <ref name="dhq_model.ptrLike"/>
+          <ref name="dhq_model.inter"/>
+          <ref name="dhq_quote"/>
+          <ref name="dhq_said"/>
+          <ref name="dhq_q"/>
+          <ref name="dhq_note"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_note">
+    <element name="note">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(note) contains a note or annotation. [3.9.1. Notes and Simple Annotation 2.2.6. The Notes Statement 3.12.2.8. Notes and Statement of Language 9.3.5.4. Notes within Entries]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the note</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_noteGrp">
+    <element name="noteGrp">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a group of notes [3.9.1.1. Encoding Grouped Notes]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_desc"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <choice>
+            <ref name="dhq_note"/>
+            <ref name="dhq_noteGrp"/>
+          </choice>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <ref name="dhq_att.anchoring.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_media">
+    <element name="media">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of any form of external media such as an audio or video clip etc. [3.10. Graphics and Other Non-textual Components]</a:documentation>
+      <zeroOrMore>
+        <ref name="dhq_model.descLike"/>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.media.attribute.scale"/>
+      <ref name="dhq_att.resourced.attributes"/>
+      <optional>
+        <attribute name="width">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="integer"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="integer"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mimeType">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>audio/wav</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Waveform audio format (.wav)</a:documentation>
+            <value>audio/mpeg</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MP3 audio files (.mp3)</a:documentation>
+            <value>image/svg+xml</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SVG file (.svg)</a:documentation>
+            <value>video/quicktime</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quicktime videos (.mov)</a:documentation>
+            <value>video/mp4</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MP4 audio/video (.mp4)</a:documentation>
+            <value>audio/x-ms-wma</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">WMA files (.wma)</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="poster">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A pointer to an image that serves as a "poster": a static image that displays when the media is not playing.</a:documentation>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_graphic">
+    <element name="graphic">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(graphic) indicates the location of a graphic or illustration, either forming part of a text, or providing an image of it. [3.10. Graphics and Other Non-textual Components 11.1. Digital Facsimiles]</a:documentation>
+      <zeroOrMore>
+        <ref name="dhq_model.descLike"/>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.internetMedia.attribute.mimeType"/>
+      <ref name="dhq_att.resourced.attributes"/>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Classifies the type of graphic object.</a:documentation>
+          <choice>
+            <value>video</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A link to a video file</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_gb">
+    <element name="gb">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(gathering beginning) marks the beginning of a new gathering or quire in a transcribed codex. [3.11.3. Milestone
 Elements]</a:documentation>
-         <empty/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.breaking.attributes"/>
-         <ref name="dhq_att.edition.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_lb">
-      <element name="lb">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line beginning) marks the beginning of a new (typographic) line in some edition or version of a text. [3.11.3. Milestone
+      <empty/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.breaking.attributes"/>
+      <ref name="dhq_att.edition.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_lb">
+    <element name="lb">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line beginning) marks the beginning of a new (typographic) line in some edition or version of a text. [3.11.3. Milestone
 Elements 7.2.5. Speech Contents]</a:documentation>
-         <empty/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.edition.attribute.edRef"/>
-         <ref name="dhq_att.breaking.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_series">
-      <element name="series">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series information) contains information about the series in which a book or other bibliographic item has appeared. [3.12.2.1. Analytic, Monographic, and Series Levels]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_title"/>
-               <ref name="dhq_model.ptrLike"/>
-               <ref name="dhq_editor"/>
-               <ref name="dhq_biblScope"/>
-               <ref name="dhq_idno"/>
-               <ref name="dhq_textLang"/>
-               <ref name="dhq_model.global"/>
-               <ref name="dhq_availability"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_author">
-      <element name="author">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(author) in a bibliographic reference, contains the name(s) of an author, personal or corporate, of a work; for example in the same form as that provided by a recognized bibliographic name authority. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_editor">
-      <element name="editor">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a secondary statement of responsibility for a bibliographic item, for example the name of an individual, institution or organization, (or of several such) acting as editor, compiler, translator, etc. [3.12.2.2. Titles, Authors, and Editors]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_title">
-      <element name="title">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title) contains a title for any kind of work. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.5. The Series Statement]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.canonical.attributes"/>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The <code xmlns="http://www.w3.org/1999/xhtml">@type</code> attribute is to be used in the header to designate and distinguish the article and issue titles.</a:documentation>
-               <choice>
-                  <value>article</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>issue</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of a title in the main body of the text and in the bibliography.</a:documentation>
-               <choice>
-                  <value>italic</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>none</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>quotes</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_meeting">
-      <element name="meeting">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the formalized descriptive title for a meeting or conference, for use in a bibliographic description for an item derived from such a meeting, or as a heading or preamble to publications emanating from it. [3.12.2.2. Titles, Authors, and Editors]</a:documentation>
-         <ref name="dhq_macro.limitedContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.canonical.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_publisher">
-      <element name="publisher">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publisher) provides the name of the organization responsible for the publication or distribution of a bibliographic item. [3.12.2.4. Imprint, Size of a Document, and Reprint Information 2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.canonical.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_biblScope">
-      <element name="biblScope">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(scope of bibliographic reference) defines the scope of a bibliographic reference, for example as a list of page numbers, or a named subdivision of a larger work. [3.12.2.5. Scopes and Ranges in Bibliographic Citations]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.citing.attribute.unit"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_citedRange">
-      <element name="citedRange">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cited range) defines the range of cited content, often represented by pages or other units [3.12.2.5. Scopes and Ranges in Bibliographic Citations]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.citing.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_pubPlace">
-      <element name="pubPlace">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication place) contains the name of the place where a bibliographic item was published. [3.12.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_bibl">
-      <element name="bibl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(bibliographic citation) contains a loosely-structured bibliographic citation of which the sub-components may or may not be explicitly tagged. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_model.highlighted"/>
-               <ref name="dhq_model.pPart.data"/>
-               <ref name="dhq_model.segLike"/>
-               <ref name="dhq_model.ptrLike"/>
-               <ref name="dhq_model.biblPart"/>
-               <ref name="dhq_model.global"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.canonical.attributes"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.sortable.attributes"/>
-         <ref name="dhq_att.docStatus.attributes"/>
-         <optional>
-            <attribute name="biblioID">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a reference to a centralized bibliography</a:documentation>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="label">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a label for use in generated bibliographies.</a:documentation>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the bibliographic item</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_listBibl">
-      <element name="listBibl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation list) contains a list of bibliographic citations of any kind. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_model.headLike"/>
-            </zeroOrMore>
-            <zeroOrMore>
-               <ref name="dhq_desc"/>
-            </zeroOrMore>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.milestoneLike"/>
-               </choice>
-            </zeroOrMore>
+      <empty/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.edition.attribute.edRef"/>
+      <ref name="dhq_att.breaking.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_series">
+    <element name="series">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series information) contains information about the series in which a book or other bibliographic item has appeared. [3.12.2.1. Analytic, Monographic, and Series Levels]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_title"/>
+          <ref name="dhq_model.ptrLike"/>
+          <ref name="dhq_editor"/>
+          <ref name="dhq_biblScope"/>
+          <ref name="dhq_idno"/>
+          <ref name="dhq_textLang"/>
+          <ref name="dhq_model.global"/>
+          <ref name="dhq_availability"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_author">
+    <element name="author">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(author) in a bibliographic reference, contains the name(s) of an author, personal or corporate, of a work; for example in the same form as that provided by a recognized bibliographic name authority. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_editor">
+    <element name="editor">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a secondary statement of responsibility for a bibliographic item, for example the name of an individual, institution or organization, (or of several such) acting as editor, compiler, translator, etc. [3.12.2.2. Titles, Authors, and Editors]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_title">
+    <element name="title">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title) contains a title for any kind of work. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.5. The Series Statement]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.canonical.attributes"/>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The <code xmlns="http://www.w3.org/1999/xhtml">@type</code> attribute is to be used in the header to designate and distinguish the article and issue titles.</a:documentation>
+          <choice>
+            <value>article</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>issue</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rend">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of a title in the main body of the text and in the bibliography.</a:documentation>
+          <choice>
+            <value>italic</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>none</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>quotes</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_meeting">
+    <element name="meeting">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the formalized descriptive title for a meeting or conference, for use in a bibliographic description for an item derived from such a meeting, or as a heading or preamble to publications emanating from it. [3.12.2.2. Titles, Authors, and Editors]</a:documentation>
+      <ref name="dhq_macro.limitedContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.canonical.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_publisher">
+    <element name="publisher">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publisher) provides the name of the organization responsible for the publication or distribution of a bibliographic item. [3.12.2.4. Imprint, Size of a Document, and Reprint Information 2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.canonical.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_biblScope">
+    <element name="biblScope">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(scope of bibliographic reference) defines the scope of a bibliographic reference, for example as a list of page numbers, or a named subdivision of a larger work. [3.12.2.5. Scopes and Ranges in Bibliographic Citations]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.citing.attribute.unit"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_citedRange">
+    <element name="citedRange">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cited range) defines the range of cited content, often represented by pages or other units [3.12.2.5. Scopes and Ranges in Bibliographic Citations]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.citing.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_pubPlace">
+    <element name="pubPlace">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication place) contains the name of the place where a bibliographic item was published. [3.12.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_bibl">
+    <element name="bibl">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(bibliographic citation) contains a loosely-structured bibliographic citation of which the sub-components may or may not be explicitly tagged. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_model.highlighted"/>
+          <ref name="dhq_model.pPart.data"/>
+          <ref name="dhq_model.segLike"/>
+          <ref name="dhq_model.ptrLike"/>
+          <ref name="dhq_model.biblPart"/>
+          <ref name="dhq_model.global"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.canonical.attributes"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.sortable.attributes"/>
+      <ref name="dhq_att.docStatus.attributes"/>
+      <optional>
+        <attribute name="biblioID">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a reference to a centralized bibliography</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="label">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a label for use in generated bibliographies.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the bibliographic item</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_listBibl">
+    <element name="listBibl">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation list) contains a list of bibliographic citations of any kind. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.headLike"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="dhq_desc"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.milestoneLike"/>
+          </choice>
+        </zeroOrMore>
+        <oneOrMore>
+          <group>
             <oneOrMore>
-               <group>
-                  <oneOrMore>
-                     <ref name="dhq_model.biblLike"/>
-                  </oneOrMore>
-                  <zeroOrMore>
-                     <choice>
-                        <ref name="dhq_model.milestoneLike"/>
-                     </choice>
-                  </zeroOrMore>
-               </group>
+              <ref name="dhq_model.biblLike"/>
             </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.sortable.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_l">
-      <element name="l">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(verse line) contains a single, possibly incomplete, line of verse. [3.13.1. Core Tags for Verse 3.13. Passages of Verse or Drama 7.2.5. Speech Contents]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_model.phrase"/>
-               <ref name="dhq_model.inter"/>
-               <ref name="dhq_model.global"/>
-            </choice>
-         </zeroOrMore>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-l-abstractModel-structure-l-in-l-constraint-report-7">
-            <rule context="tei:l">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="ancestor::tei:l[not(.//tei:note//tei:l[. = current()])]">
+            <zeroOrMore>
+              <choice>
+                <ref name="dhq_model.milestoneLike"/>
+              </choice>
+            </zeroOrMore>
+          </group>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.sortable.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_l">
+    <element name="l">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(verse line) contains a single, possibly incomplete, line of verse. [3.13.1. Core Tags for Verse 3.13. Passages of Verse or Drama 7.2.5. Speech Contents]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_model.phrase"/>
+          <ref name="dhq_model.inter"/>
+          <ref name="dhq_model.global"/>
+        </choice>
+      </zeroOrMore>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-l-abstractModel-structure-l-in-l-constraint-report-7">
+        <rule context="tei:l">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="ancestor::tei:l[not(.//tei:note//tei:l[. = current()])]">
         Abstract model violation: Lines may not contain lines or lg elements.
       </sch:report>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>indent-1</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 1</a:documentation>
-                  <value>indent-2</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 2</a:documentation>
-                  <value>indent-3</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 3</a:documentation>
-                  <value>indent-4</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 4</a:documentation>
-                  <value>indent-5</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 5</a:documentation>
-                  <value>indent-6</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 6</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_lg">
-      <element name="lg">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line group) contains one or more verse lines functioning as a formal unit, e.g. a stanza, refrain, verse paragraph, etc. [3.13.1. Core Tags for Verse 3.13. Passages of Verse or Drama 7.2.5. Speech Contents]</a:documentation>
-         <group>
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="rend">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>indent-1</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 1</a:documentation>
+            <value>indent-2</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 2</a:documentation>
+            <value>indent-3</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 3</a:documentation>
+            <value>indent-4</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 4</a:documentation>
+            <value>indent-5</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 5</a:documentation>
+            <value>indent-6</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the line is indented by 6</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_lg">
+    <element name="lg">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line group) contains one or more verse lines functioning as a formal unit, e.g. a stanza, refrain, verse paragraph, etc. [3.13.1. Core Tags for Verse 3.13. Passages of Verse or Drama 7.2.5. Speech Contents]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.divTop"/>
+            <ref name="dhq_model.global"/>
+          </choice>
+        </zeroOrMore>
+        <choice>
+          <ref name="dhq_model.lLike"/>
+          <ref name="dhq_model.stageLike"/>
+          <ref name="dhq_model.labelLike"/>
+          <ref name="dhq_lg"/>
+        </choice>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.lLike"/>
+            <ref name="dhq_model.stageLike"/>
+            <ref name="dhq_model.labelLike"/>
+            <ref name="dhq_model.global"/>
+            <ref name="dhq_lg"/>
+          </choice>
+        </zeroOrMore>
+        <zeroOrMore>
+          <group>
+            <ref name="dhq_model.divBottom"/>
             <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.divTop"/>
-                  <ref name="dhq_model.global"/>
-               </choice>
+              <ref name="dhq_model.global"/>
             </zeroOrMore>
-            <choice>
-               <ref name="dhq_model.lLike"/>
-               <ref name="dhq_model.stageLike"/>
-               <ref name="dhq_model.labelLike"/>
-               <ref name="dhq_lg"/>
-            </choice>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.lLike"/>
-                  <ref name="dhq_model.stageLike"/>
-                  <ref name="dhq_model.labelLike"/>
-                  <ref name="dhq_model.global"/>
-                  <ref name="dhq_lg"/>
-               </choice>
-            </zeroOrMore>
-            <zeroOrMore>
-               <group>
-                  <ref name="dhq_model.divBottom"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </zeroOrMore>
-         </group>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-lg-atleast1oflggapl-constraint-assert-5">
-            <rule context="tei:lg">
-               <sch:assert xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="count(descendant::tei:lg|descendant::tei:l|descendant::tei:gap) &gt; 0">An lg element
+          </group>
+        </zeroOrMore>
+      </group>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-lg-atleast1oflggapl-constraint-assert-5">
+        <rule context="tei:lg">
+          <sch:assert xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="count(descendant::tei:lg|descendant::tei:l|descendant::tei:gap) &gt; 0">An lg element
         must contain at least one child l, lg, or gap element.</sch:assert>
-            </rule>
-         </pattern>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-lg-abstractModel-structure-lg-in-l-constraint-report-8">
-            <rule context="tei:lg">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="ancestor::tei:l[not(.//tei:note//tei:lg[. = current()])]">
+        </rule>
+      </pattern>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-lg-abstractModel-structure-lg-in-l-constraint-report-8">
+        <rule context="tei:lg">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="ancestor::tei:l[not(.//tei:note//tei:lg[. = current()])]">
         Abstract model violation: Lines may not contain line groups.
       </sch:report>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_sp">
-      <element name="sp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(speech) contains an individual speech in a performance text, or a passage presented as such in a prose or verse text. [3.13.2. Core Tags for Drama 3.13. Passages of Verse or Drama 7.2.2. Speeches and Speakers]</a:documentation>
-         <group>
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_sp">
+    <element name="sp">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(speech) contains an individual speech in a performance text, or a passage presented as such in a prose or verse text. [3.13.2. Core Tags for Drama 3.13. Passages of Verse or Drama 7.2.2. Speeches and Speakers]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.global"/>
+        </zeroOrMore>
+        <optional>
+          <group>
+            <ref name="dhq_speaker"/>
             <zeroOrMore>
-               <ref name="dhq_model.global"/>
+              <ref name="dhq_model.global"/>
             </zeroOrMore>
-            <optional>
-               <group>
-                  <ref name="dhq_speaker"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </optional>
-            <oneOrMore>
-               <group>
-                  <choice>
-                     <ref name="dhq_lg"/>
-                     <ref name="dhq_model.lLike"/>
-                     <ref name="dhq_model.pLike"/>
-                     <ref name="dhq_model.listLike"/>
-                     <ref name="dhq_model.stageLike"/>
-                     <ref name="dhq_model.attributable"/>
-                  </choice>
-                  <choice>
-                     <zeroOrMore>
-                        <ref name="dhq_model.global"/>
-                     </zeroOrMore>
-                     <ref name="dhq_q"/>
-                  </choice>
-               </group>
-            </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.ascribed.directed.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_speaker">
-      <element name="speaker">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a specialized form of heading or label, giving the name of one or more speakers in a dramatic text or fragment. [3.13.2. Core Tags for Drama]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_stage">
-      <element name="stage">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(stage direction) contains any kind of stage direction within a dramatic text or fragment. [3.13.2. Core Tags for Drama 3.13. Passages of Verse or Drama 7.2.4. Stage Directions]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.ascribed.directed.attributes"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_textLang">
-      <element name="textLang">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text language) describes the languages and writing systems identified within the bibliographic work being described, rather than its description. [3.12.2.4. Imprint, Size of a Document, and Reprint Information 10.6.6. Languages and Writing Systems]</a:documentation>
-         <ref name="dhq_macro.phraseSeq"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="mainLang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(main language) supplies a code which identifies the chief language used in the bibliographic work.</a:documentation>
-               <choice>
-                  <data type="language"/>
-                  <choice>
-                     <value/>
-                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  </choice>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="otherLangs">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(other languages) one or more codes identifying any other languages used in the bibliographic work.</a:documentation>
-               <list>
-                  <zeroOrMore>
-                     <choice>
-                        <data type="language"/>
-                        <choice>
-                           <value/>
-                           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        </choice>
-                     </choice>
-                  </zeroOrMore>
-               </list>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_att.citeStructurePart.attributes">
-      <ref name="dhq_att.citeStructurePart.attribute.use"/>
-   </define>
-   <define name="dhq_att.citeStructurePart.attribute.use">
-      <attribute name="use">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in <code xmlns="http://www.w3.org/1999/xhtml">@match</code>, which will either be a sibling attribute in the case of `&lt;citeStructure&gt;` or on the parent `&lt;citeStructure&gt;` in the case of `&lt;citeData&gt;`.</a:documentation>
-         <text/>
-      </attribute>
-   </define>
-   <define name="dhq_att.patternReplacement.attributes">
-      <ref name="dhq_att.patternReplacement.attribute.matchPattern"/>
-      <ref name="dhq_att.patternReplacement.attribute.replacementPattern"/>
-   </define>
-   <define name="dhq_att.patternReplacement.attribute.matchPattern">
-      <attribute name="matchPattern">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a regular expression against which the values of other attributes can be matched.</a:documentation>
-         <data type="token"/>
-      </attribute>
-   </define>
-   <define name="dhq_att.patternReplacement.attribute.replacementPattern">
-      <attribute name="replacementPattern">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a replacement pattern, that is, the skeleton of a relative or absolute URI containing references to groups in the <code xmlns="http://www.w3.org/1999/xhtml">@matchPattern</code> which, once subpattern substitution has been performed, complete the URI.</a:documentation>
-         <text/>
-      </attribute>
-   </define>
-   <define name="dhq_teiHeader">
-      <element name="teiHeader">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI header) supplies descriptive and declarative metadata associated with a digital resource or set of resources. [2.1.1. The TEI Header and Its Components 15.1. Varieties of Composite Text]</a:documentation>
-         <group>
-            <ref name="dhq_fileDesc"/>
-            <zeroOrMore>
-               <ref name="dhq_model.teiHeaderPart"/>
-            </zeroOrMore>
-            <optional>
-               <ref name="dhq_revisionDesc"/>
-            </optional>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_fileDesc">
-      <element name="fileDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file description) contains a full bibliographic description of an electronic file. [2.2. The File Description 2.1.1. The TEI Header and Its Components]</a:documentation>
-         <group>
-            <group>
-               <ref name="dhq_titleStmt"/>
-               <ref name="dhq_publicationStmt"/>
-            </group>
-            <oneOrMore>
-               <ref name="dhq_sourceDesc"/>
-            </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_titleStmt">
-      <element name="titleStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title statement) groups information about the title of a work and those responsible for its content. [2.2.1. The Title Statement 2.2. The File Description]</a:documentation>
-         <group>
-            <oneOrMore>
-               <ref name="dhq_title"/>
-            </oneOrMore>
-            <zeroOrMore>
-               <ref name="dhq_model.respLike"/>
-            </zeroOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_sponsor">
-      <element name="sponsor">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sponsor) specifies the name of a sponsoring organization or institution. [2.2.1. The Title Statement]</a:documentation>
-         <ref name="dhq_macro.phraseSeq.limited"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.canonical.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_publicationStmt">
-      <element name="publicationStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication statement) groups information concerning the publication or distribution of an electronic or other text. [2.2.4. Publication, Distribution, Licensing, etc. 2.2. The File Description]</a:documentation>
-         <choice>
-            <oneOrMore>
-               <group>
-                  <ref name="dhq_model.publicationStmtPart.agency"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.publicationStmtPart.detail"/>
-                  </zeroOrMore>
-               </group>
-            </oneOrMore>
-            <oneOrMore>
-               <ref name="dhq_model.pLike"/>
-            </oneOrMore>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_idno">
-      <element name="idno">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) supplies any form of identifier used to identify some object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized way. [13.3.1. Basic Principles 2.2.4. Publication, Distribution, Licensing, etc. 2.2.5. The Series Statement 3.12.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
-         <zeroOrMore>
+          </group>
+        </optional>
+        <oneOrMore>
+          <group>
             <choice>
-               <text/>
-               <ref name="dhq_idno"/>
+              <ref name="dhq_lg"/>
+              <ref name="dhq_model.lLike"/>
+              <ref name="dhq_model.pLike"/>
+              <ref name="dhq_model.listLike"/>
+              <ref name="dhq_model.stageLike"/>
+              <ref name="dhq_model.attributable"/>
             </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.sortable.attributes"/>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>DHQarticle-id</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for the DHQ article ID</a:documentation>
-                  <value>volume</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for the volume number</a:documentation>
-                  <value>issue</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for the issue number</a:documentation>
-                  <value>ORCID</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for author ORCID IDs</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_availability">
-      <element name="availability">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(availability) supplies information about the availability of a text, for example any restrictions on its use or distribution, its copyright status, any licence applying to it, etc. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
-         <ref name="dhq_License"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="status">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>CC-BY-ND</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>CC-BY</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>CC0</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_licence">
-      <element name="licence">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a licence or other legal agreement applicable to the text. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_sourceDesc">
-      <element name="sourceDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source description) describes the source(s) from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as "born digital" for a text which has no previous existence. [2.2.7. The Source Description]</a:documentation>
-         <choice>
-            <oneOrMore>
-               <ref name="dhq_model.pLike"/>
-            </oneOrMore>
-            <oneOrMore>
-               <choice>
-                  <ref name="dhq_model.biblLike"/>
-                  <ref name="dhq_model.listLike"/>
-               </choice>
-            </oneOrMore>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_encodingDesc">
-      <element name="encodingDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(encoding description) documents the relationship between an electronic text and the source or sources from which it was derived. [2.3. The Encoding Description 2.1.1. The TEI Header and Its Components]</a:documentation>
-         <oneOrMore>
             <choice>
-               <ref name="dhq_model.encodingDescPart"/>
-               <ref name="dhq_model.pLike"/>
+              <zeroOrMore>
+                <ref name="dhq_model.global"/>
+              </zeroOrMore>
+              <ref name="dhq_q"/>
             </choice>
-         </oneOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_schemaRef">
-      <element name="schemaRef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(schema reference) describes or points to a related customization or schema file [2.3.10. The Schema Specification]</a:documentation>
-         <optional>
-            <ref name="dhq_model.descLike"/>
-         </optional>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.resourced.attributes"/>
-         <optional>
-            <attribute name="key">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the identifier used for the customization or schema</a:documentation>
-               <data type="NCName"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_citeStructure">
-      <element name="citeStructure">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation structure) declares a structure and method for citing the current document. [3.11.4. Declaring Reference Systems 16.2.5.4. Citation Structures]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_citeData"/>
-            </zeroOrMore>
-            <zeroOrMore>
-               <ref name="dhq_citeStructure"/>
-            </zeroOrMore>
-            <zeroOrMore>
-               <ref name="dhq_model.descLike"/>
-            </zeroOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.citeStructurePart.attributes"/>
-         <optional>
-            <attribute name="delim">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(delimiter) supplies a delimiting string preceding the structural component.</a:documentation>
-               <data type="string">
-                  <param name="pattern">.+</param>
-               </data>
-            </attribute>
-         </optional>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-citeStructure-delim-citestructure-inner-delim-constraint-rule-4">
-            <rule xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                  xmlns:xi="http://www.w3.org/2001/XInclude"
-                  context="tei:citeStructure[parent::tei:citeStructure]">
-               <assert test="@delim">A <name/> with a parent <name/> must have a @delim attribute.</assert>
-            </rule>
-         </pattern>
-         <attribute name="match">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. <code xmlns="http://www.w3.org/1999/xhtml">@match</code> on a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> without a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> parent must be an absolute XPath. If it is relative, its context is set by the <code xmlns="http://www.w3.org/1999/xhtml">@match</code> of the parent <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.</a:documentation>
-            <text/>
-         </attribute>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-citeStructure-match-citestructure-outer-match-constraint-rule-5">
-            <rule xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                  xmlns:xi="http://www.w3.org/2001/XInclude"
-                  context="tei:citeStructure[not(parent::tei:citeStructure)]">
-               <assert test="starts-with(@match,'/')">An XPath in @match on the outer <name/> must start with '/'.</assert>
-            </rule>
-         </pattern>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-citeStructure-match-citestructure-inner-match-constraint-rule-6">
-            <rule xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                  xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                  xmlns:xi="http://www.w3.org/2001/XInclude"
-                  context="tei:citeStructure[parent::tei:citeStructure]">
-               <assert test="not(starts-with(@match,'/'))">An XPath in @match must not start with '/' except on the outer <name/>.</assert>
-            </rule>
-         </pattern>
-         <optional>
-            <attribute name="unit">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unit) describes the structural unit indicated by the <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.
-Sample values include: 1] book; 2] chapter; 3] entry; 4] poem; 5] letter; 6] line; 7] section; 8] verse; 9] volume</a:documentation>
-               <data type="token">
-                  <param name="pattern">[^\p{C}\p{Z}]+</param>
-               </data>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_citeData">
-      <element name="citeData">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation data) specifies how information may be extracted from citation structures. [3.11.4. Declaring Reference Systems 16.2.5.4. Citation Structures]</a:documentation>
-         <empty/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.citeStructurePart.attributes"/>
-         <attribute name="property">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(property) A URI indicating a property definition.</a:documentation>
-            <data type="anyURI">
-               <param name="pattern">\S+</param>
-            </data>
-         </attribute>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_prefixDef">
-      <element name="prefixDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(prefix definition) defines a prefixing scheme used in teidata.pointer values, showing how abbreviated URIs using the scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
-         <zeroOrMore>
-            <ref name="dhq_model.pLike"/>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.patternReplacement.attributes"/>
-         <attribute name="ident">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a name which functions as the prefix for an abbreviated pointing scheme such as a private URI scheme. The prefix constitutes the text preceding the first colon.</a:documentation>
-            <data type="token">
-               <param name="pattern">[a-z][a-z0-9\+\.\-]*</param>
-            </data>
-         </attribute>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_listPrefixDef">
-      <element name="listPrefixDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of prefix definitions) contains a list of definitions of prefixing schemes used in teidata.pointer values, showing how abbreviated URIs using each scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_desc"/>
-            </zeroOrMore>
-            <oneOrMore>
-               <choice>
-                  <ref name="dhq_prefixDef"/>
-                  <ref name="dhq_listPrefixDef"/>
-               </choice>
-            </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_classDecl">
-      <element name="classDecl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(classification declarations) contains one or more taxonomies defining any classificatory codes used elsewhere in the text. [2.3.7. The Classification Declaration 2.3. The Encoding Description]</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_taxonomy"/>
-         </oneOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_taxonomy">
-      <element name="taxonomy">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(taxonomy) defines a typology either implicitly, by means of a bibliographic citation, or explicitly by a structured taxonomy. [2.3.7. The Classification Declaration]</a:documentation>
-         <choice>
+          </group>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.ascribed.directed.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_speaker">
+    <element name="speaker">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a specialized form of heading or label, giving the name of one or more speakers in a dramatic text or fragment. [3.13.2. Core Tags for Drama]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_stage">
+    <element name="stage">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(stage direction) contains any kind of stage direction within a dramatic text or fragment. [3.13.2. Core Tags for Drama 3.13. Passages of Verse or Drama 7.2.4. Stage Directions]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.ascribed.directed.attributes"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_textLang">
+    <element name="textLang">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text language) describes the languages and writing systems identified within the bibliographic work being described, rather than its description. [3.12.2.4. Imprint, Size of a Document, and Reprint Information 10.6.6. Languages and Writing Systems]</a:documentation>
+      <ref name="dhq_macro.phraseSeq"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="mainLang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(main language) supplies a code which identifies the chief language used in the bibliographic work.</a:documentation>
+          <choice>
+            <data type="language"/>
             <choice>
-               <oneOrMore>
-                  <choice>
-                     <ref name="dhq_taxonomy"/>
-                  </choice>
-               </oneOrMore>
-               <group>
-                  <oneOrMore>
-                     <choice>
-                        <ref name="dhq_model.descLike"/>
-                     </choice>
-                  </oneOrMore>
-                  <zeroOrMore>
-                     <choice>
-                        <ref name="dhq_taxonomy"/>
-                     </choice>
-                  </zeroOrMore>
-               </group>
+              <value/>
+              <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
             </choice>
-            <group>
-               <ref name="dhq_model.biblLike"/>
-               <zeroOrMore>
-                  <choice>
-                     <ref name="dhq_taxonomy"/>
-                  </choice>
-               </zeroOrMore>
-            </group>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the taxonomy</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_unitDecl">
-      <element name="unitDecl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unit declarations) provides information about units of measurement that are not members of the International System of Units. [2.3.9. The Unit Declaration]</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_unitDef"/>
-         </oneOrMore>
-         <ref name="dhq_att.canonical.attributes"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_unitDef">
-      <element name="unitDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unit definition) contains descriptive information related to a specific unit of measurement. [2.3.9. The Unit Declaration]</a:documentation>
-         <oneOrMore>
-            <choice>
-               <ref name="dhq_model.labelLike"/>
-               <optional>
-                  <ref name="dhq_model.placeNamePart"/>
-               </optional>
-               <optional>
-                  <ref name="dhq_conversion"/>
-               </optional>
-               <optional>
-                  <ref name="dhq_unit"/>
-               </optional>
-            </choice>
-         </oneOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.canonical.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_conversion">
-      <element name="conversion">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines how to calculate one unit of measure in terms of another. [2.3.9. The Unit Declaration]</a:documentation>
-         <empty/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.formula.attributes"/>
-         <ref name="dhq_att.locatable.attributes"/>
-         <attribute name="fromUnit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates a source unit of measure that is to be converted into another unit indicated in <code xmlns="http://www.w3.org/1999/xhtml">@toUnit</code>.</a:documentation>
-            <data type="anyURI">
-               <param name="pattern">\S+</param>
-            </data>
-         </attribute>
-         <attribute name="toUnit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the target unit of measurement for a conversion from a source unit referenced in <code xmlns="http://www.w3.org/1999/xhtml">@fromUnit</code>.</a:documentation>
-            <data type="anyURI">
-               <param name="pattern">\S+</param>
-            </data>
-         </attribute>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_profileDesc">
-      <element name="profileDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text-profile description) provides a detailed description of non-bibliographic aspects of a text, specifically the languages and sublanguages used, the situation in which it was produced, the participants and their setting. [2.4. The Profile Description 2.1.1. The TEI Header and Its Components]</a:documentation>
-         <zeroOrMore>
-            <ref name="dhq_model.profileDescPart"/>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_creation">
-      <element name="creation">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(creation) contains information about the creation of a text. [2.4.1. Creation 2.4. The Profile Description]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_model.limitedPhrase"/>
-               <ref name="dhq_listChange"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_langUsage">
-      <element name="langUsage">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language usage) describes the languages, sublanguages, registers, dialects, etc. represented within a text. [2.4.2. Language Usage 2.4. The Profile Description 15.3.2. Declarable Elements]</a:documentation>
-         <choice>
-            <oneOrMore>
-               <ref name="dhq_model.pLike"/>
-            </oneOrMore>
-            <oneOrMore>
-               <ref name="dhq_language"/>
-            </oneOrMore>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_language">
-      <element name="language">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language) characterizes a single language or sublanguage used within a text. [2.4.2. Language Usage]</a:documentation>
-         <ref name="dhq_macro.phraseSeq.limited"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="extent">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The <code xmlns="http://www.w3.org/1999/xhtml">@extent</code> attribute is used on <code xmlns="http://www.w3.org/1999/xhtml">&lt;language&gt;</code> to indicate the nature of the usage of the language in question: whether it is used for the original article, for a translation stub, or for a full translation.</a:documentation>
-               <choice>
-                  <value>original</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the language is used for the original article</a:documentation>
-                  <value>translation_stub</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the language is used for a translation stub (i.e. a placeholder or incomplete translation)</a:documentation>
-                  <value>translation</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the language is used for a full translation of the article</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <attribute name="ident">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) Supplies a language code constructed as defined in <a xmlns="http://www.w3.org/1999/xhtml"
-                  href="https://tools.ietf.org/html/bcp47">BCP 47</a> which is used to identify the language documented by this element, and which is referenced by the global <code xmlns="http://www.w3.org/1999/xhtml">@xml:lang</code> attribute.</a:documentation>
-            <choice>
-               <data type="language"/>
-               <choice>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="otherLangs">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(other languages) one or more codes identifying any other languages used in the bibliographic work.</a:documentation>
+          <list>
+            <zeroOrMore>
+              <choice>
+                <data type="language"/>
+                <choice>
                   <value/>
                   <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </choice>
-         </attribute>
-         <optional>
-            <attribute name="usage">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the approximate percentage (by volume) of the text which uses this language.</a:documentation>
-               <data type="nonNegativeInteger"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_textClass">
-      <element name="textClass">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text classification) groups information which describes the nature or topic of a text in terms of a standard classification scheme, thesaurus, etc. [2.4.3. The Text Classification]</a:documentation>
-         <zeroOrMore>
+                </choice>
+              </choice>
+            </zeroOrMore>
+          </list>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_att.citeStructurePart.attributes">
+    <ref name="dhq_att.citeStructurePart.attribute.use"/>
+  </define>
+  <define name="dhq_att.citeStructurePart.attribute.use">
+    <attribute name="use">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in <code xmlns="http://www.w3.org/1999/xhtml">@match</code>, which will either be a sibling attribute in the case of `&lt;citeStructure&gt;` or on the parent `&lt;citeStructure&gt;` in the case of `&lt;citeData&gt;`.</a:documentation>
+      <text/>
+    </attribute>
+  </define>
+  <define name="dhq_att.patternReplacement.attributes">
+    <ref name="dhq_att.patternReplacement.attribute.matchPattern"/>
+    <ref name="dhq_att.patternReplacement.attribute.replacementPattern"/>
+  </define>
+  <define name="dhq_att.patternReplacement.attribute.matchPattern">
+    <attribute name="matchPattern">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a regular expression against which the values of other attributes can be matched.</a:documentation>
+      <data type="token"/>
+    </attribute>
+  </define>
+  <define name="dhq_att.patternReplacement.attribute.replacementPattern">
+    <attribute name="replacementPattern">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a replacement pattern, that is, the skeleton of a relative or absolute URI containing references to groups in the <code xmlns="http://www.w3.org/1999/xhtml">@matchPattern</code> which, once subpattern substitution has been performed, complete the URI.</a:documentation>
+      <text/>
+    </attribute>
+  </define>
+  <define name="dhq_teiHeader">
+    <element name="teiHeader">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI header) supplies descriptive and declarative metadata associated with a digital resource or set of resources. [2.1.1. The TEI Header and Its Components 15.1. Varieties of Composite Text]</a:documentation>
+      <group>
+        <ref name="dhq_fileDesc"/>
+        <zeroOrMore>
+          <ref name="dhq_model.teiHeaderPart"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="dhq_revisionDesc"/>
+        </optional>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_fileDesc">
+    <element name="fileDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file description) contains a full bibliographic description of an electronic file. [2.2. The File Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+      <group>
+        <group>
+          <ref name="dhq_titleStmt"/>
+          <ref name="dhq_publicationStmt"/>
+        </group>
+        <oneOrMore>
+          <ref name="dhq_sourceDesc"/>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_titleStmt">
+    <element name="titleStmt">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title statement) groups information about the title of a work and those responsible for its content. [2.2.1. The Title Statement 2.2. The File Description]</a:documentation>
+      <group>
+        <oneOrMore>
+          <ref name="dhq_title"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="dhq_model.respLike"/>
+        </zeroOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_sponsor">
+    <element name="sponsor">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sponsor) specifies the name of a sponsoring organization or institution. [2.2.1. The Title Statement]</a:documentation>
+      <ref name="dhq_macro.phraseSeq.limited"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.canonical.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_publicationStmt">
+    <element name="publicationStmt">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication statement) groups information concerning the publication or distribution of an electronic or other text. [2.2.4. Publication, Distribution, Licensing, etc. 2.2. The File Description]</a:documentation>
+      <choice>
+        <oneOrMore>
+          <group>
+            <ref name="dhq_model.publicationStmtPart.agency"/>
+            <zeroOrMore>
+              <ref name="dhq_model.publicationStmtPart.detail"/>
+            </zeroOrMore>
+          </group>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="dhq_model.pLike"/>
+        </oneOrMore>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_idno">
+    <element name="idno">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) supplies any form of identifier used to identify some object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized way. [13.3.1. Basic Principles 2.2.4. Publication, Distribution, Licensing, etc. 2.2.5. The Series Statement 3.12.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_idno"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.sortable.attributes"/>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>DHQarticle-id</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for the DHQ article ID</a:documentation>
+            <value>volume</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for the volume number</a:documentation>
+            <value>issue</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for the issue number</a:documentation>
+            <value>ORCID</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">used for author ORCID IDs</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_availability">
+    <element name="availability">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(availability) supplies information about the availability of a text, for example any restrictions on its use or distribution, its copyright status, any licence applying to it, etc. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+      <ref name="dhq_License"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="status">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>CC-BY-ND</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>CC-BY</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>CC0</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_licence">
+    <element name="licence">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a licence or other legal agreement applicable to the text. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_sourceDesc">
+    <element name="sourceDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source description) describes the source(s) from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as "born digital" for a text which has no previous existence. [2.2.7. The Source Description]</a:documentation>
+      <choice>
+        <oneOrMore>
+          <ref name="dhq_model.pLike"/>
+        </oneOrMore>
+        <oneOrMore>
+          <choice>
+            <ref name="dhq_model.biblLike"/>
+            <ref name="dhq_model.listLike"/>
+          </choice>
+        </oneOrMore>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_encodingDesc">
+    <element name="encodingDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(encoding description) documents the relationship between an electronic text and the source or sources from which it was derived. [2.3. The Encoding Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+      <oneOrMore>
+        <choice>
+          <ref name="dhq_model.encodingDescPart"/>
+          <ref name="dhq_model.pLike"/>
+        </choice>
+      </oneOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_schemaRef">
+    <element name="schemaRef">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(schema reference) describes or points to a related customization or schema file [2.3.10. The Schema Specification]</a:documentation>
+      <optional>
+        <ref name="dhq_model.descLike"/>
+      </optional>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.resourced.attributes"/>
+      <optional>
+        <attribute name="key">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the identifier used for the customization or schema</a:documentation>
+          <data type="NCName"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_citeStructure">
+    <element name="citeStructure">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation structure) declares a structure and method for citing the current document. [3.11.4. Declaring Reference Systems 16.2.5.4. Citation Structures]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_citeData"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="dhq_citeStructure"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="dhq_model.descLike"/>
+        </zeroOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.citeStructurePart.attributes"/>
+      <optional>
+        <attribute name="delim">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(delimiter) supplies a delimiting string preceding the structural component.</a:documentation>
+          <data type="string">
+            <param name="pattern">.+</param>
+          </data>
+        </attribute>
+      </optional>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-citeStructure-delim-citestructure-inner-delim-constraint-rule-4">
+        <rule xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" context="tei:citeStructure[parent::tei:citeStructure]">
+          <assert test="@delim">A <name/> with a parent <name/> must have a @delim attribute.</assert>
+        </rule>
+      </pattern>
+      <attribute name="match">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. <code xmlns="http://www.w3.org/1999/xhtml">@match</code> on a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> without a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> parent must be an absolute XPath. If it is relative, its context is set by the <code xmlns="http://www.w3.org/1999/xhtml">@match</code> of the parent <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.</a:documentation>
+        <text/>
+      </attribute>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-citeStructure-match-citestructure-outer-match-constraint-rule-5">
+        <rule xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" context="tei:citeStructure[not(parent::tei:citeStructure)]">
+          <assert test="starts-with(@match,'/')">An XPath in @match on the outer <name/> must start with '/'.</assert>
+        </rule>
+      </pattern>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-citeStructure-match-citestructure-inner-match-constraint-rule-6">
+        <rule xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" context="tei:citeStructure[parent::tei:citeStructure]">
+          <assert test="not(starts-with(@match,'/'))">An XPath in @match must not start with '/' except on the outer <name/>.</assert>
+        </rule>
+      </pattern>
+      <optional>
+        <attribute name="unit">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unit) describes the structural unit indicated by the <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.
+Sample values include: 1] book; 2] chapter; 3] entry; 4] poem; 5] letter; 6] line; 7] section; 8] verse; 9] volume</a:documentation>
+          <data type="token">
+            <param name="pattern">[^\p{C}\p{Z}]+</param>
+          </data>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_citeData">
+    <element name="citeData">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation data) specifies how information may be extracted from citation structures. [3.11.4. Declaring Reference Systems 16.2.5.4. Citation Structures]</a:documentation>
+      <empty/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.citeStructurePart.attributes"/>
+      <attribute name="property">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(property) A URI indicating a property definition.</a:documentation>
+        <data type="anyURI">
+          <param name="pattern">\S+</param>
+        </data>
+      </attribute>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_prefixDef">
+    <element name="prefixDef">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(prefix definition) defines a prefixing scheme used in teidata.pointer values, showing how abbreviated URIs using the scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
+      <zeroOrMore>
+        <ref name="dhq_model.pLike"/>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.patternReplacement.attributes"/>
+      <attribute name="ident">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a name which functions as the prefix for an abbreviated pointing scheme such as a private URI scheme. The prefix constitutes the text preceding the first colon.</a:documentation>
+        <data type="token">
+          <param name="pattern">[a-z][a-z0-9\+\.\-]*</param>
+        </data>
+      </attribute>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_listPrefixDef">
+    <element name="listPrefixDef">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of prefix definitions) contains a list of definitions of prefixing schemes used in teidata.pointer values, showing how abbreviated URIs using each scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_desc"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <choice>
+            <ref name="dhq_prefixDef"/>
+            <ref name="dhq_listPrefixDef"/>
+          </choice>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_classDecl">
+    <element name="classDecl">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(classification declarations) contains one or more taxonomies defining any classificatory codes used elsewhere in the text. [2.3.7. The Classification Declaration 2.3. The Encoding Description]</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_taxonomy"/>
+      </oneOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_taxonomy">
+    <element name="taxonomy">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(taxonomy) defines a typology either implicitly, by means of a bibliographic citation, or explicitly by a structured taxonomy. [2.3.7. The Classification Declaration]</a:documentation>
+      <choice>
+        <choice>
+          <oneOrMore>
             <choice>
-               <ref name="dhq_keywords"/>
+              <ref name="dhq_taxonomy"/>
             </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_keywords">
-      <element name="keywords">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(keywords) contains a list of keywords or phrases identifying the topic or nature of a text. [2.4.3. The Text Classification]</a:documentation>
-         <choice>
+          </oneOrMore>
+          <group>
             <oneOrMore>
-               <ref name="dhq_term"/>
+              <choice>
+                <ref name="dhq_model.descLike"/>
+              </choice>
             </oneOrMore>
-            <ref name="dhq_list"/>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="scheme">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the controlled vocabulary within which the set of keywords concerned is defined, for example by a <code xmlns="http://www.w3.org/1999/xhtml">&lt;taxonomy&gt;</code> element, or by some other resource.</a:documentation>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_calendarDesc">
-      <element name="calendarDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(calendar description) contains a description of the calendar system used in any dating expression found in the text. [2.4. The Profile Description 2.4.5. Calendar Description]</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_calendar"/>
-         </oneOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_calendar">
-      <element name="calendar">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(calendar) describes a calendar or dating system used in a dating formula in the text. [2.4.5. Calendar Description]</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_model.pLike"/>
-         </oneOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_correspDesc">
-      <element name="correspDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence
+            <zeroOrMore>
+              <choice>
+                <ref name="dhq_taxonomy"/>
+              </choice>
+            </zeroOrMore>
+          </group>
+        </choice>
+        <group>
+          <ref name="dhq_model.biblLike"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="dhq_taxonomy"/>
+            </choice>
+          </zeroOrMore>
+        </group>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the taxonomy</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_unitDecl">
+    <element name="unitDecl">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unit declarations) provides information about units of measurement that are not members of the International System of Units. [2.3.9. The Unit Declaration]</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_unitDef"/>
+      </oneOrMore>
+      <ref name="dhq_att.canonical.attributes"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_unitDef">
+    <element name="unitDef">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unit definition) contains descriptive information related to a specific unit of measurement. [2.3.9. The Unit Declaration]</a:documentation>
+      <oneOrMore>
+        <choice>
+          <ref name="dhq_model.labelLike"/>
+          <optional>
+            <ref name="dhq_model.placeNamePart"/>
+          </optional>
+          <optional>
+            <ref name="dhq_conversion"/>
+          </optional>
+          <optional>
+            <ref name="dhq_unit"/>
+          </optional>
+        </choice>
+      </oneOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.canonical.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_conversion">
+    <element name="conversion">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines how to calculate one unit of measure in terms of another. [2.3.9. The Unit Declaration]</a:documentation>
+      <empty/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.formula.attributes"/>
+      <ref name="dhq_att.locatable.attributes"/>
+      <attribute name="fromUnit">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates a source unit of measure that is to be converted into another unit indicated in <code xmlns="http://www.w3.org/1999/xhtml">@toUnit</code>.</a:documentation>
+        <data type="anyURI">
+          <param name="pattern">\S+</param>
+        </data>
+      </attribute>
+      <attribute name="toUnit">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the target unit of measurement for a conversion from a source unit referenced in <code xmlns="http://www.w3.org/1999/xhtml">@fromUnit</code>.</a:documentation>
+        <data type="anyURI">
+          <param name="pattern">\S+</param>
+        </data>
+      </attribute>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_profileDesc">
+    <element name="profileDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text-profile description) provides a detailed description of non-bibliographic aspects of a text, specifically the languages and sublanguages used, the situation in which it was produced, the participants and their setting. [2.4. The Profile Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+      <zeroOrMore>
+        <ref name="dhq_model.profileDescPart"/>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_creation">
+    <element name="creation">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(creation) contains information about the creation of a text. [2.4.1. Creation 2.4. The Profile Description]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_model.limitedPhrase"/>
+          <ref name="dhq_listChange"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_langUsage">
+    <element name="langUsage">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language usage) describes the languages, sublanguages, registers, dialects, etc. represented within a text. [2.4.2. Language Usage 2.4. The Profile Description 15.3.2. Declarable Elements]</a:documentation>
+      <choice>
+        <oneOrMore>
+          <ref name="dhq_model.pLike"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="dhq_language"/>
+        </oneOrMore>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_language">
+    <element name="language">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language) characterizes a single language or sublanguage used within a text. [2.4.2. Language Usage]</a:documentation>
+      <ref name="dhq_macro.phraseSeq.limited"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="extent">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The <code xmlns="http://www.w3.org/1999/xhtml">@extent</code> attribute is used on <code xmlns="http://www.w3.org/1999/xhtml">&lt;language&gt;</code> to indicate the nature of the usage of the language in question: whether it is used for the original article, for a translation stub, or for a full translation.</a:documentation>
+          <choice>
+            <value>original</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the language is used for the original article</a:documentation>
+            <value>translation_stub</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the language is used for a translation stub (i.e. a placeholder or incomplete translation)</a:documentation>
+            <value>translation</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the language is used for a full translation of the article</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <attribute name="ident">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) Supplies a language code constructed as defined in <a xmlns="http://www.w3.org/1999/xhtml" href="https://tools.ietf.org/html/bcp47">BCP 47</a> which is used to identify the language documented by this element, and which is referenced by the global <code xmlns="http://www.w3.org/1999/xhtml">@xml:lang</code> attribute.</a:documentation>
+        <choice>
+          <data type="language"/>
+          <choice>
+            <value/>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="usage">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the approximate percentage (by volume) of the text which uses this language.</a:documentation>
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_textClass">
+    <element name="textClass">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text classification) groups information which describes the nature or topic of a text in terms of a standard classification scheme, thesaurus, etc. [2.4.3. The Text Classification]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <ref name="dhq_keywords"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_keywords">
+    <element name="keywords">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(keywords) contains a list of keywords or phrases identifying the topic or nature of a text. [2.4.3. The Text Classification]</a:documentation>
+      <choice>
+        <oneOrMore>
+          <ref name="dhq_term"/>
+        </oneOrMore>
+        <ref name="dhq_list"/>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="scheme">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the controlled vocabulary within which the set of keywords concerned is defined, for example by a <code xmlns="http://www.w3.org/1999/xhtml">&lt;taxonomy&gt;</code> element, or by some other resource.</a:documentation>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_calendarDesc">
+    <element name="calendarDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(calendar description) contains a description of the calendar system used in any dating expression found in the text. [2.4. The Profile Description 2.4.5. Calendar Description]</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_calendar"/>
+      </oneOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_calendar">
+    <element name="calendar">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(calendar) describes a calendar or dating system used in a dating formula in the text. [2.4.5. Calendar Description]</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_model.pLike"/>
+      </oneOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_correspDesc">
+    <element name="correspDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence
     description) contains a description of the actions related to one act of correspondence. [2.4.6. Correspondence Description]</a:documentation>
-         <choice>
+      <choice>
+        <oneOrMore>
+          <ref name="dhq_model.correspDescPart"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="dhq_model.pLike"/>
+        </oneOrMore>
+      </choice>
+      <ref name="dhq_att.canonical.attributes"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_correspAction">
+    <element name="correspAction">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence action) contains a structured description of the place, the name of a person/organization and the date related to the sending/receiving of a message or any other action related to the correspondence. [2.4.6. Correspondence Description]</a:documentation>
+      <choice>
+        <oneOrMore>
+          <ref name="dhq_model.correspActionPart"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="dhq_model.pLike"/>
+        </oneOrMore>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.sortable.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_correspContext">
+    <element name="correspContext">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence context) provides references to preceding or following correspondence related to this piece of correspondence. [2.4.6. Correspondence Description]</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_model.correspContextPart"/>
+      </oneOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_xenoData">
+    <element name="xenoData">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]</a:documentation>
+      <choice>
+        <text/>
+        <ref name="anyElement-xenoData"/>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>embed_map</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>embed_audio</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>embed_video</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>embed_3d</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="subtype">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>soundcloud</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>google</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_revisionDesc">
+    <element name="revisionDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(revision description) summarizes the revision history for a file. [2.6. The Revision Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+      <choice>
+        <ref name="dhq_list"/>
+        <ref name="dhq_listChange"/>
+        <oneOrMore>
+          <ref name="dhq_change"/>
+        </oneOrMore>
+      </choice>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.docStatus.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_change">
+    <element name="change">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(change) documents a change or set of changes made during the production of a source document, or during the revision of an electronic file. [2.6. The Revision Description 2.4.1. Creation 11.7. Identifying Changes and Revisions]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.ascribed.attributes"/>
+      <ref name="dhq_att.docStatus.attributes"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="when">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a date in regularized format.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="target">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(target) points to one or more elements that belong to this change.</a:documentation>
+          <list>
             <oneOrMore>
-               <ref name="dhq_model.correspDescPart"/>
+              <data type="anyURI">
+                <param name="pattern">\S+</param>
+              </data>
             </oneOrMore>
-            <oneOrMore>
-               <ref name="dhq_model.pLike"/>
-            </oneOrMore>
-         </choice>
-         <ref name="dhq_att.canonical.attributes"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_correspAction">
-      <element name="correspAction">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence action) contains a structured description of the place, the name of a person/organization and the date related to the sending/receiving of a message or any other action related to the correspondence. [2.4.6. Correspondence Description]</a:documentation>
-         <choice>
-            <oneOrMore>
-               <ref name="dhq_model.correspActionPart"/>
-            </oneOrMore>
-            <oneOrMore>
-               <ref name="dhq_model.pLike"/>
-            </oneOrMore>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.sortable.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_correspContext">
-      <element name="correspContext">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence context) provides references to preceding or following correspondence related to this piece of correspondence. [2.4.6. Correspondence Description]</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_model.correspContextPart"/>
-         </oneOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_xenoData">
-      <element name="xenoData">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]</a:documentation>
-         <choice>
-            <text/>
-            <ref name="anyElement-xenoData"/>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>embed_map</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>embed_audio</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>embed_video</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>embed_3d</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="subtype">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>soundcloud</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>google</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_revisionDesc">
-      <element name="revisionDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(revision description) summarizes the revision history for a file. [2.6. The Revision Description 2.1.1. The TEI Header and Its Components]</a:documentation>
-         <choice>
-            <ref name="dhq_list"/>
+          </list>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_listChange">
+    <element name="listChange">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups a number of change descriptions associated with either the creation of a source text or the revision of an encoded text. [2.6. The Revision Description 11.7. Identifying Changes and Revisions]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_desc"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <choice>
             <ref name="dhq_listChange"/>
+            <ref name="dhq_change"/>
+          </choice>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.sortable.attributes"/>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="ordered" a:defaultValue="true">
+          <a:documentation>indicates whether the ordering of its child <code xmlns="http://www.w3.org/1999/xhtml">&lt;change&gt;</code> elements is to be considered significant or not</a:documentation>
+          <data type="boolean"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_TEI">
+    <element name="TEI">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI document) contains a single TEI-conformant document, combining a single TEI header with one or more members of the model.resource class. Multiple <code xmlns="http://www.w3.org/1999/xhtml">&lt;TEI&gt;</code> elements may be combined within a <code xmlns="http://www.w3.org/1999/xhtml">&lt;TEI&gt;</code> (or <code xmlns="http://www.w3.org/1999/xhtml">&lt;teiCorpus&gt;</code>) element. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
+      <group>
+        <ref name="dhq_teiHeader"/>
+        <choice>
+          <group>
             <oneOrMore>
-               <ref name="dhq_change"/>
+              <ref name="dhq_model.resource"/>
             </oneOrMore>
-         </choice>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.docStatus.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_change">
-      <element name="change">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(change) documents a change or set of changes made during the production of a source document, or during the revision of an electronic file. [2.6. The Revision Description 2.4.1. Creation 11.7. Identifying Changes and Revisions]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.ascribed.attributes"/>
-         <ref name="dhq_att.docStatus.attributes"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="when">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a date in regularized format.</a:documentation>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="target">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(target) points to one or more elements that belong to this change.</a:documentation>
-               <list>
-                  <oneOrMore>
-                     <data type="anyURI">
-                        <param name="pattern">\S+</param>
-                     </data>
-                  </oneOrMore>
-               </list>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_listChange">
-      <element name="listChange">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups a number of change descriptions associated with either the creation of a source text or the revision of an encoded text. [2.6. The Revision Description 11.7. Identifying Changes and Revisions]</a:documentation>
-         <group>
             <zeroOrMore>
-               <ref name="dhq_desc"/>
+              <ref name="dhq_TEI"/>
             </zeroOrMore>
+          </group>
+          <oneOrMore>
+            <ref name="dhq_TEI"/>
+          </oneOrMore>
+        </choice>
+      </group>
+      <sch:ns xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+      <sch:ns xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+      <sch:ns xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_text">
+    <element name="text">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text) contains a single text of any kind, whether unitary or composite, for example a poem or drama, a collection of essays, a novel, a dictionary, or a corpus sample. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.global"/>
+        </zeroOrMore>
+        <optional>
+          <group>
+            <ref name="dhq_front"/>
+            <zeroOrMore>
+              <ref name="dhq_model.global"/>
+            </zeroOrMore>
+          </group>
+        </optional>
+        <choice>
+          <ref name="dhq_body"/>
+          <ref name="dhq_group"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="dhq_model.global"/>
+        </zeroOrMore>
+        <optional>
+          <group>
+            <ref name="dhq_back"/>
+            <zeroOrMore>
+              <ref name="dhq_model.global"/>
+            </zeroOrMore>
+          </group>
+        </optional>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="resp">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the agent responsible for the content of the <code xmlns="http://www.w3.org/1999/xhtml">&lt;text&gt;</code> element</a:documentation>
+          <list>
             <oneOrMore>
-               <choice>
-                  <ref name="dhq_listChange"/>
-                  <ref name="dhq_change"/>
-               </choice>
+              <data type="anyURI">
+                <param name="pattern">\S+</param>
+              </data>
             </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.sortable.attributes"/>
-         <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                       name="ordered"
-                       a:defaultValue="true">
-               <a:documentation>indicates whether the ordering of its child <code xmlns="http://www.w3.org/1999/xhtml">&lt;change&gt;</code> elements is to be considered significant or not</a:documentation>
-               <data type="boolean"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_TEI">
-      <element name="TEI">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI document) contains a single TEI-conformant document, combining a single TEI header with one or more members of the model.resource class. Multiple <code xmlns="http://www.w3.org/1999/xhtml">&lt;TEI&gt;</code> elements may be combined within a <code xmlns="http://www.w3.org/1999/xhtml">&lt;TEI&gt;</code> (or <code xmlns="http://www.w3.org/1999/xhtml">&lt;teiCorpus&gt;</code>) element. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
-         <group>
-            <ref name="dhq_teiHeader"/>
-            <choice>
-               <group>
-                  <oneOrMore>
-                     <ref name="dhq_model.resource"/>
-                  </oneOrMore>
-                  <zeroOrMore>
-                     <ref name="dhq_TEI"/>
-                  </zeroOrMore>
-               </group>
-               <oneOrMore>
-                  <ref name="dhq_TEI"/>
-               </oneOrMore>
-            </choice>
-         </group>
-         <sch:ns xmlns="http://www.tei-c.org/ns/1.0"
-                 xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                 xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                 prefix="tei"
-                 uri="http://www.tei-c.org/ns/1.0"/>
-         <sch:ns xmlns="http://www.tei-c.org/ns/1.0"
-                 xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                 xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                 prefix="xs"
-                 uri="http://www.w3.org/2001/XMLSchema"/>
-         <sch:ns xmlns="http://www.tei-c.org/ns/1.0"
-                 xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                 xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                 prefix="rng"
-                 uri="http://relaxng.org/ns/structure/1.0"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_text">
-      <element name="text">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text) contains a single text of any kind, whether unitary or composite, for example a poem or drama, a collection of essays, a novel, a dictionary, or a corpus sample. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
-         <group>
+          </list>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies whether the text is in the language of its original authorship, or is a full translation, or is a stub translation (i.e. abstract only)</a:documentation>
+          <choice>
+            <value>original</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text is in the language of its original authorship</a:documentation>
+            <value>translation</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text is a full translation of the originally authored article</a:documentation>
+            <value>translation_stub</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text is a stub or partial translation</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_body">
+    <element name="body">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text body) contains the whole body of a single unitary text, excluding any front or back matter. [4. Default Text Structure]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.global"/>
+        </zeroOrMore>
+        <optional>
+          <group>
+            <ref name="dhq_model.divTop"/>
             <zeroOrMore>
-               <ref name="dhq_model.global"/>
+              <choice>
+                <ref name="dhq_model.global"/>
+                <ref name="dhq_model.divTop"/>
+              </choice>
             </zeroOrMore>
-            <optional>
-               <group>
-                  <ref name="dhq_front"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </optional>
-            <choice>
-               <ref name="dhq_body"/>
-               <ref name="dhq_group"/>
-            </choice>
-            <zeroOrMore>
-               <ref name="dhq_model.global"/>
-            </zeroOrMore>
-            <optional>
-               <group>
-                  <ref name="dhq_back"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </optional>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="resp">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the agent responsible for the content of the <code xmlns="http://www.w3.org/1999/xhtml">&lt;text&gt;</code> element</a:documentation>
-               <list>
-                  <oneOrMore>
-                     <data type="anyURI">
-                        <param name="pattern">\S+</param>
-                     </data>
-                  </oneOrMore>
-               </list>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies whether the text is in the language of its original authorship, or is a full translation, or is a stub translation (i.e. abstract only)</a:documentation>
-               <choice>
-                  <value>original</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text is in the language of its original authorship</a:documentation>
-                  <value>translation</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text is a full translation of the originally authored article</a:documentation>
-                  <value>translation_stub</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text is a stub or partial translation</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_body">
-      <element name="body">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text body) contains the whole body of a single unitary text, excluding any front or back matter. [4. Default Text Structure]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_model.global"/>
-            </zeroOrMore>
-            <optional>
-               <group>
-                  <ref name="dhq_model.divTop"/>
-                  <zeroOrMore>
-                     <choice>
-                        <ref name="dhq_model.global"/>
-                        <ref name="dhq_model.divTop"/>
-                     </choice>
-                  </zeroOrMore>
-               </group>
-            </optional>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.global"/>
-               </choice>
-            </zeroOrMore>
-            <choice>
-               <oneOrMore>
-                  <group>
-                     <ref name="dhq_model.divLike"/>
-                     <zeroOrMore>
-                        <choice>
-                           <ref name="dhq_model.global"/>
-                        </choice>
-                     </zeroOrMore>
-                  </group>
-               </oneOrMore>
-               <zeroOrMore>
-                  <choice>
-                     <ref name="dhq_model.global"/>
-                  </choice>
-               </zeroOrMore>
-               <group>
-                  <oneOrMore>
-                     <group>
-                        <choice>
-                           <ref name="dhq_model.common"/>
-                        </choice>
-                        <zeroOrMore>
-                           <ref name="dhq_model.global"/>
-                        </zeroOrMore>
-                     </group>
-                  </oneOrMore>
-                  <optional>
-                     <choice>
-                        <oneOrMore>
-                           <group>
-                              <ref name="dhq_model.divLike"/>
-                              <zeroOrMore>
-                                 <choice>
-                                    <ref name="dhq_model.global"/>
-                                 </choice>
-                              </zeroOrMore>
-                           </group>
-                        </oneOrMore>
-                        <zeroOrMore>
-                           <choice>
-                              <ref name="dhq_model.global"/>
-                           </choice>
-                        </zeroOrMore>
-                     </choice>
-                  </optional>
-               </group>
-            </choice>
-            <zeroOrMore>
-               <group>
-                  <ref name="dhq_model.divBottom"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </zeroOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_group">
-      <element name="group">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(group) contains the body of a composite text, grouping together a sequence of distinct texts (or groups of such texts) which are regarded as a unit for some purpose, for example the collected works of an author, a sequence of prose essays, etc. [4. Default Text Structure 4.3.1. Grouped Texts 15.1. Varieties of Composite Text]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.divTop"/>
-                  <ref name="dhq_model.global"/>
-               </choice>
-            </zeroOrMore>
+          </group>
+        </optional>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.global"/>
+          </choice>
+        </zeroOrMore>
+        <choice>
+          <oneOrMore>
             <group>
-               <choice>
-                  <ref name="dhq_text"/>
-                  <ref name="dhq_group"/>
-               </choice>
-               <zeroOrMore>
-                  <choice>
-                     <ref name="dhq_text"/>
-                     <ref name="dhq_group"/>
-                     <ref name="dhq_model.global"/>
-                  </choice>
-               </zeroOrMore>
+              <ref name="dhq_model.divLike"/>
+              <zeroOrMore>
+                <choice>
+                  <ref name="dhq_model.global"/>
+                </choice>
+              </zeroOrMore>
             </group>
-            <zeroOrMore>
-               <ref name="dhq_model.divBottom"/>
-            </zeroOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_floatingText">
-      <element name="floatingText">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(floating text) contains a single text of any kind, whether unitary or composite, which interrupts the text containing it at any point and after which the surrounding text resumes. [4.3.2. Floating Texts]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_model.global"/>
-            </zeroOrMore>
-            <optional>
-               <group>
-                  <ref name="dhq_front"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </optional>
+          </oneOrMore>
+          <zeroOrMore>
             <choice>
-               <ref name="dhq_body"/>
-               <ref name="dhq_group"/>
+              <ref name="dhq_model.global"/>
+            </choice>
+          </zeroOrMore>
+          <group>
+            <oneOrMore>
+              <group>
+                <choice>
+                  <ref name="dhq_model.common"/>
+                </choice>
+                <zeroOrMore>
+                  <ref name="dhq_model.global"/>
+                </zeroOrMore>
+              </group>
+            </oneOrMore>
+            <optional>
+              <choice>
+                <oneOrMore>
+                  <group>
+                    <ref name="dhq_model.divLike"/>
+                    <zeroOrMore>
+                      <choice>
+                        <ref name="dhq_model.global"/>
+                      </choice>
+                    </zeroOrMore>
+                  </group>
+                </oneOrMore>
+                <zeroOrMore>
+                  <choice>
+                    <ref name="dhq_model.global"/>
+                  </choice>
+                </zeroOrMore>
+              </choice>
+            </optional>
+          </group>
+        </choice>
+        <zeroOrMore>
+          <group>
+            <ref name="dhq_model.divBottom"/>
+            <zeroOrMore>
+              <ref name="dhq_model.global"/>
+            </zeroOrMore>
+          </group>
+        </zeroOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_group">
+    <element name="group">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(group) contains the body of a composite text, grouping together a sequence of distinct texts (or groups of such texts) which are regarded as a unit for some purpose, for example the collected works of an author, a sequence of prose essays, etc. [4. Default Text Structure 4.3.1. Grouped Texts 15.1. Varieties of Composite Text]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.divTop"/>
+            <ref name="dhq_model.global"/>
+          </choice>
+        </zeroOrMore>
+        <group>
+          <choice>
+            <ref name="dhq_text"/>
+            <ref name="dhq_group"/>
+          </choice>
+          <zeroOrMore>
+            <choice>
+              <ref name="dhq_text"/>
+              <ref name="dhq_group"/>
+              <ref name="dhq_model.global"/>
+            </choice>
+          </zeroOrMore>
+        </group>
+        <zeroOrMore>
+          <ref name="dhq_model.divBottom"/>
+        </zeroOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_floatingText">
+    <element name="floatingText">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(floating text) contains a single text of any kind, whether unitary or composite, which interrupts the text containing it at any point and after which the surrounding text resumes. [4.3.2. Floating Texts]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.global"/>
+        </zeroOrMore>
+        <optional>
+          <group>
+            <ref name="dhq_front"/>
+            <zeroOrMore>
+              <ref name="dhq_model.global"/>
+            </zeroOrMore>
+          </group>
+        </optional>
+        <choice>
+          <ref name="dhq_body"/>
+          <ref name="dhq_group"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="dhq_model.global"/>
+        </zeroOrMore>
+        <optional>
+          <group>
+            <ref name="dhq_back"/>
+            <zeroOrMore>
+              <ref name="dhq_model.global"/>
+            </zeroOrMore>
+          </group>
+        </optional>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_div">
+    <element name="div">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text division) contains a subdivision of the front, body, or back of a text. [4.1. Divisions of the Body]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.divTop"/>
+            <ref name="dhq_model.global"/>
+          </choice>
+        </zeroOrMore>
+        <optional>
+          <group>
+            <choice>
+              <oneOrMore>
+                <group>
+                  <choice>
+                    <ref name="dhq_model.divLike"/>
+                  </choice>
+                  <zeroOrMore>
+                    <ref name="dhq_model.global"/>
+                  </zeroOrMore>
+                </group>
+              </oneOrMore>
+              <group>
+                <oneOrMore>
+                  <group>
+                    <choice>
+                      <ref name="dhq_model.common"/>
+                    </choice>
+                    <zeroOrMore>
+                      <ref name="dhq_model.global"/>
+                    </zeroOrMore>
+                  </group>
+                </oneOrMore>
+                <zeroOrMore>
+                  <group>
+                    <choice>
+                      <ref name="dhq_model.divLike"/>
+                    </choice>
+                    <zeroOrMore>
+                      <ref name="dhq_model.global"/>
+                    </zeroOrMore>
+                  </group>
+                </zeroOrMore>
+              </group>
             </choice>
             <zeroOrMore>
-               <ref name="dhq_model.global"/>
-            </zeroOrMore>
-            <optional>
-               <group>
-                  <ref name="dhq_back"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </optional>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_div">
-      <element name="div">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text division) contains a subdivision of the front, body, or back of a text. [4.1. Divisions of the Body]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.divTop"/>
+              <group>
+                <ref name="dhq_model.divBottom"/>
+                <zeroOrMore>
                   <ref name="dhq_model.global"/>
-               </choice>
+                </zeroOrMore>
+              </group>
             </zeroOrMore>
-            <optional>
-               <group>
-                  <choice>
-                     <oneOrMore>
-                        <group>
-                           <choice>
-                              <ref name="dhq_model.divLike"/>
-                           </choice>
-                           <zeroOrMore>
-                              <ref name="dhq_model.global"/>
-                           </zeroOrMore>
-                        </group>
-                     </oneOrMore>
-                     <group>
-                        <oneOrMore>
-                           <group>
-                              <choice>
-                                 <ref name="dhq_model.common"/>
-                              </choice>
-                              <zeroOrMore>
-                                 <ref name="dhq_model.global"/>
-                              </zeroOrMore>
-                           </group>
-                        </oneOrMore>
-                        <zeroOrMore>
-                           <group>
-                              <choice>
-                                 <ref name="dhq_model.divLike"/>
-                              </choice>
-                              <zeroOrMore>
-                                 <ref name="dhq_model.global"/>
-                              </zeroOrMore>
-                           </group>
-                        </zeroOrMore>
-                     </group>
-                  </choice>
-                  <zeroOrMore>
-                     <group>
-                        <ref name="dhq_model.divBottom"/>
-                        <zeroOrMore>
-                           <ref name="dhq_model.global"/>
-                        </zeroOrMore>
-                     </group>
-                  </zeroOrMore>
-               </group>
-            </optional>
-         </group>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-div-abstractModel-structure-div-in-l-or-lg-constraint-report-9">
-            <rule context="tei:div">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="(ancestor::tei:l or ancestor::tei:lg) and not(ancestor::tei:floatingText)">
+          </group>
+        </optional>
+      </group>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-div-abstractModel-structure-div-in-l-or-lg-constraint-report-9">
+        <rule context="tei:div">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="(ancestor::tei:l or ancestor::tei:lg) and not(ancestor::tei:floatingText)">
         Abstract model violation: Lines may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.
       </sch:report>
-            </rule>
-         </pattern>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-div-abstractModel-structure-div-in-ab-or-p-constraint-report-10">
-            <rule context="tei:div">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           test="(ancestor::tei:p or ancestor::tei:ab) and not(ancestor::tei:floatingText)">
+        </rule>
+      </pattern>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-div-abstractModel-structure-div-in-ab-or-p-constraint-report-10">
+        <rule context="tei:div">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="(ancestor::tei:p or ancestor::tei:ab) and not(ancestor::tei:floatingText)">
         Abstract model violation: p and ab may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.
       </sch:report>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the division.</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>appendix</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_trailer">
-      <element name="trailer">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a closing title or footer appearing at the end of a division of a text. [4.2.4. Content of Textual Divisions 4.2. Elements Common to All Divisions]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_lg"/>
-               <ref name="dhq_model.phrase"/>
-               <ref name="dhq_model.inter"/>
-               <ref name="dhq_model.lLike"/>
-               <ref name="dhq_model.global"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_dateline">
-      <element name="dateline">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(dateline) contains a brief description of the place, date, time, etc. of production of a letter, newspaper story, or other work, prefixed or suffixed to it as a kind of heading or trailer. [4.2.2. Openers and Closers]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_model.phrase"/>
-               <ref name="dhq_model.global"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_epigraph">
-      <element name="epigraph">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(epigraph) contains a quotation, anonymous or attributed, appearing at the start or end of a section or on a title page. [4.2.3. Arguments, Epigraphs, and Postscripts 4.2. Elements Common to All Divisions 4.6. Title Pages]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <ref name="dhq_model.common"/>
-               <ref name="dhq_model.global"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of the quoted material, whether inline or set as a block.</a:documentation>
-               <choice>
-                  <value>center</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates a block quotation, typically containing one or more paragraphs or other chunky things, with the block and text centered. </a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_salute">
-      <element name="salute">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(salutation) contains a salutation or greeting prefixed to a foreword, dedicatory epistle, or other division of a text, or the salutation in the closing of a letter, preface, etc. [4.2.2. Openers and Closers]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_signed">
-      <element name="signed">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(signature) contains the closing salutation, etc., appended to a foreword, dedicatory epistle, or other division of a text. [4.2.2. Openers and Closers]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_postscript">
-      <element name="postscript">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a postscript, e.g. to a letter. [4.2. Elements Common to All Divisions]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.global"/>
-                  <ref name="dhq_model.divTopPart"/>
-               </choice>
-            </zeroOrMore>
-            <ref name="dhq_model.common"/>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_model.global"/>
-                  <ref name="dhq_model.common"/>
-               </choice>
-            </zeroOrMore>
-            <zeroOrMore>
-               <group>
-                  <ref name="dhq_model.divBottomPart"/>
-                  <zeroOrMore>
-                     <ref name="dhq_model.global"/>
-                  </zeroOrMore>
-               </group>
-            </zeroOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_front">
-      <element name="front">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The front matter consists of an abstract followed by a teaser.</a:documentation>
-         <group>
-            <oneOrMore>
-               <ref name="dhq_abstract"/>
-            </oneOrMore>
-            <oneOrMore>
-               <ref name="dhq_teaser"/>
-            </oneOrMore>
-         </group>
-      </element>
-   </define>
-   <define name="dhq_back">
-      <element name="back">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-         <optional>
-            <ref name="dhq_listBibl"/>
-         </optional>
-      </element>
-   </define>
-   <define name="dhq_att.tableDecoration.attribute.rows">
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                    name="rows"
-                    a:defaultValue="1">
-            <a:documentation>(rows) indicates the number of rows occupied by this cell or row.</a:documentation>
-            <data type="nonNegativeInteger"/>
-         </attribute>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the division.</a:documentation>
+          <data type="ID"/>
+        </attribute>
       </optional>
-   </define>
-   <define name="dhq_att.tableDecoration.attribute.cols">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                    name="cols"
-                    a:defaultValue="1">
-            <a:documentation>(columns) indicates the number of columns occupied by this cell or row.</a:documentation>
-            <data type="nonNegativeInteger"/>
-         </attribute>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
       </optional>
-   </define>
-   <define name="dhq_table">
-      <element name="table">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table) contains text displayed in tabular form, in rows and columns. [14.1.1. TEI Tables]</a:documentation>
-         <group>
-            <optional>
-               <ref name="dhq_head"/>
-            </optional>
-            <oneOrMore>
-               <ref name="dhq_row"/>
-            </oneOrMore>
-            <optional>
-               <ref name="dhq_caption"/>
-            </optional>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the table</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>unbordered</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="rows">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rows) indicates the number of rows in the table.</a:documentation>
-               <data type="nonNegativeInteger"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="cols">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(columns) indicates the number of columns in each row of the table.</a:documentation>
-               <data type="nonNegativeInteger"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_row">
-      <element name="row">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(row) contains one row of a table. [14.1.1. TEI Tables]</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_cell"/>
-         </oneOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.tableDecoration.attribute.rows"/>
-         <ref name="dhq_att.tableDecoration.attribute.cols"/>
-         <optional>
-            <attribute name="role">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the role of the table row</a:documentation>
-               <choice>
-                  <value>label</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell serves as a label (otherwise is assumed to be data)</a:documentation>
-                  <value>data</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell contains data (default value)</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_cell">
-      <element name="cell">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cell) contains one cell of a table. [14.1.1. TEI Tables]</a:documentation>
-         <ref name="dhq_macro.specialPara"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.tableDecoration.attribute.rows"/>
-         <ref name="dhq_att.tableDecoration.attribute.cols"/>
-         <optional>
-            <attribute name="role">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the role of the table cell</a:documentation>
-               <choice>
-                  <value>label</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell serves as a label (otherwise is assumed to be data)</a:documentation>
-                  <value>data</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell contains data (default value)</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_formula">
-      <element name="formula">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(formula) contains a mathematical or other formula. [14.2. Formulæ and Mathematical Expressions]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_note"/>
-               <ref name="m_math"/>
-               <ref name="dhq_model.graphicLike"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="notation">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">names the notation used for the content of the element.</a:documentation>
-               <choice>
-                  <value>asciimath</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>tex</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>mathml</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>inline</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                  <value>block</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the formula</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_notatedMusic">
-      <element name="notatedMusic">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">encodes the presence of music notation in a text [14.3. Notated Music in Written Text]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <ref name="dhq_model.labelLike"/>
-               <ref name="dhq_model.ptrLike"/>
-               <ref name="dhq_graphic"/>
-               <ref name="dhq_seg"/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_figure">
-      <element name="figure">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure) groups elements representing or containing graphic information such as an illustration, formula, or figure. [14.4. Specific Elements for Graphic Images]</a:documentation>
-         <group>
-            <optional>
-               <ref name="dhq_head"/>
-            </optional>
-            <zeroOrMore>
-               <choice>
-                  <ref name="dhq_figDesc"/>
-                  <ref name="dhq_model.graphicLike"/>
-                  <ref name="dhq_figure"/>
-               </choice>
-            </zeroOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the figure</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_figDesc">
-      <element name="figDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of figure) contains a brief prose description of the appearance or content of a graphic figure, for use when documenting an image without displaying it. [14.4. Specific Elements for Graphic Images]</a:documentation>
-         <ref name="dhq_macro.limitedContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_att">
-      <element name="att">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(attribute) contains the name of an attribute appearing within running text. [22. Documentation Elements]</a:documentation>
-         <data type="Name"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                       name="scheme"
-                       a:defaultValue="TEI">
-               <a:documentation>(scheme) supplies an identifier for the scheme in which this name is defined.
-Sample values include: 1] TEI (Text Encoding Initiative); 2] DBK (Docbook); 3] XX (unknown); 4] imaginary (imaginary); 5] XHTML (XHTML); 6] XML (XML); 7] XI (XI)</a:documentation>
-               <data type="token">
-                  <param name="pattern">[^\p{C}\p{Z}]+</param>
-               </data>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_code">
-      <element name="code">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains literal code from some formal language such as a programming language. [22.1.1. Phrase Level Terms]</a:documentation>
-         <text/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>bash</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in bash</a:documentation>
-                  <value>css</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in CSS</a:documentation>
-                  <value>fortran</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Fortran</a:documentation>
-                  <value>json</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JSON</a:documentation>
-                  <value>perl</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Perl</a:documentation>
-                  <value>php</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in PHP</a:documentation>
-                  <value>python</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Python</a:documentation>
-                  <value>r</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in R</a:documentation>
-                  <value>sql</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SQL</a:documentation>
-                  <value>sparql</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SPARQL</a:documentation>
-                  <value>unspecified</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in languages not explicitly identified</a:documentation>
-                  <value>xml</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in any XML language or syntactically similar language (such as HTML)</a:documentation>
-                  <value>xquery</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in XQuery or XPath</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_eg">
-      <element name="eg">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(example) contains any kind of illustrative example. [22.5. Element Specifications 22.5.3. Attribute List Specification]</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <ref name="dhq_hi"/>
-               <ref name="dhq_formula"/>
-               <text/>
-            </choice>
-         </zeroOrMore>
-         <ref name="dhq_att.global.attributes"/>
-         <attribute name="lang">
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>appendix</value>
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            <choice>
-               <value>bash</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in bash</a:documentation>
-               <value>c++</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in C++</a:documentation>
-               <value>c#</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in C#</a:documentation>
-               <value>css</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in CSS</a:documentation>
-               <value>fortran</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Fortran</a:documentation>
-               <value>java</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JavaScript</a:documentation>
-               <value>javascript</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JavaScript</a:documentation>
-               <value>json</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JSON</a:documentation>
-               <value>nohighlight</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples that should be handled as plain text (no syntax highlighting)</a:documentation>
-               <value>perl</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Perl</a:documentation>
-               <value>php</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in PHP</a:documentation>
-               <value>python</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Python</a:documentation>
-               <value>r</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in R</a:documentation>
-               <value>sql</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SQL</a:documentation>
-               <value>sparql</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SPARQL</a:documentation>
-               <value>code-general</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in languages not explicitly identified</a:documentation>
-               <value>xml</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in any XML language or syntactically similar language (such as HTML)</a:documentation>
-               <value>xquery</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in XQuery or XPath</a:documentation>
-            </choice>
-         </attribute>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_gi">
-      <element name="gi">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(element name) contains the name (generic identifier) of an element. [22. Documentation Elements 22.5. Element Specifications]</a:documentation>
-         <data type="Name"/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                       name="scheme"
-                       a:defaultValue="TEI">
-               <a:documentation>supplies the name of the scheme in which this name is defined.
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_trailer">
+    <element name="trailer">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a closing title or footer appearing at the end of a division of a text. [4.2.4. Content of Textual Divisions 4.2. Elements Common to All Divisions]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_lg"/>
+          <ref name="dhq_model.phrase"/>
+          <ref name="dhq_model.inter"/>
+          <ref name="dhq_model.lLike"/>
+          <ref name="dhq_model.global"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_dateline">
+    <element name="dateline">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(dateline) contains a brief description of the place, date, time, etc. of production of a letter, newspaper story, or other work, prefixed or suffixed to it as a kind of heading or trailer. [4.2.2. Openers and Closers]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_model.phrase"/>
+          <ref name="dhq_model.global"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_epigraph">
+    <element name="epigraph">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(epigraph) contains a quotation, anonymous or attributed, appearing at the start or end of a section or on a title page. [4.2.3. Arguments, Epigraphs, and Postscripts 4.2. Elements Common to All Divisions 4.6. Title Pages]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <ref name="dhq_model.common"/>
+          <ref name="dhq_model.global"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="rend">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the presentation of the quoted material, whether inline or set as a block.</a:documentation>
+          <choice>
+            <value>center</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates a block quotation, typically containing one or more paragraphs or other chunky things, with the block and text centered. </a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_salute">
+    <element name="salute">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(salutation) contains a salutation or greeting prefixed to a foreword, dedicatory epistle, or other division of a text, or the salutation in the closing of a letter, preface, etc. [4.2.2. Openers and Closers]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_signed">
+    <element name="signed">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(signature) contains the closing salutation, etc., appended to a foreword, dedicatory epistle, or other division of a text. [4.2.2. Openers and Closers]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_postscript">
+    <element name="postscript">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a postscript, e.g. to a letter. [4.2. Elements Common to All Divisions]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.global"/>
+            <ref name="dhq_model.divTopPart"/>
+          </choice>
+        </zeroOrMore>
+        <ref name="dhq_model.common"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_model.global"/>
+            <ref name="dhq_model.common"/>
+          </choice>
+        </zeroOrMore>
+        <zeroOrMore>
+          <group>
+            <ref name="dhq_model.divBottomPart"/>
+            <zeroOrMore>
+              <ref name="dhq_model.global"/>
+            </zeroOrMore>
+          </group>
+        </zeroOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_front">
+    <element name="front">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The front matter consists of an abstract followed by a teaser.</a:documentation>
+      <group>
+        <oneOrMore>
+          <ref name="dhq_abstract"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="dhq_teaser"/>
+        </oneOrMore>
+      </group>
+    </element>
+  </define>
+  <define name="dhq_back">
+    <element name="back">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+      <optional>
+        <ref name="dhq_listBibl"/>
+      </optional>
+    </element>
+  </define>
+  <define name="dhq_att.tableDecoration.attribute.rows">
+    <optional>
+      <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="rows" a:defaultValue="1">
+        <a:documentation>(rows) indicates the number of rows occupied by this cell or row.</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_att.tableDecoration.attribute.cols">
+    <optional>
+      <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="cols" a:defaultValue="1">
+        <a:documentation>(columns) indicates the number of columns occupied by this cell or row.</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="dhq_table">
+    <element name="table">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table) contains text displayed in tabular form, in rows and columns. [14.1.1. TEI Tables]</a:documentation>
+      <group>
+        <optional>
+          <ref name="dhq_head"/>
+        </optional>
+        <oneOrMore>
+          <ref name="dhq_row"/>
+        </oneOrMore>
+        <optional>
+          <ref name="dhq_caption"/>
+        </optional>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the table</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rend">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>unbordered</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rows">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rows) indicates the number of rows in the table.</a:documentation>
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="cols">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(columns) indicates the number of columns in each row of the table.</a:documentation>
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_row">
+    <element name="row">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(row) contains one row of a table. [14.1.1. TEI Tables]</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_cell"/>
+      </oneOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.tableDecoration.attribute.rows"/>
+      <ref name="dhq_att.tableDecoration.attribute.cols"/>
+      <optional>
+        <attribute name="role">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the role of the table row</a:documentation>
+          <choice>
+            <value>label</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell serves as a label (otherwise is assumed to be data)</a:documentation>
+            <value>data</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell contains data (default value)</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_cell">
+    <element name="cell">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cell) contains one cell of a table. [14.1.1. TEI Tables]</a:documentation>
+      <ref name="dhq_macro.specialPara"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.tableDecoration.attribute.rows"/>
+      <ref name="dhq_att.tableDecoration.attribute.cols"/>
+      <optional>
+        <attribute name="role">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the role of the table cell</a:documentation>
+          <choice>
+            <value>label</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell serves as a label (otherwise is assumed to be data)</a:documentation>
+            <value>data</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the cell contains data (default value)</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_formula">
+    <element name="formula">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(formula) contains a mathematical or other formula. [14.2. Formulæ and Mathematical Expressions]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_note"/>
+          <ref name="m_math"/>
+          <ref name="dhq_model.graphicLike"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="notation">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">names the notation used for the content of the element.</a:documentation>
+          <choice>
+            <value>asciimath</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>tex</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>mathml</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rend">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>inline</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <value>block</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the formula</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_notatedMusic">
+    <element name="notatedMusic">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">encodes the presence of music notation in a text [14.3. Notated Music in Written Text]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <ref name="dhq_model.labelLike"/>
+          <ref name="dhq_model.ptrLike"/>
+          <ref name="dhq_graphic"/>
+          <ref name="dhq_seg"/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_figure">
+    <element name="figure">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure) groups elements representing or containing graphic information such as an illustration, formula, or figure. [14.4. Specific Elements for Graphic Images]</a:documentation>
+      <group>
+        <optional>
+          <ref name="dhq_head"/>
+        </optional>
+        <zeroOrMore>
+          <choice>
+            <ref name="dhq_figDesc"/>
+            <ref name="dhq_model.graphicLike"/>
+            <ref name="dhq_figure"/>
+          </choice>
+        </zeroOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the figure</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_figDesc">
+    <element name="figDesc">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of figure) contains a brief prose description of the appearance or content of a graphic figure, for use when documenting an image without displaying it. [14.4. Specific Elements for Graphic Images]</a:documentation>
+      <ref name="dhq_macro.limitedContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_att">
+    <element name="att">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(attribute) contains the name of an attribute appearing within running text. [22. Documentation Elements]</a:documentation>
+      <data type="Name"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="scheme" a:defaultValue="TEI">
+          <a:documentation>(scheme) supplies an identifier for the scheme in which this name is defined.
+Sample values include: 1] TEI (Text Encoding Initiative); 2] DBK (Docbook); 3] XX (unknown); 4] imaginary (imaginary); 5] XHTML (XHTML); 6] XML (XML); 7] XI (XI)</a:documentation>
+          <data type="token">
+            <param name="pattern">[^\p{C}\p{Z}]+</param>
+          </data>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_code">
+    <element name="code">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains literal code from some formal language such as a programming language. [22.1.1. Phrase Level Terms]</a:documentation>
+      <text/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>bash</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in bash</a:documentation>
+            <value>css</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in CSS</a:documentation>
+            <value>fortran</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Fortran</a:documentation>
+            <value>json</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JSON</a:documentation>
+            <value>perl</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Perl</a:documentation>
+            <value>php</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in PHP</a:documentation>
+            <value>python</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Python</a:documentation>
+            <value>r</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in R</a:documentation>
+            <value>sql</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SQL</a:documentation>
+            <value>sparql</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SPARQL</a:documentation>
+            <value>unspecified</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in languages not explicitly identified</a:documentation>
+            <value>xml</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in any XML language or syntactically similar language (such as HTML)</a:documentation>
+            <value>xquery</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in XQuery or XPath</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_eg">
+    <element name="eg">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(example) contains any kind of illustrative example. [22.5. Element Specifications 22.5.3. Attribute List Specification]</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <ref name="dhq_hi"/>
+          <ref name="dhq_formula"/>
+          <text/>
+        </choice>
+      </zeroOrMore>
+      <ref name="dhq_att.global.attributes"/>
+      <attribute name="lang">
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        <choice>
+          <value>bash</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in bash</a:documentation>
+          <value>c++</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in C++</a:documentation>
+          <value>c#</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in C#</a:documentation>
+          <value>css</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in CSS</a:documentation>
+          <value>fortran</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Fortran</a:documentation>
+          <value>java</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JavaScript</a:documentation>
+          <value>javascript</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JavaScript</a:documentation>
+          <value>json</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in JSON</a:documentation>
+          <value>nohighlight</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples that should be handled as plain text (no syntax highlighting)</a:documentation>
+          <value>perl</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Perl</a:documentation>
+          <value>php</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in PHP</a:documentation>
+          <value>python</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in Python</a:documentation>
+          <value>r</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in R</a:documentation>
+          <value>sql</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SQL</a:documentation>
+          <value>sparql</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in SPARQL</a:documentation>
+          <value>code-general</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in languages not explicitly identified</a:documentation>
+          <value>xml</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in any XML language or syntactically similar language (such as HTML)</a:documentation>
+          <value>xquery</value>
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for code samples in XQuery or XPath</a:documentation>
+        </choice>
+      </attribute>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_gi">
+    <element name="gi">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(element name) contains the name (generic identifier) of an element. [22. Documentation Elements 22.5. Element Specifications]</a:documentation>
+      <data type="Name"/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="scheme" a:defaultValue="TEI">
+          <a:documentation>supplies the name of the scheme in which this name is defined.
 Sample values include: 1] TEI; 2] DBK (docbook); 3] XX (unknown); 4] Schematron; 5] HTML</a:documentation>
-               <data type="token">
-                  <param name="pattern">[^\p{C}\p{Z}]+</param>
-               </data>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_val">
-      <element name="val">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(value) contains a single attribute value. [22. Documentation Elements 22.5.3. Attribute List Specification]</a:documentation>
-         <text/>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_ab">
-      <element name="ab">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anonymous block) contains any arbitrary component-level unit of text, acting as an anonymous container for phrase or inter level elements analogous to, but without the semantic baggage of, a paragraph. [16.3. Blocks, Segments, and Anchors]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-ab-abstractModel-structure-ab-in-ab-or-p-constraint-report-11">
-            <rule context="tei:ab">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           xmlns:xi="http://www.w3.org/2001/XInclude"
-                           test="    (ancestor::tei:p or ancestor::tei:ab)                          and not( ancestor::tei:floatingText                                  |parent::tei:exemplum                                 |parent::tei:item                                 |parent::tei:note                                 |parent::tei:q                                 |parent::tei:quote                                 |parent::tei:remarks                                 |parent::tei:said                                 |parent::tei:sp                                 |parent::tei:stage                                 |parent::tei:cell                                 |parent::tei:figure                                )">
+          <data type="token">
+            <param name="pattern">[^\p{C}\p{Z}]+</param>
+          </data>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_val">
+    <element name="val">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(value) contains a single attribute value. [22. Documentation Elements 22.5.3. Attribute List Specification]</a:documentation>
+      <text/>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_ab">
+    <element name="ab">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anonymous block) contains any arbitrary component-level unit of text, acting as an anonymous container for phrase or inter level elements analogous to, but without the semantic baggage of, a paragraph. [16.3. Blocks, Segments, and Anchors]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-ab-abstractModel-structure-ab-in-ab-or-p-constraint-report-11">
+        <rule context="tei:ab">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" test="    (ancestor::tei:p or ancestor::tei:ab)                          and not( ancestor::tei:floatingText                                  |parent::tei:exemplum                                 |parent::tei:item                                 |parent::tei:note                                 |parent::tei:q                                 |parent::tei:quote                                 |parent::tei:remarks                                 |parent::tei:said                                 |parent::tei:sp                                 |parent::tei:stage                                 |parent::tei:cell                                 |parent::tei:figure                                )">
         Abstract model violation: ab may not occur inside paragraphs or other ab elements.
       </sch:report>
-            </rule>
-         </pattern>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-ab-abstractModel-structure-ab-in-l-or-lg-constraint-report-12">
-            <rule context="tei:ab">
-               <sch:report xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           xmlns:xi="http://www.w3.org/2001/XInclude"
-                           test="    (ancestor::tei:l or ancestor::tei:lg)                         and not( ancestor::tei:floatingText                                 |parent::tei:figure                                 |parent::tei:note                                )">
+        </rule>
+      </pattern>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-ab-abstractModel-structure-ab-in-l-or-lg-constraint-report-12">
+        <rule context="tei:ab">
+          <sch:report xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" test="    (ancestor::tei:l or ancestor::tei:lg)                         and not( ancestor::tei:floatingText                                 |parent::tei:figure                                 |parent::tei:note                                )">
         Abstract model violation: Lines may not contain higher-level divisions such as p or ab, unless ab is a child of figure or note, or is a descendant of floatingText.
       </sch:report>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_anchor">
-      <element name="anchor">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anchor point) attaches an identifier to a point within a text, whether or not it corresponds with a textual element. [8.4.2. Synchronization and Overlap 16.5. Correspondence and Alignment]</a:documentation>
-         <empty/>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <choice>
-                  <value>revisionLoc</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a revision location in a revised article</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_seg">
-      <element name="seg">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(arbitrary segment) represents any segmentation of text below the chunk level. [16.3. Blocks, Segments, and Anchors 6.2. Components of the Verse Line 7.2.5. Speech Contents]</a:documentation>
-         <ref name="dhq_macro.paraContent"/>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.written.attributes"/>
-         <ref name="dhq_att.notated.attributes"/>
-         <optional>
-            <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_standOff">
-      <element name="standOff">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Functions as a container element for linked data, contextual information, and stand-off annotations embedded in a TEI document. [16.10. The standOff Container]</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_model.standOffPart"/>
-         </oneOrMore>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="dhq-standOff-nested_standOff_should_be_typed-constraint-assert-9">
-            <rule context="tei:standOff">
-               <sch:assert xmlns="http://www.tei-c.org/ns/1.0"
-                           xmlns:mml="http://www.w3.org/1998/Math/MathML"
-                           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
-                           xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-                           xmlns:xi="http://www.w3.org/2001/XInclude"
-                           test="@type or not(ancestor::tei:standOff)">This
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_anchor">
+    <element name="anchor">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anchor point) attaches an identifier to a point within a text, whether or not it corresponds with a textual element. [8.4.2. Synchronization and Overlap 16.5. Correspondence and Alignment]</a:documentation>
+      <empty/>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <choice>
+            <value>revisionLoc</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a revision location in a revised article</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_seg">
+    <element name="seg">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(arbitrary segment) represents any segmentation of text below the chunk level. [16.3. Blocks, Segments, and Anchors 6.2. Components of the Verse Line 7.2.5. Speech Contents]</a:documentation>
+      <ref name="dhq_macro.paraContent"/>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.written.attributes"/>
+      <ref name="dhq_att.notated.attributes"/>
+      <optional>
+        <attribute name="type">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_standOff">
+    <element name="standOff">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Functions as a container element for linked data, contextual information, and stand-off annotations embedded in a TEI document. [16.10. The standOff Container]</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_model.standOffPart"/>
+      </oneOrMore>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="dhq-standOff-nested_standOff_should_be_typed-constraint-assert-9">
+        <rule context="tei:standOff">
+          <sch:assert xmlns="http://www.tei-c.org/ns/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:xi="http://www.w3.org/2001/XInclude" test="@type or not(ancestor::tei:standOff)">This
       <sch:name/> element must have a @type attribute, since it is
       nested inside a <sch:name/>
                </sch:assert>
-            </rule>
-         </pattern>
-         <ref name="dhq_att.global.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_listAnnotation">
-      <element name="listAnnotation">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a list of annotations, typically encoded as <code xmlns="http://www.w3.org/1999/xhtml">&lt;annotation&gt;</code>, <code xmlns="http://www.w3.org/1999/xhtml">&lt;annotationBlock&gt;</code>, or <code xmlns="http://www.w3.org/1999/xhtml">&lt;note&gt;</code>, possibly organized with nested <code xmlns="http://www.w3.org/1999/xhtml">&lt;listAnnotation&gt;</code> elements. [16.10. The standOff Container]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_model.headLike"/>
-            </zeroOrMore>
-            <zeroOrMore>
-               <ref name="dhq_model.labelLike"/>
-            </zeroOrMore>
-            <oneOrMore>
-               <choice>
-                  <ref name="dhq_model.annotationLike"/>
-                  <ref name="dhq_listAnnotation"/>
-               </choice>
-            </oneOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <ref name="dhq_att.notated.attributes"/>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_annotation">
-      <element name="annotation">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">represents an annotation following the <a xmlns="http://www.w3.org/1999/xhtml" href="#WADM">Web
+        </rule>
+      </pattern>
+      <ref name="dhq_att.global.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_listAnnotation">
+    <element name="listAnnotation">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a list of annotations, typically encoded as <code xmlns="http://www.w3.org/1999/xhtml">&lt;annotation&gt;</code>, <code xmlns="http://www.w3.org/1999/xhtml">&lt;annotationBlock&gt;</code>, or <code xmlns="http://www.w3.org/1999/xhtml">&lt;note&gt;</code>, possibly organized with nested <code xmlns="http://www.w3.org/1999/xhtml">&lt;listAnnotation&gt;</code> elements. [16.10. The standOff Container]</a:documentation>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_model.headLike"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="dhq_model.labelLike"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <choice>
+            <ref name="dhq_model.annotationLike"/>
+            <ref name="dhq_listAnnotation"/>
+          </choice>
+        </oneOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <ref name="dhq_att.notated.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_annotation">
+    <element name="annotation">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">represents an annotation following the <a xmlns="http://www.w3.org/1999/xhtml" href="#WADM">Web
       Annotation Data Model</a>. [16.10. The standOff Container]</a:documentation>
-         <group>
-            <zeroOrMore>
-               <ref name="dhq_revisionDesc"/>
-            </zeroOrMore>
-            <zeroOrMore>
-               <ref name="dhq_licence"/>
-            </zeroOrMore>
-            <zeroOrMore>
-               <ref name="dhq_model.annotationPart.body"/>
-            </zeroOrMore>
-         </group>
-         <ref name="dhq_att.global.attributes"/>
-         <optional>
-            <attribute name="motivation">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <list>
-                  <oneOrMore>
-                     <choice>
-                        <value>assessing</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to assess the target resource in some way, rather than simply make a comment about it</a:documentation>
-                        <value>bookmarking</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to create a bookmark to the target or part thereof</a:documentation>
-                        <value>classifying</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to classify the target in some way</a:documentation>
-                        <value>commenting</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to comment about the target</a:documentation>
-                        <value>describing</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to describe the target, rather than (for example) comment on it</a:documentation>
-                        <value>editing</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to request an edit or a change to the target resource</a:documentation>
-                        <value>highlighting</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to highlight the target resource or a segment thereof</a:documentation>
-                        <value>identifying</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to assign an identity to the target</a:documentation>
-                        <value>linking</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to link to a resource related to the target</a:documentation>
-                        <value>moderating</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to assign some value or quality to the target</a:documentation>
-                        <value>questioning</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to ask a question about the target</a:documentation>
-                        <value>replying</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to reply to a previous statement, either an annotation or another resource</a:documentation>
-                        <value>tagging</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to associate a tag with the target</a:documentation>
-                     </choice>
-                  </oneOrMore>
-               </list>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_citRef">
-      <element name="citRef" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation reference) A wrapper element for the citation information associated with <code xmlns="http://www.w3.org/1999/xhtml">&lt;cit&gt;</code>
+      <group>
+        <zeroOrMore>
+          <ref name="dhq_revisionDesc"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="dhq_licence"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="dhq_model.annotationPart.body"/>
+        </zeroOrMore>
+      </group>
+      <ref name="dhq_att.global.attributes"/>
+      <optional>
+        <attribute name="motivation">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <list>
+            <oneOrMore>
+              <choice>
+                <value>assessing</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to assess the target resource in some way, rather than simply make a comment about it</a:documentation>
+                <value>bookmarking</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to create a bookmark to the target or part thereof</a:documentation>
+                <value>classifying</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to classify the target in some way</a:documentation>
+                <value>commenting</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to comment about the target</a:documentation>
+                <value>describing</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to describe the target, rather than (for example) comment on it</a:documentation>
+                <value>editing</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to request an edit or a change to the target resource</a:documentation>
+                <value>highlighting</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to highlight the target resource or a segment thereof</a:documentation>
+                <value>identifying</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to assign an identity to the target</a:documentation>
+                <value>linking</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to link to a resource related to the target</a:documentation>
+                <value>moderating</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to assign some value or quality to the target</a:documentation>
+                <value>questioning</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to ask a question about the target</a:documentation>
+                <value>replying</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to reply to a previous statement, either an annotation or another resource</a:documentation>
+                <value>tagging</value>
+                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">intent is to associate a tag with the target</a:documentation>
+              </choice>
+            </oneOrMore>
+          </list>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_citRef">
+    <element name="citRef" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(citation reference) A wrapper element for the citation information associated with <code xmlns="http://www.w3.org/1999/xhtml">&lt;cit&gt;</code>
          </a:documentation>
-         <oneOrMore>
-            <choice>
-               <ref name="dhq_ptr"/>
-               <ref name="dhq_ref"/>
-               <ref name="dhq_bibl"/>
-               <text/>
-            </choice>
-         </oneOrMore>
-      </element>
-   </define>
-   <define name="dhq_passThroughCode">
-      <element name="passThroughCode" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Passthrough code gets passed through to the HTML output where it can be executed. The assumption is that this code will be HTML, or something that can be embedded within an HTML document.</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="anyElement-passThroughCode"/>
-            </choice>
-         </zeroOrMore>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the code is to be presented as block or in-line element. If "block", a border will be generated.</a:documentation>
-               <choice>
-                  <value>block</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the embedded code should be presented as a block element</a:documentation>
-                  <value>inline</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the embedded code should be presented as an inline element</a:documentation>
-               </choice>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the element</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the formal language in which the code is expressed</a:documentation>
-               <ref name="dhq_teidata.word"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_example">
-      <element name="example" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An example is similar to a figure, but presents textual information (e.g. code or a sample text) instead of a graphic.</a:documentation>
-         <group>
-            <optional>
-               <ref name="dhq_head"/>
-            </optional>
-            <zeroOrMore>
-               <ref name="dhq_model.common"/>
-            </zeroOrMore>
-            <optional>
-               <ref name="dhq_caption"/>
-            </optional>
-         </group>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the example item</a:documentation>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_articleType">
-      <element name="articleType" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates the type of article</a:documentation>
-         <choice>
-            <value>article</value>
-            <value>review</value>
-            <value>editorial</value>
-            <value>opinion</value>
-            <value>frontmatter</value>
-            <value>case study</value>
-            <value>field report</value>
-         </choice>
-      </element>
-   </define>
-   <define name="dhq_abstract">
-      <element name="abstract" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The abstract for the article. Contains one or more paragraphs.</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_p"/>
-         </oneOrMore>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_teaser">
-      <element name="teaser" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The teaser for the article. Contains one or more paragraphs</a:documentation>
-         <ref name="dhq_p"/>
-         <optional>
-            <attribute name="xml:lang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_author_name">
-      <element name="author_name" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of an author of the article.</a:documentation>
-         <oneOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_family"/>
-            </choice>
-         </oneOrMore>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_translator_name">
-      <element name="translator_name" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of a translator of the article.</a:documentation>
-         <oneOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_family"/>
-            </choice>
-         </oneOrMore>
-      </element>
-   </define>
-   <define name="dhq_family">
-      <element name="family" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the family name of the author.</a:documentation>
-         <text/>
-      </element>
-   </define>
-   <define name="dhq_affiliation">
-      <element name="affiliation" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the author's affiliation.</a:documentation>
-         <text/>
-      </element>
-   </define>
-   <define name="dhq_bio">
-      <element name="bio" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a brief biography of the author. Contains one or more paragraphs.</a:documentation>
-         <oneOrMore>
-            <ref name="dhq_p"/>
-         </oneOrMore>
-      </element>
-   </define>
-   <define name="dhq_authorInfo">
-      <element name="authorInfo" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The <code xmlns="http://www.w3.org/1999/xhtml">&lt;authorInfo&gt;</code> element contains contact and biographical details of the author.</a:documentation>
-         <group>
-            <ref name="dhq_author_name"/>
-            <optional>
-               <ref name="dhq_idno"/>
-            </optional>
-            <optional>
-               <ref name="dhq_affiliation"/>
-            </optional>
-            <optional>
-               <ref name="dhq_email"/>
-            </optional>
-            <optional>
-               <ref name="dhq_bio"/>
-            </optional>
-         </group>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_caption">
-      <element name="caption" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A caption for an example or table. May contain either paragraphs or mixed content.</a:documentation>
-         <zeroOrMore>
-            <choice>
-               <text/>
-               <ref name="dhq_model.phrase"/>
-               <ref name="dhq_model.inter"/>
-               <ref name="dhq_model.divPart"/>
-               <ref name="dhq_model.global"/>
-            </choice>
-         </zeroOrMore>
-      </element>
-   </define>
-   <define name="dhq_translatorInfo">
-      <element name="translatorInfo" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">In DHQPublish, the <code xmlns="http://www.w3.org/1999/xhtml">&lt;translatorInfo&gt;</code> element contains contact and biographical details of the translator.</a:documentation>
-         <group>
-            <ref name="dhq_translator_name"/>
-            <optional>
-               <ref name="dhq_affiliation"/>
-            </optional>
-            <optional>
-               <ref name="dhq_email"/>
-            </optional>
-            <optional>
-               <ref name="dhq_bio"/>
-            </optional>
-         </group>
-         <optional>
-            <attribute name="xml:id">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="ID"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_revisionNote">
-      <element name="revisionNote" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A revisionNote contains information about a post-publication revision to the article.</a:documentation>
-         <ref name="dhq_macro.limitedContent"/>
-         <optional>
-            <attribute name="previous">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="next">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <optional>
-            <attribute name="when">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <define name="dhq_dedication">
-      <element name="dedication" ns="http://www.digitalhumanities.org/ns/dhq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A dedication contains a brief phrase of dedication; it appears at the top of the article as a child of <code xmlns="http://www.w3.org/1999/xhtml">&lt;body&gt;</code>, immediately following the heading</a:documentation>
-         <text/>
-      </element>
-   </define>
-   <define name="dhq_License">
-      <element name="License" ns="http://web.resource.org/cc/">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-         <empty/>
-         <optional>
-            <attribute name="about" ns="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-               <data type="anyURI">
-                  <param name="pattern">\S+</param>
-               </data>
-            </attribute>
-         </optional>
-         <empty/>
-      </element>
-   </define>
-   <start>
+      <oneOrMore>
+        <choice>
+          <ref name="dhq_ptr"/>
+          <ref name="dhq_ref"/>
+          <ref name="dhq_bibl"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="dhq_passThroughCode">
+    <element name="passThroughCode" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Passthrough code gets passed through to the HTML output where it can be executed. The assumption is that this code will be HTML, or something that can be embedded within an HTML document.</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="anyElement-passThroughCode"/>
+        </choice>
+      </zeroOrMore>
+      <optional>
+        <attribute name="rend">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the code is to be presented as block or in-line element. If "block", a border will be generated.</a:documentation>
+          <choice>
+            <value>block</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the embedded code should be presented as a block element</a:documentation>
+            <value>inline</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates that the embedded code should be presented as an inline element</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the element</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the formal language in which the code is expressed</a:documentation>
+          <ref name="dhq_teidata.word"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_example">
+    <element name="example" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An example is similar to a figure, but presents textual information (e.g. code or a sample text) instead of a graphic.</a:documentation>
+      <group>
+        <optional>
+          <ref name="dhq_head"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="dhq_model.common"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="dhq_caption"/>
+        </optional>
+      </group>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a unique identifier for the example item</a:documentation>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content</a:documentation>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_articleType">
+    <element name="articleType" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Designates the type of article</a:documentation>
       <choice>
-         <ref name="dhq_TEI"/>
+        <value>article</value>
+        <value>review</value>
+        <value>editorial</value>
+        <value>opinion</value>
+        <value>frontmatter</value>
+        <value>case study</value>
+        <value>field report</value>
       </choice>
-   </start>
+    </element>
+  </define>
+  <define name="dhq_abstract">
+    <element name="abstract" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The abstract for the article. Contains one or more paragraphs.</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_p"/>
+      </oneOrMore>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_teaser">
+    <element name="teaser" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The teaser for the article. Contains one or more paragraphs</a:documentation>
+      <ref name="dhq_p"/>
+      <optional>
+        <attribute name="xml:lang">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_author_name">
+    <element name="author_name" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of an author of the article.</a:documentation>
+      <oneOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_family"/>
+        </choice>
+      </oneOrMore>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_translator_name">
+    <element name="translator_name" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of a translator of the article.</a:documentation>
+      <oneOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_family"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="dhq_family">
+    <element name="family" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the family name of the author.</a:documentation>
+      <text/>
+    </element>
+  </define>
+  <define name="dhq_affiliation">
+    <element name="affiliation" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the author's affiliation.</a:documentation>
+      <text/>
+    </element>
+  </define>
+  <define name="dhq_bio">
+    <element name="bio" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a brief biography of the author. Contains one or more paragraphs.</a:documentation>
+      <oneOrMore>
+        <ref name="dhq_p"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="dhq_authorInfo">
+    <element name="authorInfo" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The <code xmlns="http://www.w3.org/1999/xhtml">&lt;authorInfo&gt;</code> element contains contact and biographical details of the author.</a:documentation>
+      <group>
+        <ref name="dhq_author_name"/>
+        <optional>
+          <ref name="dhq_idno"/>
+        </optional>
+        <optional>
+          <ref name="dhq_affiliation"/>
+        </optional>
+        <optional>
+          <ref name="dhq_email"/>
+        </optional>
+        <optional>
+          <ref name="dhq_bio"/>
+        </optional>
+      </group>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_caption">
+    <element name="caption" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A caption for an example or table. May contain either paragraphs or mixed content.</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="dhq_model.phrase"/>
+          <ref name="dhq_model.inter"/>
+          <ref name="dhq_model.divPart"/>
+          <ref name="dhq_model.global"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="dhq_translatorInfo">
+    <element name="translatorInfo" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">In DHQPublish, the <code xmlns="http://www.w3.org/1999/xhtml">&lt;translatorInfo&gt;</code> element contains contact and biographical details of the translator.</a:documentation>
+      <group>
+        <ref name="dhq_translator_name"/>
+        <optional>
+          <ref name="dhq_affiliation"/>
+        </optional>
+        <optional>
+          <ref name="dhq_email"/>
+        </optional>
+        <optional>
+          <ref name="dhq_bio"/>
+        </optional>
+      </group>
+      <optional>
+        <attribute name="xml:id">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_revisionNote">
+    <element name="revisionNote" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A revisionNote contains information about a post-publication revision to the article.</a:documentation>
+      <ref name="dhq_macro.limitedContent"/>
+      <optional>
+        <attribute name="previous">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="next">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="when">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="dhq_dedication">
+    <element name="dedication" ns="http://www.digitalhumanities.org/ns/dhq">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A dedication contains a brief phrase of dedication; it appears at the top of the article as a child of <code xmlns="http://www.w3.org/1999/xhtml">&lt;body&gt;</code>, immediately following the heading</a:documentation>
+      <text/>
+    </element>
+  </define>
+  <define name="dhq_License">
+    <element name="License" ns="http://web.resource.org/cc/">
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+      <empty/>
+      <optional>
+        <attribute name="about" ns="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+          <data type="anyURI">
+            <param name="pattern">\S+</param>
+          </data>
+        </attribute>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <start>
+    <choice>
+      <ref name="dhq_TEI"/>
+    </choice>
+  </start>
 </grammar>

--- a/common/schema/DHQauthor-TEI.xml
+++ b/common/schema/DHQauthor-TEI.xml
@@ -25,8 +25,11 @@
       </sourceDesc>
     </fileDesc>
     <revisionDesc>
-      <change when="2022-07-22" who="jhf">
-    	Added <gi>formula</gi> to the content model of <gi>head</gi> to support formulae inside figure captions.
+      <change when="2023-08-25" who="#sdb">
+        Per <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/issues/50">issue 50</ref>, add <att>xml:lang</att> to <gi>q</gi>.
+      </change>
+      <change when="2022-07-22" who="#jhf">
+        Added <gi>formula</gi> to the content model of <gi>head</gi> to support formulae inside figure captions.
       </change>
       <change when="2022-05-19" who="#sdb">
         <list>
@@ -55,7 +58,7 @@
           <gi>classRef</gi> itself. (I also deleted the comment that
           indicated what else used to be in that <gi>alternate</gi> —
           I hope that’s not a problem.)</item>
-	  <item>Whitespace and comment changes.</item>
+          <item>Whitespace and comment changes.</item>
         </list>
       </change>
       <change when="2022-05-19" who="#sdb">
@@ -1144,6 +1147,11 @@ email (should only have an email address)
         </classes>
         <attList>
           <attDef ident="type" mode="delete"/>
+          <attDef ident="xml:lang" usage="rec">
+            <datatype>
+              <rng:ref name="data.language"/>
+            </datatype>
+          </attDef>
         </attList>
       </elementSpec>
 
@@ -1158,99 +1166,99 @@ email (should only have an email address)
             </datatype>
           </attDef>
           <attDef ident="corresp">
-          	<datatype>
-          		<rng:ref name="data.enumerated"></rng:ref>
-          	</datatype>
-          	<valList type="closed">
-          		<valItem ident="#access"/> 
-          		<valItem ident="#annotation"/> 
-          		<valItem ident="#anthropology"/> 
-          		<valItem ident="#ar"/> 
-          		<valItem ident="#archaeology"/> 
-          		<valItem ident="#archives"/> 
-          		<valItem ident="#area_studies"/> 
-          		<valItem ident="#citation"/> 
-          		<valItem ident="#classics"/> 
-          		<valItem ident="#code_studies"/> 
-          		<valItem ident="#collaboration"/> 
-          		<valItem ident="#comics"/> 
-          		<valItem ident="#communications"/> 
-          		<valItem ident="#content_analysis"/> 
-          		<valItem ident="#corpora"/> 
-          		<valItem ident="#cs"/> 
-          		<valItem ident="#cultural_criticism"/> 
-          		<valItem ident="#cultural_heritage"/> 
-          		<valItem ident="#data_analytics"/> 
-          		<valItem ident="#data_curation"/> 
-          		<valItem ident="#data_modeling"/> 
-          		<valItem ident="#data_visualization"/> 
-          		<valItem ident="#databases"/> 
-          		<valItem ident="#dh"/> 
-          		<valItem ident="#digital"/> 
-          		<valItem ident="#digital_libraries"/> 
-          		<valItem ident="#digital_literacy"/> 
-          		<valItem ident="#digitization"/> 
-          		<valItem ident="#editing"/> 
-          		<valItem ident="#elit"/> 
-          		<valItem ident="#ecocriticism"/> 
-          		<valItem ident="#ethics"/> 
-          		<valItem ident="#games"/> 
-          		<valItem ident="#gender"/> 
-          		<valItem ident="#geospatial"/> 
-          		<valItem ident="#glam"/> 
-          		<valItem ident="#globalDH"/> 
-          		<valItem ident="#graphic_design"/> 
-          		<valItem ident="#history"/> 
-          		<valItem ident="#hypertext"/> 
-          		<valItem ident="#images"/> 
-          		<valItem ident="#indigenous"/> 
-          		<valItem ident="#info_architecture"/> 
-          		<valItem ident="#informatics"/> 
-          		<valItem ident="#information_retrieval"/> 
-          		<valItem ident="#infrastructure"/> 
-          		<valItem ident="#interdisciplinarity"/> 
-          		<valItem ident="#language_studies"/> 
-          		<valItem ident="#linguistics"/> 
-          		<valItem ident="#literary_studies"/> 
-          		<valItem ident="#machine_learning"/> 
-          		<valItem ident="#manuscripts"/> 
-          		<valItem ident="#markup"/> 
-          		<valItem ident="#materialisms"/> 
-          		<valItem ident="#media_history"/> 
-          		<valItem ident="#media_studies"/> 
-          		<valItem ident="#medieval"/> 
-          		<valItem ident="#metadata"/> 
-          		<valItem ident="#minimal_computing"/> 
-          		<valItem ident="#mobile"/> 
-          		<valItem ident="#moving_images"/> 
-          		<valItem ident="#music"/> 
-          		<valItem ident="#network"/> 
-          		<valItem ident="#nlp"/> 
-          		<valItem ident="#oral_history"/> 
-          		<valItem ident="#pedagogy"/> 
-          		<valItem ident="#performance"/> 
-          		<valItem ident="#philosophy"/> 
-          		<valItem ident="#project_management"/> 
-          		<valItem ident="#project_report"/> 
-          		<valItem ident="#public_history"/> 
-          		<valItem ident="#publishing"/> 
-          		<valItem ident="#race"/> 
-          		<valItem ident="#reading"/> 
-          		<valItem ident="#religion"/> 
-          		<valItem ident="#rhetoric"/> 
-          		<valItem ident="#semantic_web"/> 
-          		<valItem ident="#social_justice"/> 
-          		<valItem ident="#social_media"/> 
-          		<valItem ident="#sound"/> 
-          		<valItem ident="#standards"/> 
-          		<valItem ident="#stylistics"/> 
-          		<valItem ident="#tools"/> 
-          		<valItem ident="#transcription"/> 
-          		<valItem ident="#translation"/> 
-          		<valItem ident="#users"/> 
-          		<valItem ident="#visual_art"/> 
-          		<valItem ident="#web"/> 
-          	</valList>
+                <datatype>
+                        <rng:ref name="data.enumerated"></rng:ref>
+                </datatype>
+                <valList type="closed">
+                        <valItem ident="#access"/> 
+                        <valItem ident="#annotation"/> 
+                        <valItem ident="#anthropology"/> 
+                        <valItem ident="#ar"/> 
+                        <valItem ident="#archaeology"/> 
+                        <valItem ident="#archives"/> 
+                        <valItem ident="#area_studies"/> 
+                        <valItem ident="#citation"/> 
+                        <valItem ident="#classics"/> 
+                        <valItem ident="#code_studies"/> 
+                        <valItem ident="#collaboration"/> 
+                        <valItem ident="#comics"/> 
+                        <valItem ident="#communications"/> 
+                        <valItem ident="#content_analysis"/> 
+                        <valItem ident="#corpora"/> 
+                        <valItem ident="#cs"/> 
+                        <valItem ident="#cultural_criticism"/> 
+                        <valItem ident="#cultural_heritage"/> 
+                        <valItem ident="#data_analytics"/> 
+                        <valItem ident="#data_curation"/> 
+                        <valItem ident="#data_modeling"/> 
+                        <valItem ident="#data_visualization"/> 
+                        <valItem ident="#databases"/> 
+                        <valItem ident="#dh"/> 
+                        <valItem ident="#digital"/> 
+                        <valItem ident="#digital_libraries"/> 
+                        <valItem ident="#digital_literacy"/> 
+                        <valItem ident="#digitization"/> 
+                        <valItem ident="#editing"/> 
+                        <valItem ident="#elit"/> 
+                        <valItem ident="#ecocriticism"/> 
+                        <valItem ident="#ethics"/> 
+                        <valItem ident="#games"/> 
+                        <valItem ident="#gender"/> 
+                        <valItem ident="#geospatial"/> 
+                        <valItem ident="#glam"/> 
+                        <valItem ident="#globalDH"/> 
+                        <valItem ident="#graphic_design"/> 
+                        <valItem ident="#history"/> 
+                        <valItem ident="#hypertext"/> 
+                        <valItem ident="#images"/> 
+                        <valItem ident="#indigenous"/> 
+                        <valItem ident="#info_architecture"/> 
+                        <valItem ident="#informatics"/> 
+                        <valItem ident="#information_retrieval"/> 
+                        <valItem ident="#infrastructure"/> 
+                        <valItem ident="#interdisciplinarity"/> 
+                        <valItem ident="#language_studies"/> 
+                        <valItem ident="#linguistics"/> 
+                        <valItem ident="#literary_studies"/> 
+                        <valItem ident="#machine_learning"/> 
+                        <valItem ident="#manuscripts"/> 
+                        <valItem ident="#markup"/> 
+                        <valItem ident="#materialisms"/> 
+                        <valItem ident="#media_history"/> 
+                        <valItem ident="#media_studies"/> 
+                        <valItem ident="#medieval"/> 
+                        <valItem ident="#metadata"/> 
+                        <valItem ident="#minimal_computing"/> 
+                        <valItem ident="#mobile"/> 
+                        <valItem ident="#moving_images"/> 
+                        <valItem ident="#music"/> 
+                        <valItem ident="#network"/> 
+                        <valItem ident="#nlp"/> 
+                        <valItem ident="#oral_history"/> 
+                        <valItem ident="#pedagogy"/> 
+                        <valItem ident="#performance"/> 
+                        <valItem ident="#philosophy"/> 
+                        <valItem ident="#project_management"/> 
+                        <valItem ident="#project_report"/> 
+                        <valItem ident="#public_history"/> 
+                        <valItem ident="#publishing"/> 
+                        <valItem ident="#race"/> 
+                        <valItem ident="#reading"/> 
+                        <valItem ident="#religion"/> 
+                        <valItem ident="#rhetoric"/> 
+                        <valItem ident="#semantic_web"/> 
+                        <valItem ident="#social_justice"/> 
+                        <valItem ident="#social_media"/> 
+                        <valItem ident="#sound"/> 
+                        <valItem ident="#standards"/> 
+                        <valItem ident="#stylistics"/> 
+                        <valItem ident="#tools"/> 
+                        <valItem ident="#transcription"/> 
+                        <valItem ident="#translation"/> 
+                        <valItem ident="#users"/> 
+                        <valItem ident="#visual_art"/> 
+                        <valItem ident="#web"/> 
+                </valList>
           </attDef>
         </attList>
       </elementSpec>
@@ -1320,16 +1328,16 @@ email (should only have an email address)
 
       <elementSpec module="core" ident="l" mode="change">
         <attList>
-        	<attDef ident="rend" mode="add">
-        		<valList type="closed">
-        			<valItem ident="indent-1"><desc>the line is indented by 1</desc></valItem>
-        			<valItem ident="indent-2"><desc>the line is indented by 2</desc></valItem>
-        			<valItem ident="indent-3"><desc>the line is indented by 3</desc></valItem>
-        			<valItem ident="indent-4"><desc>the line is indented by 4</desc></valItem>
-        			<valItem ident="indent-5"><desc>the line is indented by 5</desc></valItem>
-        			<valItem ident="indent-6"><desc>the line is indented by 6</desc></valItem>
-        		</valList>
-        	</attDef>
+                <attDef ident="rend" mode="add">
+                        <valList type="closed">
+                                <valItem ident="indent-1"><desc>the line is indented by 1</desc></valItem>
+                                <valItem ident="indent-2"><desc>the line is indented by 2</desc></valItem>
+                                <valItem ident="indent-3"><desc>the line is indented by 3</desc></valItem>
+                                <valItem ident="indent-4"><desc>the line is indented by 4</desc></valItem>
+                                <valItem ident="indent-5"><desc>the line is indented by 5</desc></valItem>
+                                <valItem ident="indent-6"><desc>the line is indented by 6</desc></valItem>
+                        </valList>
+                </attDef>
           <attDef ident="part" mode="delete"/>
         </attList>
       </elementSpec>
@@ -1362,13 +1370,13 @@ email (should only have an email address)
               <valItem ident="block"/>
             </valList>
           </attDef>
-		  <attDef ident="xml:id" mode="add" usage="opt">
+                  <attDef ident="xml:id" mode="add" usage="opt">
             <desc>Provides a unique identifier for the formula</desc>
             <datatype>
               <rng:data type="ID"/>
             </datatype>
           </attDef>          
-        	<attDef ident="notation" mode="change">
+                <attDef ident="notation" mode="change">
             <valList type="closed" mode="replace">
               <valItem ident="asciimath"/>
               <valItem ident="tex"/>


### PR DESCRIPTION
Added xml:lang= to the 'q' element.
I compared the new RNG file to the old, enough to convince myself there were no major side-effects. I did not, however, try validating all the articles again.

So my instinct is that if we do want to allow `<q>` with `@xml:lang`, this is probably good to go. If not, it should be rejected.

Note that it looks to me like common/xslt/dhq2html.xsl will process `<q>` with `@xml:lang` properly already — no change required. 