### PR TITLE
Toc re org

### DIFF
--- a/toc/toc.xml
+++ b/toc/toc.xml
@@ -51,52 +51,84 @@
     An <item> is a blank element, containing only a required six digit @id to
     indicate the article ID number. ID numbers are sequentially numbered, but
     do not have to be ordered sequentially. Their order within the table of
-    contents XML file dictates their order in the generated table of contents.
--->
+    contents XML file dictates their order in the generated table of contents. -->
 <toc>
 	<journal editorial="true">
 		<cluster>
+			<!-- ENCODING QUEUE
+				
+			The manuscripts listed below are available for encoding.
+			- When a submission is ready for encoding, add it to this list if you are NOT encoding it immediately.
+			- If you ARE encoding it immediately, move to the "Internal Preview" section for instructions.
+			
+			Use the following template to add entries to this list:
+			- For an article		:		AuthorLastName, OJS ####
+			- For a review			:		AuthorLastName (book review), OJS ####
+			- For a case study	:		AuthorLastName (case study), OJS ###
+			
+			ARTICLES & REVIEWS
+			Lejeune, OJS 1634
+			Wang et al (review), OJS 1765
+			
+			SPECIAL ISSUE {TITLE HERE}
+			
+			-->
 			<title>DHQ Internal Preview</title>
-			<!-- ENCODING QUEUE: these articles/reviews are available for encoding!
-					 When an article is ready for encoding, add it here if you're not going to encode it yourself immediately
-				
-				{ $$$$$ "Legacy" article IDs (claim these numbers before progressing beyond 000738) $$$$$ }
-				{ ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––– }
-				{ $$$$$ 000580; 000678; 000722
-				{ $$$$$ Delete any pre-existing content for these IDs and start with a fresh doc    $$$$$ }
-				
-				-->
-			<!-- Special Issue articles -->
-			<!-- Non SI Articles -->
-			<!-- Wang et al. (review), OJS 1765 -->
-			<!-- Lejeune, OJS 1634 -->
 			<list id="articles">
-				<!-- AUTHORIAL REVIEW: move/create an article entry here once an article folder 
-					 and XML file have been created in GitHub. See entry templates below.	-->
-				<!-- Entry templates: -->
-				<!-- AuthorLastName (review); OJS ####; EncoderName encoding OR {ready for author review} OR {awaiting revision confirmation} -->
-				<!-- AuthorLastName; OJS ####; EncoderName encoding OR {ready for author review} OR {awaiting revision confirmation} -->
-				<!-- Current article encoding in progress 
-					
-					$$$ See list of "legacy" article IDs above to be used before adding a value above 000738 $$$
+			<!-- ENCODING IN PROGRESS & INTERNAL PREVIEW
+			
+			Move or create an entry in this list only AFTER a folder and an XML file for the manuscript have been created in GitHub.
+			- Folders and files should be named with a six-digit ID number.
+			- ID values increase sequentially and should not be skipped.
+			- DO NOT create an entry here before creating the folder and file
+				(doing so will break the "Internal Preview" portion of the production website).
+			- Keep <item> elements and their comments on the same line to prevent ambiguity and confusion.
+			
+			Appropriate encoding statuses may vary, but here are some examples:
+			- encoding
+			- out for author review
+			- incorporating revisions
+			- languishing in despair ;)
+			
+			Follow the templates below to create an entry (comment out the info after the <item> element):
+			- For an article		:		<item id="######"/> AuthorLastName, OJS ####; EncoderName {status}
+			- For a review			:		<item id="######"/> AuthorLastName (book review), OJS ####; EncoderName {status}
+			- For a case study	:		<item id="######"/> AuthorLastName (case study), OJS ####; EncoderName {status}
+			-->
 				
-				-->
-				<item id="000432"/><!-- Agarwal (book review), OJS  1582; Benjamin ready for author review -->
+			<!-- TEMPORARY "LEGACY" ID CLEAN-UP PROJECT
+			
+			We are currently trying to ensure the full sequence of DHQ article IDs has been used.
+			- To do so means reintroducing a limited number of "legacy" ID values to the pool of eligible IDs
+			- Before using an ID value above 000738, claim one of the values listed below
+			- Delete any pre-existing content for ID and start with a fresh document
+			
+			Remaining "legacy" IDs: 000580; 000678; 000722
+			
+			This comment should be deleted as soon as it is no longer relevant. -->
+				
+				<item id="000432"/><!-- Agarwal (book review), OJS  1582; Benjamin out for author review -->
 				<item id="000492"/><!-- Thobois (book review), OJS 1613; Benjamin encoding -->
-				<item id="000695"/><!-- Leblanc, OJS 1532; Reba encoding  (aiming for 17.4)-->
+				<item id="000695"/><!-- Leblanc, OJS 1532; Reba encoding -->
 				<item id="000710"/><!-- Varga and Bornhofen, OJS 1500; RB encoding -->
 				<item id="000716"/><!-- Schropp et al., OJS 1534; RB encoding-->
 				<item id="000573"/><!-- Cashner, OJS 1640; Benjamin encoding -->
-				<!--<item id="000576"/> commented out until article is created to keep TOC valid and editorial preview working-->
-				<!-- Plesant, OJS 1645 (book review); Reba encoding -->
-				<item id="000737"/><!-- Bermúdez Sabel et al. (case study), OJS 1627 ; Cailin encoding; awaiting authorial revisions -->
+				<!--<item id="000576"/> commented out until article is created to keep TOC valid and editorial preview working; BRG--><!-- Plesant, OJS 1645 (book review); Reba encoding -->
+				<item id="000737"/><!-- Bermúdez Sabel et al. (case study), OJS 1627 ; Cailin awaiting authorial revisions -->
 				<item id="000424"/><!-- Havens et al. (case study), OJS 1712 ; Cailin encoding -->
-				<!-- <item id="000722"/>  -->
-				<!-- Jakacki (book review), OJS 1545 (status unclear, Evgeniia encoding as a volunteer, Julia is investigating) -->
-				<!-- End of current encoding in progress  -->
-				<!-- Holding area for completed articles for next preview (currently 18.2; 
-					start putting ready-to-publish articles here a few weeks before next issue enters preview)  -->
-				<!-- End of holding area -->
+				<!--<item id="000722"/>--><!-- Jakacki (book review), OJS 1545 (status unclear, Evgeniia encoding as a volunteer, Julia is investigating) -->
+				
+			<!-- NEXT ISSUE HOLDING AREA
+				
+			Only move articles here if we are trying to collect a critical mass of completed encoding for the next preview issue.
+			- This section is not always used in regular production.
+			- Before moving an article here, check with the production team first.
+			
+			ARTICLES & REVIEWS
+			
+			SPECIAL ISSUE {TITLE HERE}
+			
+			-->	
 			</list>
 		</cluster>
 		<cluster>


### PR DESCRIPTION
This request introduces some significant aesthetic improvements to the TOC. Mainly, it does 5 things:

1. It places content-based `<item>` elements and their corresponding `xsl:comments` on the same line of code, thus removing the potential for confusion about which elements correspond to which comments
2. It gives the documentation consistent formatting with the intention of making it easier to read both to experienced encoders (and crucially, to new members of the DHQ team)
3. It clearly lays out conventions for formatting information in `xsl:comments` which relate to `<item>` elements
4. It adjusts and confirms the flow of information so that the document can be read from the top down as a set of instructions which then mirror the actions needed to be taken by the encoder as a document moves through the encoding process.
5. It adds some language to clarify editing the TOC should only be done _after_ the creation of an appropriate article directory. (This change being noteworthy since working in the opposite order risks breaking the Internal Preview area of the production site)

These changes are made with the intention of decreasing encoder confusion about how to edit the TOC. By clarifying what types of information are necessary and where that information should go, encoders should be able to more easily navigate the necessarily significant comment section at the start of the file.