### PR TITLE
Initial proofing site deployment workflow

### DIFF
--- a/.github/workflows/proofing-deploy.yaml
+++ b/.github/workflows/proofing-deploy.yaml
@@ -1,23 +1,9 @@
 name: Deploy proofing site to dhq-proofing.digitalhumanities.org
 
 on:
-  # push:
-  #   branches: [ "main" ]
+  push:
+    branches: ["main"]
   workflow_dispatch:
-    inputs:
-      source_branch:
-        description: "Select the branch to deploy from"
-        required: true
-        default: "encoding_workflow"
-        type: choice
-        options:
-          - main
-          - encoding_workflow
-      full_site:
-        description: "Proof the full DHQ site?"
-        required: true
-        default: true
-        type: boolean
 
 jobs:
   deploy:
@@ -27,13 +13,13 @@ jobs:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.source_branch }}
+          ref: encoding_workflow
 
       - name: 🐜 Install ant
         run: sudo apt-get update && sudo apt-get install -y ant ant-contrib
 
       - name: 🏗️ Build the site
-        run: ant -lib common/lib/saxon -Ddo.proofing.full=${{ inputs.full_site }} makeInternalPreview
+        run: ant -lib common/lib/saxon -Ddo.proofing.full=false makeInternalPreview
 
       - name: 🔐 Create Key File
         run: install -m 600 -D /dev/null ~/.ssh/id_ed25519 && echo "${{ secrets.DHQ_PROOFING_SSH_PRIVATEKEY }}" > ~/.ssh/id_ed25519

--- a/.github/workflows/proofing-deploy.yaml
+++ b/.github/workflows/proofing-deploy.yaml
@@ -1,0 +1,45 @@
+name: Deploy proofing site to dhq-proofing.digitalhumanities.org
+
+on:
+  # push:
+  #   branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: "Select the branch to deploy from"
+        required: true
+        default: "encoding_workflow"
+        type: choice
+        options:
+          - main
+          - encoding_workflow
+      full_site:
+        description: "Proof the full DHQ site?"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛒 Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_branch }}
+
+      - name: 🐜 Install ant
+        run: sudo apt-get update && sudo apt-get install -y ant ant-contrib
+
+      - name: 🏗️ Build the site
+        run: ant -lib common/lib/saxon -Ddo.proofing.full=${{ inputs.full_site }} makeInternalPreview
+
+      - name: 🔐 Create Key File
+        run: install -m 600 -D /dev/null ~/.ssh/id_ed25519 && echo "${{ secrets.DHQ_PROOFING_SSH_PRIVATEKEY }}" > ~/.ssh/id_ed25519
+
+      - name: 🗃️ Create Known Hosts File
+        run: install -m 600 -D /dev/null ~/.ssh/known_hosts && echo "${{ vars.ADHO_SERVER_IPV4 }} ${{ vars.ADHO_SERVER_HOST_KEY }}" > ~/.ssh/known_hosts
+
+      - name: 🚀 Upload
+        run: rsync --archive --delete --stats /home/runner/work/dhq-journal/dhq-static/dhq-proofing/ dhq-deploy@${{ vars.ADHO_SERVER_IPV4 }}:/

--- a/.github/workflows/proofing-deploy.yaml
+++ b/.github/workflows/proofing-deploy.yaml
@@ -28,4 +28,4 @@ jobs:
         run: install -m 600 -D /dev/null ~/.ssh/known_hosts && echo "${{ vars.ADHO_SERVER_IPV4 }} ${{ vars.ADHO_SERVER_HOST_KEY }}" > ~/.ssh/known_hosts
 
       - name: 🚀 Upload
-        run: rsync --archive --delete --stats /home/runner/work/dhq-journal/dhq-static/dhq-proofing/ dhq-deploy@${{ vars.ADHO_SERVER_IPV4 }}:/
+        run: rsync --archive --delete --stats /home/runner/work/dhq-journal/dhq-static/dhq-proofing/editorial/ dhq-deploy@${{ vars.ADHO_SERVER_IPV4 }}:/


### PR DESCRIPTION
Here's a first pass at a deployment workflow for the staging site.  It deploys the built artefacts to https://dhq-proofing.digitalhumanities.org/.

Some notes/questions:
* Only `main` and `encoding_workflow` are selectable as source branches to run the ant task against -- will this be sufficient?
  * There isn't a straightforward built-in way to populate the dropdown with all available branches; the best alternative I can think of if full flexibility is needed would be to provide a text entry field and validate it in the action before using it.
* I created a checkbox to set the `do.proofing.full` property -- I'm not sure if this is really useful?
  * for now I've defaulted it to `true` as it didn't seem to be building the page at the `editorial/` route properly otherwise; but perhaps I was doing something wrong?
  * Would you prefer that _only_ the `editorial/` content was available at this address?  Seems doable with a little bit of engineering, I think?
* The on-push trigger for the `main` branch is commented-out, but can easily be enabled.

You're welcome to run with it from here if you prefer (I don't think further server-side changes are likely needed), or please let me know what you think the best behaviours are in the light of these or other issues and I'll implement as best I'm able.

Cheers!

