### PR TITLE
GitHub Actions CD Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🐜 Install ant
         run: sudo apt-get update && sudo apt-get install -y ant ant-contrib

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,8 @@
-name: DHQ Production Deploy
+name: Deploy to dhq.digitalhumanities.org
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [ "static_site_generation" ]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ant ant-contrib
 
       - name: 🏗️ Build the site
-        run: ant -lib common/lib/saxon generateSite
+        run: ant -lib common/lib/saxon generateSearchable
 
       - name: 🔐 Create Key File
         run: install -m 600 -D /dev/null ~/.ssh/id_ed25519 && echo "${{ secrets.DHQ_DEPLOY_SSH_PRIVATEKEY }}" > ~/.ssh/id_ed25519

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,27 @@
+name: DHQ Production Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛒 Checkout
+        uses: actions/checkout@v3
+
+      - name: 🐜 Install ant
+        run: sudo apt-get update && sudo apt-get install -y ant ant-contrib
+
+      - name: 🏗️ Build the site
+        run: ant -lib common/lib/saxon generateSite
+
+      - name: 🔐 Create Key File
+        run: install -m 600 -D /dev/null ~/.ssh/id_ed25519 && echo "${{ secrets.DHQ_DEPLOY_SSH_PRIVATEKEY }}" > ~/.ssh/id_ed25519
+
+      - name: 🗃️ Create Known Hosts File
+        run: install -m 600 -D /dev/null ~/.ssh/known_hosts && echo "${{ vars.ADHO_SERVER_IPV4 }} ${{ vars.ADHO_SERVER_HOST_KEY }}" > ~/.ssh/known_hosts
+
+      - name: 🚀 Upload
+        run: rsync --archive --delete --stats /home/runner/work/dhq-journal/dhq-static/dhq/ dhq-deploy@${{ vars.ADHO_SERVER_IPV4 }}:/


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build and deploy the static site directly to dhq.digitalhumanities.org when pushes are made to the `static_site_generation` branch of the repo.

For reference, test runs have been taking 20-25 minutes to complete on the GH Actions runners.

Note: I've already added the `DHQ_DEPLOY_SSH_PRIVATEKEY` secret and the `ADHO_SERVER_IPV4` and `ADHO_SERVER_HOST_KEY` variables to the `dhq-journal` repository, so it should be good to go as soon as this is merged, and a run should be triggered immediately.

