### PR TITLE
fix spacing & punctuation in author (& transloator) block at top of article HTML page

### DIFF
--- a/common/xslt/dhq-preview-html.xsl
+++ b/common/xslt/dhq-preview-html.xsl
@@ -78,28 +78,11 @@
   </xsl:template>
 
   <xsl:template match="tei:teiHeader/tei:fileDesc/tei:titleStmt/dhq:authorInfo">
-    <!-- Using lower-case of author's last name + first initial to sort [CRB] -->
-    <xsl:variable name="lower">abcdefghijklmnopqrstuvwxyz</xsl:variable>
-    <xsl:variable name="upper">ABCDEFGHIJKLMNOPQRSTUVWXYZ</xsl:variable>
-    <xsl:variable name="bios">
-    <xsl:value-of
-      select="lower-case(concat(
-        replace(dhq:author_name/dhq:family,'\s',''),
-        '_',
-        replace(normalize-space(string-join(dhq:author_name/text(),'')),'\s','_') ) )"/>
-        <!--
-      <xsl:value-of
-        select="translate(concat(translate(dhq:author_name/dhq:family,' ',''),'_',substring(normalize-space(dhq:author_name),1,1)),$upper,$lower)"
-      />-->
-    </xsl:variable>
     <div class="author">
       <span style="color: grey">
         <xsl:apply-templates select="dhq:author_name"/>
       </span>
-      <xsl:if test="normalize-space(child::dhq:affiliation)">
-        <xsl:apply-templates select="tei:email" mode="author"/>
-        <xsl:text>,&#160;</xsl:text>
-      </xsl:if>
+      <xsl:apply-templates select="tei:email" mode="author"/>
       <xsl:apply-templates select="dhq:affiliation"/>
     </div>
   </xsl:template>


### PR DESCRIPTION
[Note: the “ssg” at the beginning of the branch names stands for static_site_generation.]

I am reasonably convinced that this PR effects the desired changes from our conversation yesterday. I am less confident that it does not have any untoward side effects. (I looked, but not systematically.) I am not exactly sure off top of head when dhq-preview.xsl is invoked, so probably did not really look at its output.

#### dhq-preview-html.xsl
 - Removed a bunch of unused code, some of which was not being used before, some of which is not being used now that I have changed how the template for tei:email in author mode works.
#### dhq2html.xsl
 - Removed some commented-out code that was > 5 yrs old.
 - Changed the XPaths for default parameters so they are more consistent.
 - Factored out generation of an ID string for an author or translator to a function. (NOTE: I looked pretty carefully for anyplace else that might generate such an ID string, and thus should call the function; but I may have missed something.)
 - Changed processing of authorInfo and of translatorInfo to apply templates (and in corrected punctuation & spacing while I was at it).