### PR TITLE
Don't reference Cocoon files in Ant build 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -175,9 +175,7 @@ generateSearchableToGo
     <!-- Copy specific files in the base directory. -->
     <copy todir="${toDir.use}">
       <filelist dir=".">
-        <file name="flow.js"/>
         <file name="robots.txt"/>
-        <!--<file name="sitemap.xmap"/>-->
         <file name="sruExplain.xml"/>
       </filelist>
     </copy>


### PR DESCRIPTION
The missing flow.js file was causing our GH Action to fail, so I removed references to it.

```
BUILD FAILED
/home/runner/work/dhq-journal/dhq-journal/build.xml:176: Warning: Could not find resource file "/home/runner/work/dhq-journal/dhq-journal/flow.js" to copy.
```

I tested the build with `ant generateSite`.