### PR TITLE
fix copyright notice

### DIFF
--- a/common/xslt/footer.xsl
+++ b/common/xslt/footer.xsl
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		xmlns:tei="http://www.tei-c.org/ns/1.0"
+		xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns:dhq="http://www.digitalhumanities.org/ns/dhq"
                 xmlns="http://www.w3.org/1999/xhtml" version="3.0" >
   
   <xsl:param name="context"/>
@@ -7,35 +10,64 @@
   <xsl:template name="footer">
     <xsl:param name="docurl"/>
     <xsl:param name="baseurl" select="'http://www.digitalhumanities.org/'||$context||'/'"/>
+    <!-- The number of authors from an article file; will be 0 for
+	 most anything else, most importantly the toc.xml file. -->
+    <xsl:variable name="numAuthors" select="count( /*/tei:teiHeader/tei:fileDesc/tei:titleStmt/dhq:authorInfo )"/>
+    <xsl:variable name="yearPublished" as="xs:string">
+      <xsl:choose>
+	<!-- All articles have the publication date as <date when="">
+	     in the header. -->
+	<xsl:when test="/*/tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:date/@when">
+	  <xsl:sequence select="year-from-date( /*/tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:date/@when )!string()"/>
+	</xsl:when>
+	<!-- For the TOC, take the latest year that *something* was published. -->
+	<xsl:when test="/toc/journal">
+	  <xsl:sequence select="//journal/title!normalize-space()[matches(.,'^[0-9]{4}$')] => max()"/>
+	</xsl:when>
+	<!-- Fallback: use the year that we generated the HTML page. -->
+	<xsl:otherwise>
+	  <xsl:sequence select="year-from-date( current-date() )!string()"/>
+	</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <!-- The year for the copyright notice is either the year the
+	 single article was originally published, or for generated
+	 pages (like author bios or the about page) a range from
+	 our first year of publication to the latest year that
+	 *something* was published. -->
+    <xsl:variable name="copyYear" as="xs:string">
+      <xsl:choose>
+	<xsl:when test="$numAuthors gt 0"><xsl:sequence select="$yearPublished"/></xsl:when>
+	<xsl:when test="$numAuthors eq 0"><xsl:sequence select="'2005–'||$yearPublished"/></xsl:when>
+      </xsl:choose>
+    </xsl:variable>
+    <!-- The copyright holder for the copyright notice. -->
+    <xsl:variable name="copyHolder">
+      <xsl:choose>
+	<xsl:when test="$numAuthors eq 1">the author</xsl:when>
+	<xsl:when test="$numAuthors ge 2">the authors</xsl:when>
+	<xsl:when test="$numAuthors eq 0">DHQ</xsl:when>
+      </xsl:choose>
+    </xsl:variable>
     <div id="footer"> 
       <div style="float:left; max-width:70%;" xsl:expand-text="yes">
         URL: {$baseurl}{$docurl}
-        <br/>
-        Comments:&#x20;
+        <br/>Comments:&#x20;
         <a href="mailto:dhqinfo@digitalhumanities.org" class="footer">dhqinfo@digitalhumanities.org</a>
-        <br/>
-        Published by:&#x20;
+        <br/>Published by:&#x20;
         <a href="http://www.digitalhumanities.org" class="footer">The Alliance of Digital Humanities Organizations</a>
         &#x20;and&#x20;
         <a href="http://www.ach.org" class="footer">The Association for Computers and the Humanities</a>
-        <br/>
-        Affiliated with:&#x20;
+        <br/>Affiliated with:&#x20;
         <a href="https://academic.oup.com/dsh">Digital Scholarship in the Humanities</a>
-        <br/>
-        DHQ has been made possible in part by the&#x20;
+        <br/>DHQ has been made possible in part by the&#x20;
         <a href="https://www.neh.gov/">National Endowment for the Humanities</a>.
-        <br/>
-        Copyright © 2005 -&#x20;
-        <script type="text/javascript">
-          var currentDate = new Date();
-          document.write(currentDate.getFullYear());
-        </script>
+        <br/>© {$copyYear} {$copyHolder}
         <br/>
         <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/">
           <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/80x15.png"/>
         </a>
-        <br/>
-        Unless otherwise noted, the DHQ web site and all DHQ published content are published under a
+        <br/>Unless otherwise noted, the DHQ web site and all DHQ published content are published under a
         <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.
         Individual articles may carry a more permissive license, as described in the footer for the individual article, and in the article’s metadata.
       </div>


### PR DESCRIPTION
- 17 U.S. Code § 401b says to use one of either “Copyright”, “Copyr.”, or ‘©’; @jawalsh & I prefer just the symbol, just because it is shorter and cooler, so that is what I went with.
- The same section of the law requires that the copyright holder (or a phrase that can easily be interpreted to find out who the copyright holder is) be specified after the date.
- In general, a date range should be separated by an en dash (U+2013) rather than a hyphen (U+002D).
- It does not make sense to assert a copyright as having been in effect _before_ an article was published, so for articles I have updated the code to use the year of publication.
- It does not make sense to assert a copyright as of the year a user loaded the HTML into her browser, so for the end year of the range for non-article pages I used the year the last article was published (per the TOC).
