### PR TITLE
stop searching some silly places

### DIFF
--- a/data/uvepss/config.xml
+++ b/data/uvepss/config.xml
@@ -22,6 +22,8 @@
   </params>
   <rules>
     <rule match="/html/body//text()[not( ancestor::div[@id eq 'mainContent'] )]" weight="0"/>
+    <rule match="/html/body//div[ @class = ('toolbar', 'license') ]" weight="0"/>
+    <rule match="/html/body//div[ @id    = ('pubInfo', 'recommendations', 'printSiteTitle', 'footer') ]" weight="0"/>
   </rules>
   <contexts>
     <context label="headings" match="h1 | h2 | h3 | h4 | h5 | h6"/>

--- a/data/uvepss/search.html
+++ b/data/uvepss/search.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <title>Test search</title>
-    </head>
-    <body>
-      <h1>Search</h1>
-      <div id="staticSearch"/>
-      <!-- <p>… post-search stuff.</p> -->
-    </body>
+  <head>
+    <title>Test search</title>
+  </head>
+  <body>
+    <h1>Search Articles</h1>
+    <div id="staticSearch"/>
+    <!-- <p>… post-search stuff.</p> -->
+  </body>
 </html>


### PR DESCRIPTION
 * Search page heading now says “Search Articles” instead of just “Search”.
 * We no longer index (and thus no longer search through or show results in ) `<div>` elements with a `@class` of "toolbar" or "license" or an `@id` of "pubInfo", "recommendations", "printSiteTitle", or "footer".