### PR TITLE
cleaning side & top nav

### DIFF
--- a/common/xslt/comments.xsl
+++ b/common/xslt/comments.xsl
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns="http://www.w3.org/1999/xhtml"
-    version="1.0">
-    <xsl:template name="comments">
-        <xsl:param name="id"/>
-        <xsl:param name="docurl"/>
-        <xsl:param name="baseurl" select="'http://www.digitalhumanities.org/dhq/'"/>
-	<div id="comments">
-        <div id="disqus_thread"></div>
-        <script type="text/javascript">
+                xmlns="http://www.w3.org/1999/xhtml" version="1.0">
+  <!-- This file is currently unused. —Syd, 2025-06-20 -->
+  <xsl:template name="comments">
+    <xsl:param name="id"/>
+    <xsl:param name="docurl"/>
+    <xsl:param name="baseurl" select="'http://www.digitalhumanities.org/dhq/'"/>
+    <div id="comments">
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
     /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
     var disqus_shortname = 'dhquarterly'; // required: replace example with your forum shortname
 
@@ -22,8 +22,8 @@
         dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
-</script>
-        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-</div>
-    </xsl:template>
+      </script>
+      <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    </div>
+  </xsl:template>
 </xsl:stylesheet>

--- a/common/xslt/commentscount.xsl
+++ b/common/xslt/commentscount.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns="http://www.w3.org/1999/xhtml"
-    version="1.0">
-    <xsl:template name="commentscount">
-<script type="text/javascript">
+                xmlns="http://www.w3.org/1999/xhtml" version="1.0">
+  <!-- This file is currently unused. —Syd, 2025-06-20 -->
+  <xsl:template name="commentscount">
+    <script type="text/javascript">
     /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
     var disqus_shortname = 'dhquarterly'; // required: replace example with your forum shortname
 
@@ -14,6 +14,6 @@
         s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
-</script>
-    </xsl:template>
+    </script>
+  </xsl:template>
 </xsl:stylesheet>

--- a/common/xslt/sidenavigation.xsl
+++ b/common/xslt/sidenavigation.xsl
@@ -35,57 +35,46 @@
       <span>Current Issue<br/></span>
       <ul>
         <li>
-	  <!-- There must be one and only one <journal> in the TOC with a @current attribute. -->
+          <!-- There must be one and only one <journal> in the TOC with a @current attribute. -->
           <xsl:variable name="currentIssue" select="$tocJournals[@current]" as="element(journal)"/>
           <xsl:variable name="vol" select="$currentIssue/@vol" as="xs:string"/>
           <xsl:variable name="issue" select="$currentIssue/@issue" as="xs:string"/>
           <a href="{$path_to_home}/vol/{$vol}/{$issue}/index.html">
-	    <xsl:sequence select="$currentIssue/title!normalize-space(.)||': '||$vol||'.'||$issue"/>
-	  </a>
+            <xsl:sequence select="$currentIssue/title!normalize-space(.)||': '||$vol||'.'||$issue"/>
+          </a>
         </li>
       </ul>
       
       <!-- if there are items in the preview, display the link to the section [CRB] -->
-      <xsl:variable name="previewIssue" select="$tocJournals[@preview]"/>
+      <!-- There should be one and only one <journal> in the TOC with a @preview attribute. -->
+      <xsl:variable name="previewIssue" select="$tocJournals[@preview]" as="element(journal)?"/>
       <xsl:if test="exists($previewIssue)">
-        <span>Preview Issue<br/>
-        </span>
+        <span>Preview Issue<br/></span>
+        <xsl:variable name="vol" select="$previewIssue/@vol" as="xs:string"/>
+        <xsl:variable name="issue" select="$previewIssue/@issue" as="xs:string"/>
         <ul>
           <li>
             <a href="{$path_to_home}/preview/index.html">
-              <xsl:value-of select="$previewIssue/title"/>
-              <xsl:text>: </xsl:text>
-              <xsl:value-of select="$previewIssue/@vol"/>
-              <xsl:text>.</xsl:text>
-              <xsl:value-of select="$previewIssue/@issue"/>
+              <xsl:sequence select="$previewIssue/title!normalize-space(.)||': '||$vol||'.'||$issue"/>
             </a>
           </li>
         </ul>
       </xsl:if>
       
-      <span>Previous Issues<br/>
-      </span>
+      <span>Previous Issues<br/></span>
       <ul>
-        <xsl:for-each select="$tocJournals[not(@current|@preview|@editorial)]">
-          <xsl:variable name="vol" select="@vol/data(.)"/>
-          <xsl:variable name="issue" select="@issue/data(.)"/>
+        <xsl:for-each select="$tocJournals[ not( @current | @preview | @editorial ) ]">
+          <xsl:variable name="vol" select="@vol" as="xs:string"/>
+          <xsl:variable name="issue" select="@issue" as="xs:string"/>
           <li>
             <a href="{$path_to_home}/vol/{$vol}/{$issue}/index.html">
-              <xsl:value-of select="./title"/>
-              <xsl:value-of select="concat(': ',$vol)"/>
-              <xsl:value-of select="concat('.',$issue)"/>
+              <xsl:sequence select="./title||': '||$vol||'.'||$issue"/>
             </a>
           </li>
         </xsl:for-each>
-        <!--<li> <a href="">Preview Next Issue</a></li>
-            <li><a href="">Browse DHQ Archives</a></li>
-            <li> <a href="">Browse by Author</a></li>
-            <li><a href="">Browse by Title</a></li>
-            <li> <a href="">Advanced Search</a></li>-->
       </ul>
       
-      <span>Indexes<br />
-      </span>
+      <span>Indexes<br/></span>
       <ul>
         <li>
           <a href="{$path_to_home}/index/title.html">Title</a>
@@ -95,16 +84,15 @@
         </li>
       </ul>
       
-      
     </div>
     
     <img alt="" style="margin-left : 7px;">
-      <xsl:attribute name="src" select="concat($path_to_home,'/common/images/lbarrev.png')"/>
+      <xsl:attribute name="src" select="$path_to_home||'/common/images/lbarrev.png'"/>
     </img>
     
     <!-- issn announcement etc -->
     <div id="leftsideID">
-      <b>ISSN 1938-4122</b>
+      <strong>ISSN 1938-4122</strong>
       <br/>
     </div>
     
@@ -112,22 +100,15 @@
       <h3>Announcements</h3>
       <ul>
         <li>
-          <a><xsl:attribute name="href">
-            <xsl:value-of select="concat($path_to_home,'/news/news.html#peer_reviews')"/>
-          </xsl:attribute>Call for Reviewers</a>
+          <a href="{$path_to_home}/news/news.html#peer_reviews">Call for Reviewers</a>
         </li>
         <li>
-          <a><xsl:attribute name="href">
-            <xsl:value-of select="concat($path_to_home,'/submissions/index.html#logistics')"/>
-          </xsl:attribute>Call for Submissions</a>
+          <a href="{$path_to_home}/submissions/index.html#logistics">Call for Submissions</a>
         </li>
       </ul>
     </div>
     <!-- 2024-07, AMC: Removed AddThis button and Editorial area "logout" button. -->
-    
   </xsl:template>
-  
-  
   
   <xsl:template name="sitetitle">
     <div id="printSiteTitle">DHQ: Digital Humanities Quarterly</div>

--- a/common/xslt/sidenavigation.xsl
+++ b/common/xslt/sidenavigation.xsl
@@ -20,7 +20,6 @@
   
   <xsl:param name="staticPublishingPathPrefix" select="'../../toc/'" as="xs:string"/>
   <xsl:variable name="tocFile" select="$staticPublishingPathPrefix||'toc.xml'" as="xs:string"/>
-  <xsl:param name="context"/>
   <!-- The relative path from the webpage to the DHQ home directory. The path must not end with a 
        slash. This value is used by this and other stylesheets to construct links relative, if not 
        directly from the current page, then from the DHQ home directory. Because this stylesheet is used for 

--- a/common/xslt/sidenavigation.xsl
+++ b/common/xslt/sidenavigation.xsl
@@ -1,140 +1,136 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    exclude-result-prefixes="#all"
-    version="3.0">
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="#all"
+                version="3.0">
+  
+  <!--
+      This stylesheet contains the template "sidenavigation", which generates the 
+      sidebar navigation menu. The navbar contains links to every issue in DHQ.
+      
+      As one of the base DHQ stylesheets, it is imported into other stylesheets 
+      which generate full HTML pages.
+      
+      CHANGES
+      2025-06, SDB: Lots of tweaks to make more readable, no changes to output.
+      2024-07, AMC: Refactored, and replaced links to "/dhq/" with links relative
+                    to the home directory.
+  -->
+  
+  <xsl:param name="staticPublishingPathPrefix" select="'../../toc/'" as="xs:string"/>
+  <xsl:variable name="tocFile" select="$staticPublishingPathPrefix||'toc.xml'" as="xs:string"/>
+  <xsl:param name="context"/>
+  <!-- The relative path from the webpage to the DHQ home directory. The path must not end with a 
+       slash. This value is used by this and other stylesheets to construct links relative, if not 
+       directly from the current page, then from the DHQ home directory. Because this stylesheet is used for 
+       pages throughout DHQ, the value of $path_to_home should be provided by an stylesheet which imports 
+       this one. -->
+  <xsl:param name="path_to_home" select="''" as="xs:string"/>
+  
+  <xsl:template name="sidenavigation">
+    <xsl:variable name="tocJournals" select="doc( $tocFile )//journal" as="element(journal)+"/>
+    <!-- sidenavigation -->
+    <div id="leftsidenav">
+      <span>Current Issue<br/></span>
+      <ul>
+        <li>
+	  <!-- There must be one and only one <journal> in the TOC with a @current attribute. -->
+          <xsl:variable name="currentIssue" select="$tocJournals[@current]" as="element(journal)"/>
+          <xsl:variable name="vol" select="$currentIssue/@vol" as="xs:string"/>
+          <xsl:variable name="issue" select="$currentIssue/@issue" as="xs:string"/>
+          <a href="{$path_to_home}/vol/{$vol}/{$issue}/index.html">
+	    <xsl:sequence select="$currentIssue/title!normalize-space(.)||': '||$vol||'.'||$issue"/>
+	  </a>
+        </li>
+      </ul>
+      
+      <!-- if there are items in the preview, display the link to the section [CRB] -->
+      <xsl:variable name="previewIssue" select="$tocJournals[@preview]"/>
+      <xsl:if test="exists($previewIssue)">
+        <span>Preview Issue<br/>
+        </span>
+        <ul>
+          <li>
+            <a href="{$path_to_home}/preview/index.html">
+              <xsl:value-of select="$previewIssue/title"/>
+              <xsl:text>: </xsl:text>
+              <xsl:value-of select="$previewIssue/@vol"/>
+              <xsl:text>.</xsl:text>
+              <xsl:value-of select="$previewIssue/@issue"/>
+            </a>
+          </li>
+        </ul>
+      </xsl:if>
+      
+      <span>Previous Issues<br/>
+      </span>
+      <ul>
+        <xsl:for-each select="$tocJournals[not(@current|@preview|@editorial)]">
+          <xsl:variable name="vol" select="@vol/data(.)"/>
+          <xsl:variable name="issue" select="@issue/data(.)"/>
+          <li>
+            <a href="{$path_to_home}/vol/{$vol}/{$issue}/index.html">
+              <xsl:value-of select="./title"/>
+              <xsl:value-of select="concat(': ',$vol)"/>
+              <xsl:value-of select="concat('.',$issue)"/>
+            </a>
+          </li>
+        </xsl:for-each>
+        <!--<li> <a href="">Preview Next Issue</a></li>
+            <li><a href="">Browse DHQ Archives</a></li>
+            <li> <a href="">Browse by Author</a></li>
+            <li><a href="">Browse by Title</a></li>
+            <li> <a href="">Advanced Search</a></li>-->
+      </ul>
+      
+      <span>Indexes<br />
+      </span>
+      <ul>
+        <li>
+          <a href="{$path_to_home}/index/title.html">Title</a>
+        </li>
+        <li>
+          <a href="{$path_to_home}/index/author.html">Author</a>
+        </li>
+      </ul>
+      
+      
+    </div>
     
-    <!--
-        This stylesheet contains the template "sidenavigation", which generates the 
-        sidebar navigation menu. The navbar contains links to every issue in DHQ.
-        
-        As one of the base DHQ stylesheets, it is imported into other stylesheets 
-        which generate full HTML pages.
-        
-        CHANGES
-          2024-07, AMC: Refactored, and replaced links to "/dhq/" with links 
-            relative to the home directory.
-      -->
+    <img alt="" style="margin-left : 7px;">
+      <xsl:attribute name="src" select="concat($path_to_home,'/common/images/lbarrev.png')"/>
+    </img>
     
-    <xsl:param name="staticPublishingPathPrefix" select="'../../toc/'"/>
-    <xsl:param name="context"/>
-    <!-- The relative path from the webpage to the DHQ home directory. The path must not end with a 
-      slash. This value is used by this and other stylesheets to construct links relative, if not 
-      directly from the current page, then from the DHQ home directory. Because this stylesheet is used for 
-      pages throughout DHQ, the value of $path_to_home should be provided by an stylesheet which imports 
-      this one. -->
-    <xsl:param name="path_to_home" select="''" as="xs:string"/>
+    <!-- issn announcement etc -->
+    <div id="leftsideID">
+      <b>ISSN 1938-4122</b>
+      <br/>
+    </div>
     
+    <div class="leftsidecontent">
+      <h3>Announcements</h3>
+      <ul>
+        <li>
+          <a><xsl:attribute name="href">
+            <xsl:value-of select="concat($path_to_home,'/news/news.html#peer_reviews')"/>
+          </xsl:attribute>Call for Reviewers</a>
+        </li>
+        <li>
+          <a><xsl:attribute name="href">
+            <xsl:value-of select="concat($path_to_home,'/submissions/index.html#logistics')"/>
+          </xsl:attribute>Call for Submissions</a>
+        </li>
+      </ul>
+    </div>
+    <!-- 2024-07, AMC: Removed AddThis button and Editorial area "logout" button. -->
     
-    <xsl:template name="sidenavigation">
-        <xsl:variable name="tocJournals" 
-          select="doc(concat($staticPublishingPathPrefix,'toc.xml'))//journal"/>
-        <!--sidenavigation-->
-        <div id="leftsidenav">
-            <span>Current Issue<br/>
-            </span>
-            <ul>
-                <li>
-                    <xsl:variable name="currentIssue" select="$tocJournals[@current]"/>
-                    <xsl:variable name="vol" select="$currentIssue/@vol/data(.)"/>
-                    <xsl:variable name="issue" select="$currentIssue/@issue/data(.)"/>
-                    <a href="{$path_to_home}/vol/{$vol}/{$issue}/index.html">
-                        <xsl:value-of select="$currentIssue/title"/>
-                        <xsl:text>: </xsl:text>
-                        <xsl:value-of select="$vol"/>
-                        <xsl:text>.</xsl:text>
-                        <xsl:value-of select="$issue"/>
-                    </a>
-                </li>
-            </ul>
-            
-            <!-- if there are items in the preview, display the link to the section [CRB] -->
-            <xsl:variable name="previewIssue" select="$tocJournals[@preview]"/>
-            <xsl:if test="exists($previewIssue)">
-                <span>Preview Issue<br/>
-                </span>
-                <ul>
-                    <li>
-                        <a href="{$path_to_home}/preview/index.html">
-                            <xsl:value-of select="$previewIssue/title"/>
-                            <xsl:text>: </xsl:text>
-                            <xsl:value-of select="$previewIssue/@vol"/>
-                            <xsl:text>.</xsl:text>
-                            <xsl:value-of select="$previewIssue/@issue"/>
-                        </a>
-                    </li>
-                </ul>
-            </xsl:if>
-            
-            <span>Previous Issues<br/>
-            </span>
-            <ul>
-                <xsl:for-each select="$tocJournals[not(@current|@preview|@editorial)]">
-                    <xsl:variable name="vol" select="@vol/data(.)"/>
-                    <xsl:variable name="issue" select="@issue/data(.)"/>
-                    <li>
-                        <a href="{$path_to_home}/vol/{$vol}/{$issue}/index.html">
-                            <xsl:value-of select="./title"/>
-                            <xsl:value-of select="concat(': ',$vol)"/>
-                            <xsl:value-of select="concat('.',$issue)"/>
-                        </a>
-                    </li>
-                </xsl:for-each>
-                <!--<li> <a href="">Preview Next Issue</a></li>
-                    <li><a href="">Browse DHQ Archives</a></li>
-                    <li> <a href="">Browse by Author</a></li>
-                    <li><a href="">Browse by Title</a></li>
-                    <li> <a href="">Advanced Search</a></li>-->
-            </ul>
-            
-            <span>Indexes<br />
-            </span>
-            <ul>
-                <li>
-                  <a href="{$path_to_home}/index/title.html">Title</a>
-                </li>
-                <li>
-                  <a href="{$path_to_home}/index/author.html">Author</a>
-                </li>
-            </ul>
-            
-            
-        </div>
-        
-        <img alt="" style="margin-left : 7px;">
-            <xsl:attribute name="src" select="concat($path_to_home,'/common/images/lbarrev.png')"/>
-        </img>
-        
-        <!-- issn announcement etc -->
-        <div id="leftsideID">
-            <b>ISSN 1938-4122</b>
-            <br/>
-        </div>
-        
-        <div class="leftsidecontent">
-            <h3>Announcements</h3>
-            <ul>
-                <li>
-                    <a><xsl:attribute name="href">
-                        <xsl:value-of select="concat($path_to_home,'/news/news.html#peer_reviews')"/>
-                    </xsl:attribute>Call for Reviewers</a>
-                </li>
-                <li>
-                    <a><xsl:attribute name="href">
-                        <xsl:value-of select="concat($path_to_home,'/submissions/index.html#logistics')"/>
-                    </xsl:attribute>Call for Submissions</a>
-                </li>
-            </ul>
-        </div>
-      <!-- 2024-07, AMC: Removed AddThis button and Editorial area "logout" button. -->
-        
-    </xsl:template>
-    
-    
-    
-    <xsl:template name="sitetitle">
-        <div id="printSiteTitle">DHQ: Digital Humanities Quarterly</div>
-    </xsl:template>
-    
+  </xsl:template>
+  
+  
+  
+  <xsl:template name="sitetitle">
+    <div id="printSiteTitle">DHQ: Digital Humanities Quarterly</div>
+  </xsl:template>
+  
 </xsl:stylesheet>

--- a/common/xslt/topnavigation.xsl
+++ b/common/xslt/topnavigation.xsl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
-		xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-		exclude-result-prefixes="#all"
-		version="3.0">
-  <xsl:param name="context"/>
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+                exclude-result-prefixes="#all"
+                version="3.0">
+
   <xsl:param name="doProofing" select="false()" as="xs:boolean"/>
   <!-- The relative path from the webpage to the DHQ home directory. The path must not end with a 
        slash. This value is used by this and other stylesheets to construct links relative, if not 
@@ -48,24 +48,25 @@
         </span>
       </div>
       <div id="searchStuff">
-	<form id="searchForm" method="get" action="{$path_to_home}/vol/search.html"
-	      enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
-	  <div id="search">
-	    <label for="q">Search</label>
-	    <input id="q" type="text" name="q" value="" placeholder="keyword"/>
-	    <input id="searchSubmit" type="submit" value="go!"/>
-	  </div>
-	</form>
+        <form id="searchForm" method="get" action="{$path_to_home}/vol/search.html"
+              enctype="application/x-www-form-urlencoded" accept-charset="UTF-8">
+          <div id="search">
+            <label for="q">Search</label>
+            <input id="q" type="text" name="q" value="" placeholder="keyword"/>
+            <input id="searchSubmit" type="submit" value="go!"/>
+          </div>
+        </form>
       </div>
     </div>
   </xsl:template>
+
   <xsl:template name="topbanner">
     <!-- Added for rotating banner image -->
     <div id="backgroundpic">
       <xsl:variable name="imgFile">
         <xsl:sequence select="unparsed-text('../images/bannerimg/banner29.jpg.base64')"/>
       </xsl:variable>   
-      <img alt="" width="100%" height="62px" src="{concat('data:image/jpeg;base64,',$imgFile)}"/>​
+      <img alt="" width="100%" height="62px" src="data:image/jpeg;base64,{$imgFile}"/>​
     </div>    
     <div id="banner">
       <!-- If we're generating a proofing copy, add a textual notice of that here. -->
@@ -78,14 +79,15 @@
         <xsl:variable name="imgFile">
           <xsl:sequence select="unparsed-text('../images/dhqlogo.png.base64')"/>
         </xsl:variable>        
-        <img alt="DHQ" src="{concat('data:image/png;base64,',$imgFile)}" />
+        <img alt="DHQ" src="data:image/png;base64,{$imgFile}"/>
       </div>
       <div id="longdhqlogo">
         <xsl:variable name="imgFile">
           <xsl:sequence select="unparsed-text('../images/dhqlogolonger.png.base64')"/>
         </xsl:variable>        
-        <img alt="Digital Humanities Quarterly" src="{concat('data:image/png;base64,',$imgFile)}" />
+        <img alt="Digital Humanities Quarterly" src="data:image/png;base64,{$imgFile}"/>
       </div>
     </div>
   </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
I have tested these changes by
1. Running the "generateSite" target, and renaming the output dir to dhq-static_pre-clean-up/.
2. Making changes.
3. Running the "generateSite" target again, leaving the output dir as the usual dhq-static/.
4. Comparing all HTML files in the two directories.¹

The only differences are:
- The ISSN is listed in the sidebar in a `<strong>` instead of a `<b>`.
- The value of `@accept-charset` has been changed from "utf-8" to "UTF-8".

**Note**
¹ To compare all files I used `cd ../dhq-static_pre-clean-up && for f in $(find . -type f -name '*html') ; do diff -C0 -bBw $f  ../dhq-static/$f; done`. Notice that the search is for `*html`, not `*.html`, because there are a few .xhtml files. I do not think they needed to be compared, but just in case…
Also worth noting that in order to ignore the two changes that I knew I made, I actually used `<(egrep -va 'enctype="application/x-www-form-urlencoded" accept-charset="...-8"|common/images/lbarrev.png" /><div id="leftsideID"><(b|strong)>ISSN 1938-4122</' $f)` as the first input file, and the same for the ../dhq-static/$f as the second.