### PR TITLE
adding additional checks on @target of <ref>

### DIFF
--- a/common/schema/dhqTEI-ready.sch
+++ b/common/schema/dhqTEI-ready.sch
@@ -176,9 +176,9 @@
     </rule>
   	
   	<!--checks to see when @target begins with a '#' AND does not point to an @xml:id-->
-  	<rule context="tei:ref[starts-with(@target,'#')]">
-  		<assert role="warning" test="replace(@target,'^#','') = //*/@xml:id">
-  			<name/> does not reference an @xml:id in this document</assert>
+  	<rule context="tei:ref[starts-with(normalize-space(@target),'#')]">
+  		<assert role="warning" test="substring(normalize-space(@target), 2) = //@xml:id">
+  			The @target of <name/> does not reference an @xml:id in this document</assert>
   	</rule>
 
     <rule context="tei:ptr[starts-with(@target,'#')]">


### PR DESCRIPTION
Following a discussion at the weekly production meeting on January 12, this (small) Schematron update adds a rule which checks for intended values of `@target` in the context of `<ref>`.

Its aim is to ensure that when `@target` begins with a '#' (i.e., it is an internal document link) it points to an existing `@xml:id` somewhere in the document. The purpose of this assertion is to help eliminate encoding spelling errors when `<ref>` is used to point to a `<bibl>`, as well as ensure that internal links to elements like sections, figures, tables, and whatever else we assign `@xml:id` values to actually lead readers to their intended destination.

Following the merge of this request, a realistic next step would be to generate a report of `<ref>` elements which fail this new assertion, to aid in fixing broken links within the article corpus.