### PR TITLE
Check article id from toc

### DIFF
--- a/articles/999889/999889.xml
+++ b/articles/999889/999889.xml
@@ -21,7 +21,7 @@
             <publicationStmt><publisher>Alliance of Digital Humanities Organizations</publisher>
 <publisher>Association for Computers and the Humanities</publisher>
                
-                <idno type="DHQarticle-id">999888</idno>
+                <idno type="DHQarticle-id">999889</idno>
                 <idno type="volume">3</idno>
                 <idno type="issue">4</idno>
                 <date when="2009-06-21">21 June 2009</date>

--- a/toc/toc-xml.sch
+++ b/toc/toc-xml.sch
@@ -34,7 +34,7 @@
         accurate URL for the article. -->
       <sch:report test="doc-available($expected-filepath) 
                     and not( doc($expected-filepath)//tei:idno[@type eq 'DHQarticle-id'][normalize-space(.) = $itemId] )"
-        >File at <sch:value-of select="$human-readable-filepath"/> doesn't know its own article ID</sch:report>
+        >The internal ID stored in file <sch:value-of select="$human-readable-filepath"/> does not match its filename</sch:report>
     </sch:rule>
     
   </sch:pattern>

--- a/toc/toc-xml.sch
+++ b/toc/toc-xml.sch
@@ -2,6 +2,8 @@
 <sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
   xmlns:sqf="http://www.schematron-quickfix.com/validator/process">
   
+  <sch:ns uri="http://www.tei-c.org/ns/1.0" prefix="tei"/>
+  
   <!--<sch:let name="toc-article-group-types" value="('editorials', 'articles', 'reviews', 'case_studies', 'frontmatter', 'issues', 'posters')"/>-->
   
   <sch:pattern>
@@ -18,10 +20,21 @@
     </sch:rule>
     
     <sch:rule context="item">
-      <sch:let name="expected-filepath" value="@id[matches(.,'^\c+')]/resolve-uri(concat('../articles/',.,'/',.,'.xml'),document-uri(/))"/>
+      <sch:let name="itemId" value="@id[matches(.,'^\c+')]/xs:string(.)"/>
+      <sch:let name="human-readable-filepath" value="concat('../articles/',$itemId,'/',$itemId,'.xml')"/>
+      <sch:let name="expected-filepath" value="resolve-uri($human-readable-filepath, document-uri(/))"/>
       <sch:assert test="exists($expected-filepath)">Can't construct a path to a file from @id value '<sch:value-of select="@id"/>'</sch:assert>
+      <!-- If the file wasn't found, it's most helpful to include the entire filepath we tested, not the 
+        relative, human-readable one. -->
       <sch:assert test="empty($expected-filepath) or unparsed-text-available($expected-filepath)">File not found at <sch:value-of select="$expected-filepath"/></sch:assert>
-      <sch:assert test="empty($expected-filepath) or not(unparsed-text-available($expected-filepath)) or doc-available($expected-filepath)">File at <sch:value-of select="$expected-filepath"/> will not parse</sch:assert>
+      <sch:assert test="empty($expected-filepath) or not(unparsed-text-available($expected-filepath)) or doc-available($expected-filepath)">File at <sch:value-of select="$human-readable-filepath"/> will not parse</sch:assert>
+      <!-- Make sure that the file matching the ID in the TOC doesn't just exist, it includes an 
+        <idno type="DHQarticle-id"> that matches the ID that the TOC thinks it should have. If the file 
+        exists but "doesn't know its own ID", the index for that article's issue will fail to produce an 
+        accurate URL for the article. -->
+      <sch:report test="doc-available($expected-filepath) 
+                    and not( doc($expected-filepath)//tei:idno[@type eq 'DHQarticle-id'][normalize-space(.) = $itemId] )"
+        >File at <sch:value-of select="$human-readable-filepath"/> doesn't know its own article ID</sch:report>
     </sch:rule>
     
   </sch:pattern>


### PR DESCRIPTION
When an issue index is generated, the XSLT stylesheets rely on the article XML having an accurate `<idno type="DHQarticle-id">`, otherwise the link will be wrong. There's currently an example of this on the DHQ proofing site, for article 000791. If you pull down my branch (`check-article-id-from-toc`) and validate the TOC, you should see an error message for that article.

<img width="719" height="175" alt="Screenshot displaying a URL ending with slash dot html" src="https://github.com/user-attachments/assets/09957e45-091f-47d5-b254-6d1aad36a8de" />


I've added a new check to the TOC's Schematron (`toc-xml.sch`): If the article *is* available at the file system address we expect (a path which relies on the TOC knowing the right ID), that article should *also* have an `<idno type="DHQarticle-id">` that matches the ID that the TOC believes it should have (and thus, its own filename). I'm hopeful we could eventually use this to validate the TOC before running any GitHub actions. In the meantime, it seems useful to let editors have this information — if the TOC doesn't validate, something will go wrong on publication.

I've also made the TOC article-checking messages slightly more readable by reporting the relative path, rather than the full absolute path. And I fixed the ID for test file `999889.xml`, which thought of itself as the ID number prior (likely a copy-paste mishap).

Open to suggestions for making this better!