### PR TITLE
minor changes for validity

### DIFF
--- a/common/schema/dhqTEI-ready.sch
+++ b/common/schema/dhqTEI-ready.sch
@@ -3,7 +3,12 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   queryBinding="xslt2">
 
-
+  <ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+  <ns prefix="dhq" uri="http://www.digitalhumanities.org/ns/dhq"/>
+  <ns prefix="cc"  uri="http://web.resource.org/cc/"/>
+  <ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <ns prefix="xs"  uri="http://www.w3.org/2001/XMLSchema"/>
+  
   <p>Authorial readiness check for DHQ articles.</p>
 
   <p>This checks a number of constraints on DHQauthor articles that we can't or
@@ -16,12 +21,6 @@
   <!-- Also check DHQ-TEI-diagnostic.sch for rules that should be
        in here -->
 
-  <ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
-  <ns prefix="dhq" uri="http://www.digitalhumanities.org/ns/dhq"/>
-  <ns prefix="cc"  uri="http://web.resource.org/cc/"/>
-  <ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
-  <ns prefix="xs"  uri="http://www.w3.org/2001/XMLSchema"/>
-  
   <pattern id="top-level">
 <!-- Cannot put up with hrefs to http: in
       <?oxygen RNGSchema="../../common/schema/DHQauthor-TEI.rng" type="xml"?>
@@ -57,14 +56,15 @@
                    tei:profileDesc//* |
                    tei:revisionDesc"
       >
-      <!-- matching these to create exceptions for the next rules --> </rule>
+      <assert test="true()"> matching these to create exceptions for the following rules </assert>
+    </rule>
 
     <rule context="tei:publicationStmt/tei:idno[@type = ('volume','issue')][. castable as xs:integer]">
       <let name="me" value="normalize-space(.)"/>
-      <assert test="$me eq .">There should be no spaces in the <value-of select="@type"/> number</assert>
-      <assert test="$me castable as xs:positiveInteger">The <value-of select="@type"/> number should be a positive integer</assert>
       <let name="min" value="1"/>
       <let name="max" value="if (@type eq 'issue') then 4 else 899"/> <!-- rule only works for ~900 years -->
+      <assert test="$me eq .">There should be no spaces in the <value-of select="@type"/> number</assert>
+      <assert test="$me castable as xs:positiveInteger">The <value-of select="@type"/> number should be a positive integer</assert>
       <assert test="$max ge xs:integer($me)  and  xs:integer($me) ge $min">The <value-of select="@type"/> number is out of range</assert>
       <assert test="if (@type eq 'volume') then string-length($me) eq 3 else true()">The volume number should be 3 digits long (with leading zeroes as needed)</assert>
       <assert test="if (@type eq 'issue') then string-length($me) eq 1 else true()">The issue number should be only 1 digit long (no leading zeroes allowed)</assert>
@@ -91,8 +91,8 @@
       <assert test="not(@when)">Publication date is missing its @when attribute value</assert>
     </rule>
     <rule context="tei:teiHeader//tei:date[ @when  and  @when ne '']">
-      <assert test="@when castable as xs:date"><value-of select="name(..)"/><name/>/@when is not an ISO date</assert>
       <let name="date-str" value="@when/format-date(.,'[D] [MNn] [Y]')"/>
+      <assert test="@when castable as xs:date"><value-of select="name(..)"/><name/>/@when is not an ISO date</assert>
       <assert test=". eq $date-str">date value is not @when in 'D Month YYYY' format (expecting '<value-of select="$date-str"/>')</assert>
     </rule>
     
@@ -104,19 +104,21 @@
     </rule>
 
     <rule context="tei:taxonomy[@xml:id='dhq_keywords']">
-      <!--<let name="contents" value="*|text()[normalize-space(.)]"/>
-      <assert test="exists(bibl[1]) and not($contents except tei:bibl[1])"><name/> contains
-      unexpected content (should have a single bibl)</assert>
-      <assert test="normalize-space(.) = 
-        normalize-space('DHQ classification scheme; full list available in the
-        DHQ keyword taxonomy')">text content of <name/> is incorrect: should be
-        "DHQ classification scheme; full list available in the
-        DHQ keyword taxonomy"</assert>--> </rule>
-    <rule context="tei:taxonomy[@xml:id='authorial_keywords']"/>
+      <assert test="true()"> could put a test for contents here; previous attempt commented out, below </assert>
+      <!--
+        <let name="contents" value="*|text()[normalize-space(.)]"/>
+        <assert test="exists(bibl[1]) and not($contents except tei:bibl[1])"><name/> contains unexpected content (should have a single bibl)</assert>
+        <assert test="normalize-space(.) = normalize-space('DHQ classification scheme; full list available in the DHQ keyword taxonomy')">
+          text content of <name/> is incorrect: should be "DHQ classification scheme; full list available in the DHQ keyword taxonomy"
+        </assert>
+      -->
+    </rule>
+    <rule context="tei:taxonomy[@xml:id='authorial_keywords']">
+      <assert test="true()"/>
+    </rule>
     <rule context="tei:classDecl/*">
       <report test="true()"><name/> unexpected here</report>
     </rule>
-
     <rule context="tei:front//dhq:*">
       <assert test="normalize-space(.)"><name/> is empty</assert>
     </rule>
@@ -137,16 +139,16 @@
     <rule role="warning" context="tei:div">
       <report test="empty(tei:head)">A div has no head.</report>
     </rule>
-  	
-  	<!-- Checks new  <change> template (implemented 2022-08)
-  		to verify the article number was replaced in the gitHub url -->
-  	<rule role="error" context="tei:change/tei:ref">
-  		<extends rule="target-uri-constraints"/>
-  		<report role="error" test="matches(@target,'NNNNNN')">
-  			Revision description appears suspect: does not contain proper article id.
-  		</report>
-  	</rule>
-  	
+        
+        <!-- Checks new  <change> template (implemented 2022-08)
+                to verify the article number was replaced in the gitHub url -->
+        <rule role="error" context="tei:change/tei:ref">
+                <extends rule="target-uri-constraints"/>
+                <report role="error" test="matches(@target,'NNNNNN')">
+                        Revision description appears suspect: does not contain proper article id.
+                </report>
+        </rule>
+        
     <rule role="warning" context="tei:head">
       <assert test="empty(preceding-sibling::tei:head)">This is not the first head in this element; please check (is this a new div or caption)?</assert>
     </rule>
@@ -174,19 +176,19 @@
       <assert role="warning" test="matches(@target,'#|/')"><name/>/@target
         appears suspect: it has neither '#' nor '/'</assert>
     </rule>
-  	
-  	<!--checks to see when @target begins with a '#' AND does not point to an @xml:id-->
-  	<rule context="tei:ref[starts-with(normalize-space(@target),'#')]">
-  		<assert role="warning" test="substring(normalize-space(@target), 2) = //@xml:id">
-  			The @target of <name/> does not reference an @xml:id in this document</assert>
-  	</rule>
+        
+        <!--checks to see when @target begins with a '#' AND does not point to an @xml:id-->
+        <rule context="tei:ref[starts-with(normalize-space(@target),'#')]">
+                <assert role="warning" test="substring(normalize-space(@target), 2) = //@xml:id">
+                        The @target of <name/> does not reference an @xml:id in this document</assert>
+        </rule>
 
     <rule context="tei:ptr[starts-with(@target,'#')]">
       <extends rule="target-uri-constraints"/>
       <assert test="replace(@target,'^#','') = //tei:bibl/@xml:id"
         role="warning"><name/> does not reference a bibl</assert>
-    	<!-- Removing the checks on @loc; actual values are too complex to model/constrain with Schematron. 
-    		Retaining the code in case we want it later.
+        <!-- Removing the checks on @loc; actual values are too complex to model/constrain with Schematron. 
+                Retaining the code in case we want it later.
       <!- $d is an arabic natural number (one or more digits not starting with 0) 
       <let name="d" value="'[1-9]\d*'"/>
       <!- $r is a lower-case roman numeral 
@@ -197,15 +199,15 @@
       <let name="rr" value="concat($r,'(&#x2013;',$r,')?')"/>
       <!- $drrr is a choice between $dr and $rr 
       <let name="drrr" value="concat('(',$dr,'|',$rr,')')"/>
-      <!- $s is one of a set of special characters 	
-      <let name="s" value="'[§¶]*'"></let>	
+      <!- $s is one of a set of special characters      
+      <let name="s" value="'[§¶]*'"></let>      
       <!- $seq is a sequence of one or more $drrr, comma-delimited, with optional special-character prefix $s 
       <let name="seq" value="concat('^',$s,$drrr,'(, ',$drrr,')*$')"/>
       
       <assert test="not(@loc) or matches(@loc,$seq)" role="warning"
         ><name/>/@loc '<value-of select="@loc"/>' is unusual: please
         check</assert>
-    	 -->
+         -->
       <report test="contains(@loc,'-')" role="warning"><name/>/@loc contains
         '-' (hyphen): try '&#x2013;' (en-dash)</report>
       <!-- elsewhere we check bibl elements to which we have ptr cross-references,
@@ -283,7 +285,9 @@
 
   <pattern>
     <title>flagging markup content</title>
-    <rule context="tei:code | tei:eg | tei:formula"/>
+    <rule context="tei:code | tei:eg | tei:formula">
+      <assert test="true()"> the exceptions to the following rule </assert>
+    </rule>
     <rule context="*[exists(text()[normalize-space(.)])]">
       <!-- matches any elements that don't match the first rule -->
       <report role="warning" test="exists(text()[matches(.,'&lt;|&gt;')])">
@@ -321,5 +325,13 @@
         next to non-space character</report>
     </rule>
   </pattern>
+
+  <properties>
+    <property id="placeholder" role="validity">
+      This is here only because ISO 19757-3:2016 appendix A requires
+      it for validity. We do not actually use properties. (I do not
+      even know how to.) —Syd, 2024-01-29
+    </property>
+  </properties>
   
 </schema>


### PR DESCRIPTION
No changes to actual constraints.

I found I could not validate against common/schema/dhqTEI-ready.sch using schxslt. I want to submit a bug report about schxslt, but figure I cannot expect a Schematron processor to work properly unless the schema is valid. But it turns out it was not valid, at least not against the RELAX NG schema provided in ISO 19757-3:2016 appendix A. (It was, and still is, valid against the Schematron schema in appendix B.)

I don’t really understand what is going on here, because it _is_ valid according to oXygen. So I am not sure what schema SyncRO is using. I will probably ask on one of their forums later today.

In the meantime I made a few tweaks to dhqTEI-ready.sch so that it is now valid against 19757-3:2016 and is still valid in oXygen:

- Moved `<sch:ns>` elements to precede paragraphs of prose.
- Moved `<sch:let>` elements to precede their `<sch:assert>` or `<sch:report>` siblings.
- Added an `<sch:assert test="true()">` child to empty `<sch:rule>` elements. (Note that such an assertion will _never_ fire.)
- Added a pointless `<sch:properties>` element at the end. (Not only do we not use properties, I do not (currently) know how to.)

I do not think it useful to review this by looking at individual lines of code. (But if you do, make sure to check “Hide whitespace”, because I converted all tabs (U+0009) to spaces.) I have tested this change by validating the entire articles/0*/0*.xml corpus against both the before- and after- versions of the dhqTEI-ready.sch schema and comparing the results. They are _exactly_ the same (roughly 1300 errors). But the method I use to validate against Schematron is probably not how others do, so I think someone should spot-check 3+ files by validating them against the dhqTEI-ready.sch schema in the main branch and the dhqTEI-ready.sch schema in this branch, and making sure the results are the same. 
