### PR TITLE
Fix more broken links

### DIFF
--- a/articles/000081/000081.xml
+++ b/articles/000081/000081.xml
@@ -441,7 +441,7 @@
                <head>The Hypertext Editing System (HES) console at Brown University. Original photo
                   by Greg Lloyd, 1969.</head>
                <figDesc>Photograph of the HES console with lightpen and keyboard.</figDesc>
-               <graphic url="...000081/resources/figure01.jpg"/>
+               <graphic url="resources/figure01.jpg"/>
             </figure>
             <p>HES, as a first prototype, naturally had its shortcomings. Part of the goal behind
                FRESS was to improve on these shortcomings. Firstly, HES was programmed specifically

--- a/articles/000082/000082.xml
+++ b/articles/000082/000082.xml
@@ -363,7 +363,7 @@
                   <figure xml:id="figure01">
                      <head/>
                      <figDesc/>
-                     <graphic url=".../000082/resources/figure01.jpg"/>
+                     <graphic url="resources/figure01.jpg"/>
                   </figure>
                </p>
                <div>
@@ -557,7 +557,7 @@
                <figure xml:id="figure02">
                   <head/>
                   <figDesc/>
-                  <graphic url="..../000082/resources/figure02.jpg"/>
+                  <graphic url="resources/figure02.jpg"/>
                </figure>
                <p>As can be seen, the adjectives <foreign xml:lang="it">stupito, perplesso</foreign>
                   and <foreign xml:lang="it">inquieto</foreign> on the last line (bottom left of
@@ -754,13 +754,13 @@
                   <item>Second version (which we call A): <figure xml:id="figure03">
                      <head/>
                         <figDesc/>
-                        <graphic url=".../000082/resources/figure03.jpg"/>
+                        <graphic url="resources/figure03.jpg"/>
                      </figure>
                   </item>
                   <item>Sixth version (which we call B): <figure xml:id="figure04">
                      <head/>
                         <figDesc/>
-                        <graphic url=".../000082/resources/figure04.jpg"/>
+                        <graphic url="resources/figure04.jpg"/>
                      </figure>
                   </item>
                </list>

--- a/articles/000083/000083.xml
+++ b/articles/000083/000083.xml
@@ -282,7 +282,7 @@
                   <figDesc>Response chart for the question <q>What is
                         the purpose of the tools you have developed?</q>
                   </figDesc>
-                  <graphic url="...000083/resources/figure01.jpg"/>
+                  <graphic url="resources/figure01.jpg"/>
                </figure>
                <p>Other categories that were not captured but which had more than one response were
                   database management tools, indexing tools, and archiving tools.<note>If we are to
@@ -354,7 +354,7 @@
                   <figDesc>Response chart for the question, <q>How do
                         you measure the success of tool development activities?</q>
                   </figDesc>
-                  <graphic url="...000083/resources/figure02.jpg"/>
+                  <graphic url="resources/figure02.jpg"/>
                </figure>
                <p>Twenty-one respondents checked that their tool development was <q>somewhat
                      successful.</q> The reasons for their lack of success fit, by and large, into
@@ -424,7 +424,7 @@
                   <figDesc>Response chart for the question, <q>Has
                         tool developed counted towards career advancement?</q>
                   </figDesc>
-                  <graphic url="...000083/resources/figure03.jpg"/>
+                  <graphic url="resources/figure03.jpg"/>
                </figure>
                <p>There were several repeated themes among the 51 respondents who elaborated on
                   their answers: the most-often-cited positive responses included raising one’s

--- a/articles/000086/000086.xml
+++ b/articles/000086/000086.xml
@@ -253,7 +253,7 @@
                   one on each floor. Today, it has 46 apartments whose different prices reflect the
                   goal of the building to house diverse individuals and households. Courtesy of the
                   Mackin Group</head>
-               <graphic url="...000086/resources/figure01.jpg"/>
+               <graphic url="resources/figure01.jpg"/>
                <figDesc>Burbank Street Building</figDesc>
             </figure>
             <sp>
@@ -318,7 +318,7 @@
                   Administration (FHA). These contracts provided protections against rent increases
                   and evictions. <ptr target="#achtenberg1974"/>
                </head>
-               <graphic url="...000086/resources/figure02.jpg"/>
+               <graphic url="resources/figure02.jpg"/>
                <figDesc>Cover:<title rend="italic">Tenants First! A Research and Organizing Guide to
                      FHA Housing.</title>
                </figDesc>
@@ -425,7 +425,7 @@
                <figDesc>
                   <title rend="italic">Chicago Defender</title> headline, <title rend="quotes">Hansberry Decision Opens New Homes to Race</title>
                </figDesc>
-               <graphic url="...000086/resources/figure03.jpg"/>
+               <graphic url="resources/figure03.jpg"/>
             </figure>
             <sp>
                <speaker>Irish</speaker>
@@ -445,13 +445,13 @@
                   <head>Portion of print edition of Alexander Pope's <title rend="italic">The
                      Dunciad</title>. Text Encoding Initiative, <ref target="http://www.tei-c.org/release/doc/tei-p5-doc/fr/html/SA.html">http://www.tei-c.org/release/doc/tei-p5-doc/fr/html/SA.html</ref>.</head>
                   <figDesc>Screenshot of example text.</figDesc>
-                  <graphic url="...000086/resources/figure04.jpg"/>
+                  <graphic url="resources/figure04.jpg"/>
                </figure>
                <figure xml:id="figure05">
                   <head>Several lines of Pope's <title rend="italic">The Dunciad</title> with TEI
                      mark-up. Text Encoding Initiative, <ref target="http://www.tei-c.org/release/doc/tei-p5-doc/fr/html/SA.html">http://www.tei-c.org/release/doc/tei-p5-doc/fr/html/SA.html</ref>.</head>
                   <figDesc>Screenshot of example mark-up.</figDesc>
-                  <graphic url="...000086/resources/figure05.jpg"/>
+                  <graphic url="resources/figure05.jpg"/>
                </figure>
                <p> Working at the TEI triggered my interest in the effects of digitization on the
                   production of history. In 1991, I decided to do an independent study on the
@@ -606,7 +606,7 @@
                <head>An example of the interface of a Bulletin Board System (BBS), an early group
                   messaging system in the 1980s and 1990s. Vintage Computing and Gaming, <ref target="http://www.vintagecomputing.com/wp-content/bbsmenu_large.jpg">http://www.vintagecomputing.com/wp-content/bbsmenu_large.jpg</ref>.</head>
                <figDesc>Bulletin Board System Interface Screenshot</figDesc>
-               <graphic url="...000086/resources/figure06.jpg"/>
+               <graphic url="resources/figure06.jpg"/>
             </figure>
             <sp>
                <speaker>Irish</speaker>
@@ -638,7 +638,7 @@
                <head>Sidebar showing early H-Net lists at UIC. Thomas J. DeLoughry, <title rend="quotes">History, Post-Print</title>, <title rend="italic">Chronicle of
                      Higher Education</title> (12 January 1994), A19.</head>
                <figDesc/>
-               <graphic url="...000086/resources/figure07.jpg"/>
+               <graphic url="resources/figure07.jpg"/>
             </figure>
             <sp>
                <speaker>Irish</speaker>
@@ -908,7 +908,7 @@
                   <title rend="italic">Chronicle of Higher Education</title> 43:20 (24 January
                   1997), A23-A24.</head>
                <figDesc>H-Net Lists Sample Discussions</figDesc>
-               <graphic url="...000086/resources/figure08.jpg"/>
+               <graphic url="resources/figure08.jpg"/>
             </figure>
             <sp>
                <speaker>Irish</speaker>
@@ -1107,7 +1107,7 @@
                      faith among historians in the existence of a single objective truth.</head>
                   <figDesc>The cover image of <title rend="italic">That Noble
                      Dream</title>.</figDesc>
-                  <graphic url="...000086/resources/figure09.jpg"/>
+                  <graphic url="resources/figure09.jpg"/>
                </figure>
                <p> However, I believe that this outlook denies the degree to which good historical
                   monographs consist of <emph>debatable facts</emph> and <emph>ideas</emph> that can
@@ -1175,7 +1175,7 @@
                   City</title> (Yale University Press, 1995).</head>
                <figDesc>Cover of <title rend="italic">The Encyclopedia of New York
                   City</title>.</figDesc>
-               <graphic url="...000086/resources/figure10.jpg"/>
+               <graphic url="resources/figure10.jpg"/>
             </figure>
             <sp>
                <speaker>Irish</speaker>
@@ -1435,7 +1435,7 @@
                   Prints and Photographs, Farm Security Administration, Office of War Information
                   Photograph Collection, <ref target="http://www.loc.gov/rr/microform/images/microfilm.jpg">http://www.loc.gov/rr/microform/images/microfilm.jpg</ref>.</head>
                <figDesc/>
-               <graphic url="...000086/resources/figure11.jpg"/>
+               <graphic url="resources/figure11.jpg"/>
             </figure>
             <sp>
                <speaker>Irish</speaker>

--- a/articles/000088/000088.xml
+++ b/articles/000088/000088.xml
@@ -171,10 +171,10 @@
                      right hand side: editorial notes.</head>
                     <row>
                         <cell>
-                            <graphic url="...000088/resources/figure01.jpg"/>
+                            <graphic url="resources/figure01.jpg"/>
                         </cell>
                         <cell>
-                            <graphic url="...000088/resources/figure02.jpg"/>
+                            <graphic url="resources/figure02.jpg"/>
                         </cell>
                     </row>
                 </table>
@@ -196,7 +196,7 @@
                   <head>Snippet from volume 6: first part of the list of references to
                      London in the index of places.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure03.jpg"/>
+                    <graphic url="resources/figure03.jpg"/>
                 </figure>
                 <p>Therefore, the indices in the print edition are available only in the final
                     volume, where occurrences are expressed by volume number followed by page
@@ -235,10 +235,10 @@
                      space or aesthetic reasons.</head>
                     <row>
                         <cell>
-                            <graphic url="...000088/resources/figure04.jpg"/>
+                            <graphic url="resources/figure04.jpg"/>
                         </cell>
                         <cell>
-                            <graphic url="...000088/resources/figure05.jpg"/>
+                            <graphic url="resources/figure05.jpg"/>
                         </cell>
                     </row>
                 </table>
@@ -257,10 +257,10 @@
                      composition together with real dimension at the top. </head>
                     <row>
                         <cell>
-                            <graphic url="...000088/resources/figure06.jpg"/>
+                            <graphic url="resources/figure06.jpg"/>
                         </cell>
                         <cell>
-                            <graphic url="...000088/resources/figure07.jpg"/>
+                            <graphic url="resources/figure07.jpg"/>
                         </cell>
                     </row>
                 </table>
@@ -302,7 +302,7 @@
                      it, and the list of recently visited letters (possibly the only element
                      aiming at tracking the user’s navigation in this web edition).</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure08.jpg"/>
+                    <graphic url="resources/figure08.jpg"/>
                 </figure>
                 <p>The facsimiles of the letters can be kept at the level of the other viewing
                     panels or be enlarged, panned, or zoomed in and out in a separate window.</p>
@@ -311,7 +311,7 @@
                      left (panel 1), column containing the letter metadata, facsimile (panel 2)
                      and artworks panel at the far right (panel 3).</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure09.jpg"/>
+                    <graphic url="resources/figure09.jpg"/>
                 </figure>
                <figure xml:id="figure10">
                   <head>A grey label and icon signals the presence of a sketch at the
@@ -321,12 +321,12 @@
                      section on the grey label together with the guiding sequence of verso/recto
                      in the facsimile window.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure10.jpg"/>
+                    <graphic url="resources/figure10.jpg"/>
                 </figure>
                <figure xml:id="figure11">
                   <head>Example of zoomed up sketch.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure11.jpg"/>
+                    <graphic url="resources/figure11.jpg"/>
                 </figure>
                 <p>Once at play with all these textual and graphic objects, one regrets, for
                     instance, that the sketches cannot be rotated on the fly when desirable.</p>
@@ -342,7 +342,7 @@
                      one of the letter we can reach the index of these references with only one
                      click.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure12.jpg"/>
+                    <graphic url="resources/figure12.jpg"/>
                 </figure>
                 <p>This is the case not only for explicit and recognisable proper names but also for
                     general referencing strings. The reader can mouse over such strings to get a
@@ -382,7 +382,7 @@
                      we were looking for. By clicking on the search tab, we get to the search
                      results shown below.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure13.jpg"/>
+                    <graphic url="resources/figure13.jpg"/>
                 </figure>
                <figure xml:id="figure14">
                   <head>An action of mouse over the relevant reference to a letter in the
@@ -391,7 +391,7 @@
                      across search results by speeding up the discovery of the relevant letter
                      and by avoiding useless steps of direct consultations.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure14.jpg"/>
+                    <graphic url="resources/figure14.jpg"/>
                 </figure>
                <figure xml:id="figure15">
                   <head>Here is the final step of the search process outlined above: the
@@ -401,7 +401,7 @@
                      The latter are signalled with a distinctive round orange and brown icon
                      which makes them easy to spot while screening the text.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure15.jpg"/>
+                    <graphic url="resources/figure15.jpg"/>
                 </figure>
                <figure xml:id="figure16">
                   <head>This painting (<title rend="italic">Piles of French novels and a
@@ -416,7 +416,7 @@
                      thread compared to the ones one can expand, reconstruct, deconstruct and
                      re-invent browsing the web edition.</head>
                     <figDesc/>
-                    <graphic url="...000088/resources/figure16.jpg"/>
+                    <graphic url="resources/figure16.jpg"/>
                 </figure>
             </div>
             <div>

--- a/articles/000089/000089.xml
+++ b/articles/000089/000089.xml
@@ -696,7 +696,7 @@
                   <head>A partial family tree of ADVENTURE, showing ports,
                      modifications and reimplementations.</head>
                     <figDesc/>
-                    <graphic url="...000089/resources/figure01.jpg"/>
+                    <graphic url="resources/figure01.jpg"/>
                 </figure>
                 <p>This typology of changes highlights one of the unique features about interactive
                     fiction works such as ADVENTURE as textual artifacts, and one of the
@@ -859,7 +859,7 @@
                <figure xml:id="figure02">
                   <head>FRBR Expressions of ADVENTURE</head>
                     <figDesc/>
-                    <graphic url="...000089/resources/figure02.jpg"/>
+                    <graphic url="resources/figure02.jpg"/>
                 </figure>
                 <p>Unfortunately, an alternative in which we claim that all three source code
                     expressions produce a single executable expression with three different
@@ -884,7 +884,7 @@
                   <head>ADVENTURE with a Single Executable
                      Expression</head>
                     <figDesc/>
-                    <graphic url="...000089/resources/figure03.jpg"/>
+                    <graphic url="resources/figure03.jpg"/>
                 </figure>
                 <p>The compilation of the three different source files here raises other questions
                     with respect to the nature of games and their description within a FRBR
@@ -971,7 +971,7 @@
                   <head>FRBR Group 1 Entity Relationships for two ADVENTURE
                      Works</head>
                     <figDesc/>
-                    <graphic url="...000089/resources/figure04.jpg"/>
+                    <graphic url="resources/figure04.jpg"/>
                 </figure>
                 <p>The description of computer games within the FRBR model provides a reasonably
                     compelling justification for the notion of a Superwork, a potential addition to
@@ -1013,7 +1013,7 @@
                   <head>Doom Series Game Mods Page from
                      fileplanet.com.</head>
                     <figDesc/>
-                    <graphic url="...000089/resources/figure05.jpg"/>
+                    <graphic url="resources/figure05.jpg"/>
                 </figure>
                 <p>One final comment should be made about the FRBR model and its application to
                     computer games and interactive fiction. While the focus of our analysis has

--- a/articles/000090/000090.xml
+++ b/articles/000090/000090.xml
@@ -879,7 +879,7 @@
               <soCalled>underground,</soCalled> and the <soCalled>warm</soCalled> inside design of the lab.</p>
                <figure xml:id="figure01">
                   <head>Photo of HUMlab (original lab space)</head>
-                  <graphic url="...000090/resources/images/figure01.jpg"/>
+                  <graphic url="resources/images/figure01.jpg"/>
                   <figDesc/>
                </figure>
                <p>The foundational function is further evidenced through 24 pillars and the rotunda,
@@ -1464,7 +1464,7 @@
             laptop-friendly table and a new combined whiteboard and projection screen (see <ref target="#figure03">Figure 3</ref>). </p>
                <figure xml:id="figure03">
                   <head>Photo of HUMlab (redesigned corner)</head>
-                  <graphic url="...000090/resources/images/figure03.jpg"/>
+                  <graphic url="resources/images/figure03.jpg"/>
                   <figDesc/>
                </figure>
                <p>After the corner space was redesigned into this more <soCalled>café-like</soCalled> setting, usage
@@ -1698,7 +1698,7 @@
             administration.</p>
                <figure xml:id="figure04">
                   <head>Rendering of HUMlab from 2006 (based on a 3D model)</head>
-                  <graphic url="...000090/resources/images/figure04.jpg"/>
+                  <graphic url="resources/images/figure04.jpg"/>
                   <figDesc/>
                </figure>
                <p>In Figure 4, the right hand side of the visualization represents the existing part of

--- a/articles/000090/000090.xml
+++ b/articles/000090/000090.xml
@@ -916,7 +916,7 @@
                <figure xml:id="figure02">
                   <head>Photo of HUMlab (part of the screenscape and the expanded studio
                      space)</head>
-                  <graphic url=".../000090/resources/images/figure02.jpg"/>
+                  <graphic url="resources/images/figure02.jpg"/>
                   <figDesc/>
                </figure>
                <p>These public screens are simultaneously individual and part of the screenscape, and

--- a/articles/000091/000091.xml
+++ b/articles/000091/000091.xml
@@ -274,7 +274,7 @@
                   identities (gender) and temporality (now) are all self-evident. Graphic credit Xárene Eskandar.</head>
                <figDesc>Bar chart comparing the percentage of men and women in national populations at
             the present time.</figDesc>
-               <graphic url="...000091/resources/images/figure01.jpg"/>
+               <graphic url="resources/images/figure01.jpg"/>
             </figure>
             <p>Certain issues immediately arise. A standard critique of data introduces reservations
           about the appearance of certainty such a chart presents. What counts as a nation? Are
@@ -304,7 +304,7 @@
                 entities. Graphic credit Xárene Eskandar.</head>
                   <figDesc>Bar chart showing gender modification with paired male and female columns
               labelled A through F.</figDesc>
-                  <graphic url="...000091/resources/images/figure02.jpg"/>
+                  <graphic url="resources/images/figure02.jpg"/>
                </figure>
             </p>
             <p>The point I’m making is that the basic categories of supposedly quantitative information,
@@ -430,7 +430,7 @@
                   publisher in the years 1855-1862.</head>
                <figDesc>Chart showing novels put into print by a single publisher in the years
             1855-1862.</figDesc>
-               <graphic url="...000091/resources/images/figure03.jpg"/>
+               <graphic url="resources/images/figure03.jpg"/>
             </figure>
             <figure xml:id="figure04">
                <head>The <soCalled>appearance</soCalled> in 1855 of fourteen novels is shown in relation
@@ -440,7 +440,7 @@
                   considered in relation to any number of variables, not just the moment of its
                   publication. Graphic credit Xárene Eskandar.</head>
                <figDesc/>
-               <graphic url="...000091/resources/images/figure04.jpg"/>
+               <graphic url="resources/images/figure04.jpg"/>
             </figure>
             <p>For instance, what is a novel, what does <soCalled>published</soCalled> mean in this context (date of
           appearance, editing, composition, acquisition, review, distribution), and how was the
@@ -471,7 +471,7 @@
                   feelings in the course of an afternoon. Standard metrics are used and a graphical
                   display of the quantized experience appears. Graphic credit Xárene Eskandar.</head>
                <figDesc>A chart showing mood over time.</figDesc>
-               <graphic url="...000091/resources/images/figure05.jpg"/>
+               <graphic url="resources/images/figure05.jpg"/>
             </figure>
             <p>The next task is more complicated. Subjective information, that is information whose
           constitution exhibits its subjective character, deviates from the standard norms by using
@@ -499,7 +499,7 @@
                </head>
                <figDesc>A chart featuring words of different sizes, shades, and boldness in multiple
             columns.</figDesc>
-               <graphic url="...000091/resources/images/figure06.jpg"/>
+               <graphic url="resources/images/figure06.jpg"/>
             </figure>
             <p>A subjective grid to show anxiety might have a widely varying set of spacings to show
           that the information on display is constituted as a variable of some other aspect of
@@ -581,7 +581,7 @@
                 lower branch curve back to allow a retrospective view of the event’s unfolding back
                 onto an earlier moment. Graphic credit Xárene Eskandar.</head>
                   <figDesc>Terminus event and critical response images.</figDesc>
-                  <graphic url="...000091/resources/images/figure07.jpg"/>
+                  <graphic url="resources/images/figure07.jpg"/>
                </figure> These visualizations express the topological and systemic complexity necessary
           to model the number of variables (of coordinates, forces, and the changing relations of
           variables) present in the experience of events, and/or analysis of their representation in
@@ -594,7 +594,7 @@
                 shown as vectors. The first shows the event as a fold, the second shows it as a
                 vortex. Graphic credit Xárene Eskandar.</head>     
                   <figDesc>Two charts showing an event reaching crisis.</figDesc>
-                  <graphic url="...000091/resources/images/figure08.jpg"/>
+                  <graphic url="resources/images/figure08.jpg"/>
                </figure> But even standard coordinate systems, such as the conventions of perspectival
           drawing, allow for the interpretative quality temporal experience to be expressed more
           fully than is possible with standard timelines. A parallax view, in which prospective
@@ -612,7 +612,7 @@
                 as per the old temporal modeling design, and its position on the bottom line indicates
                 the position of the observer within the course of even. Graphic credit Xárene Eskandar.</head>
                   <figDesc>Figure 9 — Two linear charts showing anticipation and assessment of an event.</figDesc>
-                  <graphic url="...000091/resources/images/figure09.jpg"/>
+                  <graphic url="resources/images/figure09.jpg"/>
                </figure> By breaking the relentlessly regular grid, the potential for graphing temporal
           modeling as a complex system of events is greatly enhanced. The relational, and
           co-dependent quality of temporal events finds its expression in these more sophisticated
@@ -636,18 +636,18 @@
                   change from one state to another (changes in degrees of anxiety) is shown in a
                   continuous line. Graphic credit Xárene Eskandar.</head>
                <figDesc>A chart showing anxiety over time.</figDesc>
-               <graphic url="...000091/resources/images/figure10.jpg"/>
+               <graphic url="resources/images/figure10.jpg"/>
             </figure>
             <figure xml:id="figure11">
                <head>The difference between one state and the next is used to generate
                   a graphical form that is expresses the changes from one moment to another. Graphic credit Xárene Eskandar.</head>
                <figDesc>A chart showing anxiety intensity over time.</figDesc>
-               <graphic url="...000091/resources/images/figure11.jpg"/>
+               <graphic url="resources/images/figure11.jpg"/>
             </figure>
             <figure xml:id="figure12">
                <head/>
                <figDesc>A chart showing percieved anxiety over perceived time.</figDesc>
-               <graphic url="...000091/resources/images/figure12.jpg"/>
+               <graphic url="resources/images/figure12.jpg"/>
             </figure>
             <figure xml:id="figure13">
                <head>The differences between states are projected onto the
@@ -660,7 +660,7 @@
                   independent <soCalled>time</soCalled> and <soCalled>anxiety</soCalled> to one created as an effect of the experience of time
                   on its expression. Graphic credit Xárene Eskandar.</head>
                <figDesc> A chart showing perceived anxiety over projected time.</figDesc>
-               <graphic url="...000091/resources/images/figure13.jpg"/>
+               <graphic url="resources/images/figure13.jpg"/>
             </figure>
          </div>
          <div>
@@ -780,7 +780,7 @@
                 of equal and neutral elements of a rational spatial system, but one that must be
                 expressed with graphical distortions that show these inflections. Graphic credit Xárene Eskandar.</head>
                   <figDesc>Four charts showing change in state or circumstance.</figDesc>
-                  <graphic url="...000091/resources/images/figure14.jpg"/>
+                  <graphic url="resources/images/figure14.jpg"/>
                </figure> Police barriers are set up and suddenly make that bit of beach into a highly
           charged site. Additional fences create zones of potential transgression and prohibition,
           lines in the literal sand that when crossed by graffiti artists and taggers, vandals and
@@ -820,7 +820,7 @@
                 the metric grid are warped by the impact of an event, or events, that have simply
                 reordered the standard grid. Graphic credit Xárene Eskandar.</head>
                   <figDesc>Geographical terrain and experienced travel image.</figDesc>
-                  <graphic url="...000091/resources/images/figure15.jpg"/>
+                  <graphic url="resources/images/figure15.jpg"/>
                </figure> That is a subjective expression. The two approaches are radically
           different. In the second instance, space is an effect of spatial relations, spatiality is
           expressed as a factor of disturbance, and it might be expressed as a factor of many
@@ -906,7 +906,7 @@
                 others when depicted from within the gaze of someone actually seeing them occur.
                 Graphic credit Xárene Eskandar.</head>
                   <figDesc>Dr. John Snow's chart tracing the source of an epidemic.</figDesc>
-                  <graphic url="...000091/resources/images/figure16.jpg"/>
+                  <graphic url="resources/images/figure16.jpg"/>
                </figure> The distribution of dots on the street map makes evident the role of the pump by
           the way they cluster. A useful map, crucial to analysis, its clarity and succinctness
           served an important purpose. It was sufficient to that purpose, adequate, but we could
@@ -923,7 +923,7 @@
                <figure xml:id="figure17">
                   <head>Snow's chart altered. Graphic credit Xárene Eskandar.</head>
                   <figDesc>Snow's chart altered.</figDesc>
-                  <graphic url="...000091/resources/images/figure17.jpg"/>
+                  <graphic url="resources/images/figure17.jpg"/>
                </figure>
           These latter are all instances of the graphical expression of humanistic interpretation. They are as different from the
           visual display of quantitative information as a close reading of a poem is from the chart

--- a/articles/000103/000103.xml
+++ b/articles/000103/000103.xml
@@ -515,7 +515,7 @@
           and contextualized process.</p>
         <figure xml:id="figure01">
           <head>The StoryTrek Authorware.</head>
-          <graphic url="...000103/resources/figure01.jpg"/>
+          <graphic url="resources/figure01.jpg"/>
           <figDesc/>
         </figure>
         <p>For our initial test implementation, Pippin Barr of the IT University of Copenhagen
@@ -535,7 +535,7 @@
           environment and activity over time.</p>
         <figure xml:id="figure02">
           <head>Pippin Barr's <title rend="italic">Crisis 22</title>.</head>
-          <graphic url="...000103/resources/figure02.jpg"/>
+          <graphic url="resources/figure02.jpg"/>
           <figDesc/>
         </figure>
         <p>
@@ -607,12 +607,12 @@
           fragmentation and montage characteristic of so many hypertext narratives.</p>
         <figure xml:id="figure03">
           <head>Sarah and Celine read <title rend="italic">Crisis 22</title>.</head>
-          <graphic url="...000103/resources/figure03.jpg"/>
+          <graphic url="resources/figure03.jpg"/>
           <figDesc/>
         </figure>
         <figure xml:id="figure04">
           <head>Celine tests the boundaries of StoryTrek.</head>
-          <graphic url="...000103/resources/figure04.jpg"/>
+          <graphic url="resources/figure04.jpg"/>
           <figDesc/>
         </figure>
       </div>

--- a/articles/000151/resources/xslt/000151.xsl
+++ b/articles/000151/resources/xslt/000151.xsl
@@ -7,7 +7,7 @@
     xmlns:cc="http://web.resource.org/cc/"
     exclude-result-prefixes="tei dhq cc xdoc" version="1.0">
     
-    <xsl:import href="../../../../common/xslt/template_editorial_article.xsl"/>
+    <xsl:import href="../../../../common/xslt/template_article.xsl"/>
     
     <xsl:template match="tei:ab[@type = 'imageGallery']">
         <div class="galleria" style="margin-left:auto; margin-right:auto;">

--- a/articles/000212/resources/xslt/000212.xsl
+++ b/articles/000212/resources/xslt/000212.xsl
@@ -7,7 +7,7 @@
     xmlns:cc="http://web.resource.org/cc/"
     exclude-result-prefixes="tei dhq cc xdoc" version="1.0">
 
-    <xsl:import href="../../../../common/xslt/template_editorial_article.xsl"/>
+    <xsl:import href="../../../../common/xslt/template_article.xsl"/>
   
     <xsl:template match="tei:ab[@type = 'imageGallery']">
         <div class="galleria" style="margin-left:auto; margin-right:auto;">

--- a/articles/000214/000214.xml
+++ b/articles/000214/000214.xml
@@ -21,7 +21,7 @@
             <!-- This information will be completed at publication -->
             <idno type="DHQarticle-id">000214</idno>
             <idno type="volume">009</idno>
-            <idno type="issue">3</idno>
+            <idno type="issue">4</idno>
             <date when="2015-12-23">23 December 2015</date>
             <dhq:articleType>article</dhq:articleType>
             <availability status="CC-BY-ND">

--- a/articles/000214/resources/xslt/000214.xsl
+++ b/articles/000214/resources/xslt/000214.xsl
@@ -7,7 +7,7 @@
     xmlns:cc="http://web.resource.org/cc/"
     exclude-result-prefixes="tei dhq cc xdoc" version="1.0">
 
-    <xsl:import href="../../../../common/xslt/template_editorial_article.xsl"/>
+    <xsl:import href="../../../../common/xslt/template_article.xsl"/>
   
     <xsl:template match="tei:ab[@type = 'imageGallery']">
         <div class="galleria" style="margin-left:auto; margin-right:auto;">

--- a/articles/000218/resources/xslt/000218.xsl
+++ b/articles/000218/resources/xslt/000218.xsl
@@ -7,7 +7,7 @@
     xmlns:cc="http://web.resource.org/cc/"
     exclude-result-prefixes="tei dhq cc xdoc" version="1.0">
 
-    <xsl:import href="../../../../common/xslt/template_editorial_article.xsl"/>
+    <xsl:import href="../../../../common/xslt/template_article.xsl"/>
   
     <xsl:template match="tei:ab[@type = 'imageGallery']">
         <div class="galleria" style="margin-left:auto; margin-right:auto;">

--- a/articles/000501/resources/xslt/000501.xsl
+++ b/articles/000501/resources/xslt/000501.xsl
@@ -7,7 +7,7 @@
     xmlns:cc="http://web.resource.org/cc/"
     exclude-result-prefixes="tei dhq cc xdoc" version="1.0">
     
-    <xsl:import href="../../../../common/xslt/template_editorial_article.xsl"/>
+    <xsl:import href="../../../../common/xslt/template_article.xsl"/>
     
     
     <xsl:template name="customHead">

--- a/articles/000575/000575.xml
+++ b/articles/000575/000575.xml
@@ -22,7 +22,7 @@
             <!--This information will be completed at publication-->
             <idno type="DHQarticle-id">000575</idno>
             <idno type="volume">015</idno>
-            <idno type="issue">3</idno>
+            <idno type="issue">4</idno>
             <date when="2021-11-19">November 19, 2021</date>
             <dhq:articleType>article</dhq:articleType>
             <availability status="CC-BY-ND">

--- a/articles/000620/000620.xml
+++ b/articles/000620/000620.xml
@@ -37,7 +37,7 @@
             <!--This information will be completed at publication-->
             <idno type="DHQarticle-id"><!--including leading zeroes: e.g. 000110-->000620</idno>
             <idno type="volume"><!--volume number, with leading zeroes as needed to make 3 digits: e.g. 006-->016</idno>
-            <idno type="issue"><!--issue number, without leading zeroes: e.g. 2-->2</idno>
+            <idno type="issue"><!--issue number, without leading zeroes: e.g. 2-->3</idno>
             <date when="2022-06-25">25 June 2022</date>
             <dhq:articleType>article</dhq:articleType>
             <availability status="CC-BY-ND">

--- a/common/xslt/author_index.xsl
+++ b/common/xslt/author_index.xsl
@@ -70,15 +70,16 @@
     <xsl:template match="tei:TEI">
         <xsl:param name="vol"><xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='volume'])"/></xsl:param>
         <xsl:param name="vol_no_zeroes">
-            <xsl:call-template name="get-vol">
-                <xsl:with-param name="vol">
-                    <xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='volume'])"/>
-                </xsl:with-param>
-            </xsl:call-template>
+            <xsl:variable name="use_vol">
+              <xsl:call-template name="get-vol">
+                  <xsl:with-param name="vol" select="$vol"/>
+              </xsl:call-template>
+            </xsl:variable>
+            <xsl:value-of select="normalize-space($use_vol)"/>
         </xsl:param>
-        <xsl:param name="issue"><xsl:value-of select="tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='issue']"/></xsl:param>
+        <xsl:param name="issue"><xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='issue'])"/></xsl:param>
         <xsl:param name="id">
-            <xsl:value-of select="tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='DHQarticle-id']"/>
+            <xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='DHQarticle-id'])"/>
         </xsl:param>
         <xsl:param name="title"><xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title)"/></xsl:param>
         <xsl:param name="issueTitle"><xsl:apply-templates select="document('../../toc/toc.xml')//journal[@vol=$vol_no_zeroes and @issue=$issue]/title"/></xsl:param>

--- a/common/xslt/author_index.xsl
+++ b/common/xslt/author_index.xsl
@@ -114,9 +114,34 @@
                         </xsl:choose>
                         
                         <xsl:element name="a">
-                            <xsl:attribute name="href">
+                          <xsl:choose>
+                            <!-- If the article has no volume or issue information, do not include @href. -->
+                            <xsl:when test="$vol_no_zeroes = '' or $issue = ''">
+                              <xsl:message terminate="no">
+                                <xsl:text>Article </xsl:text>
+                                <xsl:value-of select="$id"/>
+                                <xsl:text> has a volume of '</xsl:text>
+                                <xsl:value-of select="$vol"/>
+                                <xsl:text>' and an issue of '</xsl:text>
+                                <xsl:value-of select="$issue"/>
+                                <xsl:text>'</xsl:text>
+                              </xsl:message>
+                              <!-- The attributes below are an inelegant hack to make sure that this link 
+                                appears not to be actionable. A better solution would be to just display the 
+                                text of the title instead, sans <a>. However, XSLT 1 and the need to 
+                                accommodate different languages makes this difficult to do at this time.
+                                See https://css-tricks.com/how-to-disable-links/ for more on "disabling" links. -->
+                              <xsl:attribute name="aria-disabled">true</xsl:attribute>
+                              <xsl:attribute name="style">color:currentColor;text-decoration:none;</xsl:attribute>
+                            </xsl:when>
+                            <xsl:otherwise>
+                              <xsl:attribute name="href">
                                 <xsl:value-of select="concat('/',$context,'/vol/',$vol_no_zeroes,'/',$issue,'/',$id,'/',$id,'.html')"/>
-                            </xsl:attribute>
+                              </xsl:attribute>
+                            </xsl:otherwise>
+                          </xsl:choose>
+                            
+                            
                             <xsl:if test="//tei:title/@xml:lang != 'en'">
                                 <xsl:attribute name="onclick">
                                     <xsl:value-of select="concat('localStorage.setItem(', $apos, 'pagelang', $apos, ', ', $apos, @xml:lang, $apos, ');')"/>

--- a/common/xslt/sidenavigation.xsl
+++ b/common/xslt/sidenavigation.xsl
@@ -95,7 +95,7 @@
                 <xsl:value-of select="'margin-left : 7px;'"/>
             </xsl:attribute>
             <xsl:attribute name="alt">
-                <xsl:value-of select="'sidenavbarimg'"/>
+                <xsl:value-of select="''"/>
             </xsl:attribute>
         </img>
         

--- a/common/xslt/sidenavigation.xsl
+++ b/common/xslt/sidenavigation.xsl
@@ -110,7 +110,7 @@
             <ul>
                 <li>
                     <a><xsl:attribute name="href">
-                        <xsl:value-of select="concat('/',$context,'/announcements/index.html#reviewers')"
+                        <xsl:value-of select="concat('/',$context,'/news/news.html#peer_reviews')"
                         />
                     </xsl:attribute>Call for Reviewers</a>
                 </li>

--- a/common/xslt/sidenavigation.xsl
+++ b/common/xslt/sidenavigation.xsl
@@ -117,7 +117,7 @@
                 <li>
                     <a><xsl:attribute name="href">
                         <xsl:value-of
-                            select="concat('/',$context,'/announcements/index.html#submissions')"/>
+                            select="concat('/',$context,'/submissions/index.html#logistics')"/>
                     </xsl:attribute>Call for Submissions</a>
                 </li>
             </ul>

--- a/common/xslt/template_preview_bios.xsl
+++ b/common/xslt/template_preview_bios.xsl
@@ -22,7 +22,7 @@
                 <div id="main">
                     <div id="leftsidebar">
                         <xsl:call-template name="sidenavigation">
-                            <xsl:with-param name="session" select="'true'"/>
+                            <!--<xsl:with-param name="session" select="'true'"/>-->
                         </xsl:call-template>
                     </div>
                     <div id="mainContent">

--- a/common/xslt/title_index.xsl
+++ b/common/xslt/title_index.xsl
@@ -112,9 +112,32 @@
                 </xsl:choose>
                 
                 <xsl:element name="a">
-                    <xsl:attribute name="href">
-                        <xsl:value-of select="concat('/',$context,'/vol/',$vol_no_zeroes,'/',$issue,'/',$id,'/',$id,'.html')"/>
-                    </xsl:attribute>
+                    <xsl:choose>
+                      <!-- If the article has no volume or issue information, do not include @href. -->
+                      <xsl:when test="$vol_no_zeroes = '' or $issue = ''">
+                        <xsl:message terminate="no">
+                          <xsl:text>Article </xsl:text>
+                          <xsl:value-of select="$id"/>
+                          <xsl:text> has a volume of '</xsl:text>
+                          <xsl:value-of select="$vol"/>
+                          <xsl:text>' and an issue of '</xsl:text>
+                          <xsl:value-of select="$issue"/>
+                          <xsl:text>'</xsl:text>
+                        </xsl:message>
+                        <!-- The attributes below are an inelegant hack to make sure that this link 
+                          appears not to be actionable. A better solution would be to just display the 
+                          text of the title instead, sans <a>. However, XSLT 1 and the need to 
+                          accommodate different languages makes this difficult to do at this time.
+                          See https://css-tricks.com/how-to-disable-links/ for more on "disabling" links. -->
+                        <xsl:attribute name="aria-disabled">true</xsl:attribute>
+                        <xsl:attribute name="style">color:currentColor;text-decoration:none;</xsl:attribute>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:attribute name="href">
+                          <xsl:value-of select="concat('/',$context,'/vol/',$vol_no_zeroes,'/',$issue,'/',$id,'/',$id,'.html')"/>
+                        </xsl:attribute>
+                      </xsl:otherwise>
+                    </xsl:choose>
                     <xsl:if test="//tei:title/@xml:lang != 'en'">
                         <xsl:attribute name="onclick">
                             <xsl:value-of select="concat('localStorage.setItem(', $apos, 'pagelang', $apos, ', ', $apos, @xml:lang, $apos, ');')"/>

--- a/common/xslt/title_index.xsl
+++ b/common/xslt/title_index.xsl
@@ -61,15 +61,16 @@
     <xsl:template match="tei:TEI">
         <xsl:param name="vol"><xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='volume'])"/></xsl:param>
         <xsl:param name="vol_no_zeroes">
-            <xsl:call-template name="get-vol">
-                <xsl:with-param name="vol">
-                    <xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='volume'])"/>
-                </xsl:with-param>
-            </xsl:call-template>
+            <xsl:variable name="use_vol">
+              <xsl:call-template name="get-vol">
+                  <xsl:with-param name="vol" select="$vol"/>
+              </xsl:call-template>
+            </xsl:variable>
+            <xsl:value-of select="normalize-space($use_vol)"/>
         </xsl:param>
-        <xsl:param name="issue"><xsl:value-of select="tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='issue']"/></xsl:param>
+        <xsl:param name="issue"><xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='issue'])"/></xsl:param>
         <xsl:param name="id">
-            <xsl:value-of select="tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='DHQarticle-id']"/>
+            <xsl:value-of select="normalize-space(tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:idno[@type='DHQarticle-id'])"/>
         </xsl:param>
         <xsl:param name="issueTitle"><xsl:apply-templates select="document('../../toc/toc.xml')//journal[@vol=$vol_no_zeroes and @issue=$issue]/title"/></xsl:param>
         


### PR DESCRIPTION
Fixing more broken links found during static site generation. Most of the things fixed here were problems in the main DHQ site as well as my static copy.

- The left sidebar has updated links for "Announcements" **(let me know if these should be changed!)**:
  - [Call for Reviewers](https://digitalhumanities.org/dhq/news/news.html#peer_reviews)
  - [Call for Submissions](https://digitalhumanities.org/dhq/submissions/index.html#logistics)
- Custom article stylesheets now import the regular article XSLT, not the "editorial" one.
- Whitespace in the `<teiHeader>` entries for volume, issue, and article ID is now normalized in both the title and author indexes.
- Strange URLs with the regex pattern `\.{3,}000\d\d\d/resources/images` or `\.{2,}/000\d\d\d/resources/images` have been adjusted to just `resources/images`. (Most of these work in DHQ, thanks to Cocoon magic.)
- The `$session` parameter set in `template_preview_bios.xsl` has been commented out. This should keep a "Log out" button from appearing on `/preview/bios.html`.
- The indexes for titles and authors no longer place `@href` on `<a>` when an article is missing its volume and/or issue number in the `<teiHeader>`.

I also replaced the alt text on the image that forms the border of the left-hand sidebar. Since it's decorative, the `@alt` attribute has an empty string indicating that screen readers should ignore it.