### PR TITLE
Use “main” instead of “master” in URLs that refer to “Digital-Humanities-Quarterly/dhq-journal”

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dhq-journal 
 Digital Humanities Quarterly is an international, open-access, peer-reviewed journal of digital humanities. More information about the journal and its submission and publication policies can be found at the [DHQ website](http://www.digitalhumanities.org/dhq/about/about.html). 
 
-DHQ articles are encoded using a customization of the [TEI Guidelines](https://tei-c.org). We are always grateful to authors who encode their own articles. You can find a [schema](https://github.com/Digital-Humanities-Quarterly/dhq-journal/blob/master/common/schema/DHQauthor-TEI.rng) and [encoding templates](https://github.com/Digital-Humanities-Quarterly/dhq-journal/tree/master/articles/templates) in this repository.
+DHQ articles are encoded using a customization of the [TEI Guidelines](https://tei-c.org). We are always grateful to authors who encode their own articles. You can find a [schema](https://github.com/Digital-Humanities-Quarterly/dhq-journal/blob/master/common/schema/DHQauthor-TEI.rng) and [encoding templates](https://github.com/Digital-Humanities-Quarterly/dhq-journal/tree/main/articles/templates) in this repository.
 
 [Our wiki](https://github.com/Digital-Humanities-Quarterly/dhq-journal/wiki) is home to a variety of helpful resources for authors and editors looking to endocde article files. [Consult the wiki](https://github.com/Digital-Humanities-Quarterly/dhq-journal/wiki) for encoding resources, topic area keyword descriptions, and development or data management notes.
 

--- a/articles/000000/000000.xml
+++ b/articles/000000/000000.xml
@@ -120,7 +120,7 @@
 		<revisionDesc>
 			<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000000/000000.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000000/000000.xml"
 					>GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000019/000019.xml
+++ b/articles/000019/000019.xml
@@ -77,7 +77,7 @@
             in bibliography.</change>
          <change when="2008-06-22" who="Ashwini">Removed additional blank p tag</change>
          <change when="2013-06-20" who="Tassie Gniady">Changed "dhq:caption" to "head."</change>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000019/000019.xml">GitHub </ref></change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000019/000019.xml">GitHub </ref></change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en">

--- a/articles/000044/000044.xml
+++ b/articles/000044/000044.xml
@@ -124,7 +124,7 @@
          <change when="2008" who="AR">Encoded document</change>
          <change who="Melanie Kohnen" when="2008-12-18">Added bios and teaser</change>
          <change who="Melanie Kohnen" when="2009-01-13">Added email addresses</change>
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000044/000044.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000044/000044.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000188/000188.xml
+++ b/articles/000188/000188.xml
@@ -68,7 +68,7 @@
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
             <change when="2018-07-09" who="DD">validation check</change>
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000188/000188.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000188/000188.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000237/000237.xml
+++ b/articles/000237/000237.xml
@@ -98,7 +98,7 @@
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
             <change when="2018-07-09" who="DD">validation check</change>
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000237/000237.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000237/000237.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000244/000244.xml
+++ b/articles/000244/000244.xml
@@ -155,7 +155,7 @@
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
             <change who="JDF" when="2016-03-03">Created file</change>
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000244/000244.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000244/000244.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000309/000309.xml
+++ b/articles/000309/000309.xml
@@ -180,7 +180,7 @@
       <revisionDesc>
          <!-- Each change should include @who and @when as well as a brief note on what was done. -->
          <change when="2017-04-25" who="JDF">Proofread file</change>
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000309/000309.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000309/000309.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000328/000328.xml
+++ b/articles/000328/000328.xml
@@ -96,7 +96,7 @@
             <change who="BRG" when="2022-07-14">Revised encoding of code snippets</change>
             <!-- A note to any future Editors: all CDATA snippets below must be manually reviewed if using the format and indent feature of oXygen so that correct formatting is retained. -BRG -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000328/000328.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000328/000328.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000389/000389.xml
+++ b/articles/000389/000389.xml
@@ -77,7 +77,7 @@
       </profileDesc>
       <revisionDesc>
          <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000389/000389.xml">GitHub</ref>.</change>
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000389/000389.xml">GitHub</ref>.</change>
       </revisionDesc>
    </teiHeader>
    <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000391/000391.xml
+++ b/articles/000391/000391.xml
@@ -82,7 +82,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000391/000391.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000391/000391.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000393/000393.xml
+++ b/articles/000393/000393.xml
@@ -83,7 +83,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000393/000393.xml">GitHub</ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000393/000393.xml">GitHub</ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000394/000394.xml
+++ b/articles/000394/000394.xml
@@ -74,7 +74,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000394/000394.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000394/000394.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000395/000395.xml
+++ b/articles/000395/000395.xml
@@ -105,7 +105,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000395/000395.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000395/000395.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000396/000396.xml
+++ b/articles/000396/000396.xml
@@ -100,7 +100,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000396/000396.xml">GitHub</ref>.</change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000396/000396.xml">GitHub</ref>.</change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000398/000398.xml
+++ b/articles/000398/000398.xml
@@ -74,7 +74,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000398/000398.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000398/000398.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000399/000399.xml
+++ b/articles/000399/000399.xml
@@ -86,7 +86,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000399/000399.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000399/000399.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000402/000402.xml
+++ b/articles/000402/000402.xml
@@ -76,7 +76,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000402/000402.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000402/000402.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000403/000403.xml
+++ b/articles/000403/000403.xml
@@ -119,7 +119,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000403/000403.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000403/000403.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000404/000404.xml
+++ b/articles/000404/000404.xml
@@ -79,7 +79,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000404/000404.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000404/000404.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000405/000405.xml
+++ b/articles/000405/000405.xml
@@ -66,7 +66,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/0000405/000405.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/0000405/000405.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000407/000407.xml
+++ b/articles/000407/000407.xml
@@ -107,7 +107,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000407/000407.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000407/000407.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000408/000408.xml
+++ b/articles/000408/000408.xml
@@ -107,7 +107,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000408/000408.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000408/000408.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000411/000411.xml
+++ b/articles/000411/000411.xml
@@ -158,7 +158,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000411/000411.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000411/000411.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000415/000415.xml
+++ b/articles/000415/000415.xml
@@ -106,7 +106,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000415/000415.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000415/000415.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000418/000418.xml
+++ b/articles/000418/000418.xml
@@ -102,7 +102,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000418/000418.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000418/000418.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000420/000420.xml
+++ b/articles/000420/000420.xml
@@ -96,7 +96,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000420/000420.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000420/000420.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000421/000421.xml
+++ b/articles/000421/000421.xml
@@ -91,7 +91,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000421/000421.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000421/000421.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000422/000422.xml
+++ b/articles/000422/000422.xml
@@ -72,7 +72,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000422/000422.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000422/000422.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000425/000425.xml
+++ b/articles/000425/000425.xml
@@ -76,7 +76,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000425/000425.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000425/000425.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000426/000426.xml
+++ b/articles/000426/000426.xml
@@ -120,7 +120,7 @@
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
             <change when="2019-10-11" who="p:murelj">Added author edits and bios</change>
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000426/000426.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000426/000426.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000427/000427.xml
+++ b/articles/000427/000427.xml
@@ -69,7 +69,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000427/000427.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000427/000427.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000469/000469.xml
+++ b/articles/000469/000469.xml
@@ -146,7 +146,7 @@
         </profileDesc>
         <revisionDesc>
             <!--Each change should include @who and @when as well as a brief note on what was done.-->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000469/000469.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000469/000469.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <text xml:lang="en" type="original">

--- a/articles/000471/000471.xml
+++ b/articles/000471/000471.xml
@@ -109,7 +109,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000471/000471.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000471/000471.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000478/000478.xml
+++ b/articles/000478/000478.xml
@@ -159,7 +159,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000478/000478.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000478/000478.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000485/000485.xml
+++ b/articles/000485/000485.xml
@@ -110,7 +110,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000485/000485.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000485/000485.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000502/000502.xml
+++ b/articles/000502/000502.xml
@@ -97,7 +97,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000502/000502.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000502/000502.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000520/000520.xml
+++ b/articles/000520/000520.xml
@@ -78,7 +78,7 @@
 		</profileDesc>
 		<revisionDesc>
 			<change when="2020-09-18" who="Taylor Arnold">Created file</change>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000520/000520.xml">GitHub
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000520/000520.xml">GitHub
 		</ref></change>
 		</revisionDesc>
 	

--- a/articles/000526/000526.xml
+++ b/articles/000526/000526.xml
@@ -123,7 +123,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000526/000526.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000526/000526.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000529/000529.xml
+++ b/articles/000529/000529.xml
@@ -192,7 +192,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000529/000529.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000529/000529.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000531/000531.xml
+++ b/articles/000531/000531.xml
@@ -89,7 +89,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000531/000531.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000531/000531.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000533/000533.xml
+++ b/articles/000533/000533.xml
@@ -79,7 +79,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000533/000533.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000533/000533.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000544/000544.xml
+++ b/articles/000544/000544.xml
@@ -91,7 +91,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000544/000544.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000544/000544.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000545/000545.xml
+++ b/articles/000545/000545.xml
@@ -83,7 +83,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000545/000545.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000545/000545.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000547/000547.xml
+++ b/articles/000547/000547.xml
@@ -87,7 +87,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000547/000547.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000547/000547.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000549/000549.xml
+++ b/articles/000549/000549.xml
@@ -110,7 +110,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000549/000549.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000549/000549.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000550/000550.xml
+++ b/articles/000550/000550.xml
@@ -177,7 +177,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000550/000550.xml">GitHub </ref></change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000550/000550.xml">GitHub </ref></change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en" type="original">

--- a/articles/000552/000552.xml
+++ b/articles/000552/000552.xml
@@ -88,7 +88,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000552/000552.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000552/000552.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000553/000553.xml
+++ b/articles/000553/000553.xml
@@ -160,7 +160,7 @@
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
       	<change>The version history for this file can be found on <ref target=
-      		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000553/000553.xml">GitHub
+      		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000553/000553.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000554/000554.xml
+++ b/articles/000554/000554.xml
@@ -102,7 +102,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000554/000554.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000554/000554.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000555/000555.xml
+++ b/articles/000555/000555.xml
@@ -82,7 +82,7 @@
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
       	<change>The version history for this file can be found on <ref target=
-      		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000555/000555.xml">GitHub
+      		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000555/000555.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000558/000558.xml
+++ b/articles/000558/000558.xml
@@ -159,7 +159,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000558/000558.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000558/000558.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000561/000561.xml
+++ b/articles/000561/000561.xml
@@ -70,7 +70,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000561/000561.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000561/000561.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000562/000562.xml
+++ b/articles/000562/000562.xml
@@ -147,7 +147,7 @@
 		<revisionDesc>
 			<!--Each change should include @who and @when as well as a brief note on what was done.-->
 			<change when="2022-08-02" who="BRG">added abstract from OJS documentation</change>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000562/000562.xml">GitHub </ref></change>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000562/000562.xml">GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>
 	<text xml:lang="en" type="original">

--- a/articles/000563/000563.xml
+++ b/articles/000563/000563.xml
@@ -89,7 +89,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000563/000563.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000563/000563.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000568/000568.xml
+++ b/articles/000568/000568.xml
@@ -77,7 +77,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000568/000568.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000568/000568.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000570/000570.xml
+++ b/articles/000570/000570.xml
@@ -115,7 +115,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000570/000570.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000570/000570.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000572/000572.xml
+++ b/articles/000572/000572.xml
@@ -68,7 +68,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000572/000572.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000572/000572.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000573/000573.xml
+++ b/articles/000573/000573.xml
@@ -111,7 +111,7 @@
 		</profileDesc>
 		<revisionDesc>
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000573/000573.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000573/000573.xml"
 					>GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000575/000575.xml
+++ b/articles/000575/000575.xml
@@ -66,7 +66,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000575/000575.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000575/000575.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000582/000582.xml
+++ b/articles/000582/000582.xml
@@ -88,7 +88,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000582/000582.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000582/000582.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000586/000586.xml
+++ b/articles/000586/000586.xml
@@ -106,7 +106,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000586/000586.xml">GitHub</ref>.</change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000586/000586.xml">GitHub</ref>.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en" type="original">

--- a/articles/000587/000587.xml
+++ b/articles/000587/000587.xml
@@ -73,7 +73,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000587/000587.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000587/000587.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000591/000591.xml
+++ b/articles/000591/000591.xml
@@ -132,7 +132,7 @@
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
          <change when="2022-08-02" who="BRG">fixed bibliography sortKey</change>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000591/000591.xml">GitHub </ref></change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000591/000591.xml">GitHub </ref></change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en" type="original">

--- a/articles/000592/000592.xml
+++ b/articles/000592/000592.xml
@@ -145,7 +145,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000592/000592.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000592/000592.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000593/000593.xml
+++ b/articles/000593/000593.xml
@@ -75,7 +75,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000593/000593.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000593/000593.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000594/000594.xml
+++ b/articles/000594/000594.xml
@@ -73,7 +73,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000594/000594.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000594/000594.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000597/000597.xml
+++ b/articles/000597/000597.xml
@@ -155,7 +155,7 @@
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
          <change when="2022-08-02" who="BRG">resolved minor endocding errors</change>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000597/000597.xml">GitHub </ref></change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000597/000597.xml">GitHub </ref></change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en" type="original">

--- a/articles/000598/000598.xml
+++ b/articles/000598/000598.xml
@@ -80,7 +80,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000598/000598.xml">GitHub </ref></change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000598/000598.xml">GitHub </ref></change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en" type="original">

--- a/articles/000602/000602.xml
+++ b/articles/000602/000602.xml
@@ -155,7 +155,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000602/000602.xml">GitHub </ref></change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000602/000602.xml">GitHub </ref></change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en" type="original">

--- a/articles/000605/000605.xml
+++ b/articles/000605/000605.xml
@@ -107,7 +107,7 @@
             <change when="2022-08-03" who="BRG">resolved encoding errors and revised xml:id naming
                 structure</change>
             <change>The version history for this file can be found on <ref
-                    target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000605/000605.xml"
+                    target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000605/000605.xml"
                     >GitHub </ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000606/000606.xml
+++ b/articles/000606/000606.xml
@@ -81,7 +81,7 @@
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
          <change when="2022-08-03" who="BRG">resolved encoding errors in body and back
             matter</change>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000606/000606.xml">GitHub </ref></change>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000606/000606.xml">GitHub </ref></change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="en" type="original">

--- a/articles/000613/000613.xml
+++ b/articles/000613/000613.xml
@@ -86,7 +86,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/0000613/000613.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/0000613/000613.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000632/000632.xml
+++ b/articles/000632/000632.xml
@@ -81,7 +81,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000632/000632.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000632/000632.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000635/000635.xml
+++ b/articles/000635/000635.xml
@@ -76,7 +76,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000635/000635.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000635/000635.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000636/000636.xml
+++ b/articles/000636/000636.xml
@@ -77,7 +77,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000636/000636.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000636/000636.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000642/000642.xml
+++ b/articles/000642/000642.xml
@@ -64,7 +64,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc><!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000642/000642.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000642/000642.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000643/000643.xml
+++ b/articles/000643/000643.xml
@@ -188,7 +188,7 @@
 		</profileDesc>
 		<revisionDesc>
 			<!--Each change should include @who and @when as well as a brief note on what was done.-->
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000643/000643.xml">GitHub </ref></change>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000643/000643.xml">GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>
 	<text xml:lang="en" type="original">

--- a/articles/000643/000643_01.xml
+++ b/articles/000643/000643_01.xml
@@ -208,7 +208,7 @@
 		<revisionDesc>
 			<!--Each change should include @who and @when as well as a brief note on what was done.-->
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000643/000643.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000643/000643.xml"
 					>GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000644/000644.xml
+++ b/articles/000644/000644.xml
@@ -73,7 +73,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000644/000644.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000644/000644.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000645/000645.xml
+++ b/articles/000645/000645.xml
@@ -89,7 +89,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000645/000645.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000645/000645.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000646/000646.xml
+++ b/articles/000646/000646.xml
@@ -83,7 +83,7 @@
       </profileDesc>
       <revisionDesc>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->
-      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000646/000646.xml">GitHub
+      	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000646/000646.xml">GitHub
       	</ref></change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000648/000648.xml
+++ b/articles/000648/000648.xml
@@ -87,7 +87,7 @@
 		</profileDesc>
 		<revisionDesc>
 			<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000648/000648.xml">GitHub
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000648/000648.xml">GitHub
 			</ref></change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000649/000649.xml
+++ b/articles/000649/000649.xml
@@ -107,7 +107,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000649/000649.xml">GitHub
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000649/000649.xml">GitHub
 			</ref>
 			</change>
 		</revisionDesc>

--- a/articles/000651/000651.xml
+++ b/articles/000651/000651.xml
@@ -83,7 +83,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000651/000651.xml">GitHub
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000651/000651.xml">GitHub
         	   </ref>
          </change>
          <!--Each change should include @who and @when as well as a brief note on what was done.-->

--- a/articles/000652/000652.xml
+++ b/articles/000652/000652.xml
@@ -81,7 +81,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000652/000652.xml">GitHub </ref>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000652/000652.xml">GitHub </ref>
          </change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000653/000653.xml
+++ b/articles/000653/000653.xml
@@ -64,7 +64,7 @@
             </textClass>
         </profileDesc>
         <revisionDesc>
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000653/000653.xml">GitHub
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000653/000653.xml">GitHub
             </ref>
             </change>
         </revisionDesc>

--- a/articles/000654/000654.xml
+++ b/articles/000654/000654.xml
@@ -94,7 +94,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000654/000654.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000654/000654.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000655/000655.xml
+++ b/articles/000655/000655.xml
@@ -89,7 +89,7 @@
 		</profileDesc>
 		<revisionDesc>
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000655/000655.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000655/000655.xml"
 					>GitHub </ref>
 			</change>
 		</revisionDesc>

--- a/articles/000656/000656.xml
+++ b/articles/000656/000656.xml
@@ -76,7 +76,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000656/000656.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000656/000656.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000657/000657.xml
+++ b/articles/000657/000657.xml
@@ -72,7 +72,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000657/000657.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000657/000657.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000657/000657/000657.xml
+++ b/articles/000657/000657/000657.xml
@@ -84,7 +84,7 @@
 		</profileDesc>
 		<revisionDesc>
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000657/000657.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000657/000657.xml"
 					>GitHub </ref>
 			</change>
 		</revisionDesc>

--- a/articles/000658/000658.xml
+++ b/articles/000658/000658.xml
@@ -66,7 +66,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000658/000658.xml">GitHub
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000658/000658.xml">GitHub
         	   </ref>
          </change>
          <change who="ALS" when="2022-10-07">file created</change>

--- a/articles/000659/000659.xml
+++ b/articles/000659/000659.xml
@@ -78,7 +78,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000659/000659.xml">GitHub </ref>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000659/000659.xml">GitHub </ref>
          </change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000660/000660.xml
+++ b/articles/000660/000660.xml
@@ -80,7 +80,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000660/000660.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000660/000660.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000661/000661.xml
+++ b/articles/000661/000661.xml
@@ -81,7 +81,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000661/000661.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000661/000661.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000662/000662.xml
+++ b/articles/000662/000662.xml
@@ -89,7 +89,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000662/000662.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000662/000662.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000663/000663.xml
+++ b/articles/000663/000663.xml
@@ -98,7 +98,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000663/000663.xml">GitHub </ref>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000663/000663.xml">GitHub </ref>
          </change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000664/000664.xml
+++ b/articles/000664/000664.xml
@@ -76,7 +76,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000664/000664.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000664/000664.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000665/000665.xml
+++ b/articles/000665/000665.xml
@@ -80,7 +80,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000665/000665.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000665/000665.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000666/000666.xml
+++ b/articles/000666/000666.xml
@@ -78,7 +78,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000666/000666.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000666/000666.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000667/000667.xml
+++ b/articles/000667/000667.xml
@@ -96,7 +96,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000667/000667.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000667/000667.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000668/000668.xml
+++ b/articles/000668/000668.xml
@@ -119,7 +119,7 @@
         <revisionDesc>
             
         	<change>The version history for this file can be found on <ref
-        		target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000668/000668.xml"
+        		target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000668/000668.xml"
         		>GitHub</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000669/000669.xml
+++ b/articles/000669/000669.xml
@@ -77,7 +77,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000669/000669.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000669/000669.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000670/000670.xml
+++ b/articles/000670/000670.xml
@@ -85,7 +85,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000670/000670.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000670/000670.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000671/000671.xml
+++ b/articles/000671/000671.xml
@@ -120,7 +120,7 @@
             </textClass>
         </profileDesc>
         <revisionDesc>
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000671/000671.xml">GitHub </ref>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000671/000671.xml">GitHub </ref>
             </change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000672/000672.xml
+++ b/articles/000672/000672.xml
@@ -81,7 +81,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000672/000672.xml">GitHub </ref>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000672/000672.xml">GitHub </ref>
 			</change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000673/000673.xml
+++ b/articles/000673/000673.xml
@@ -132,7 +132,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000673/000673.xml">GitHub </ref>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000673/000673.xml">GitHub </ref>
          </change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000674/000674.xml
+++ b/articles/000674/000674.xml
@@ -94,7 +94,7 @@
         </profileDesc>
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000674/000674.xml">GitHub
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000674/000674.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000675/000675.xml
+++ b/articles/000675/000675.xml
@@ -107,7 +107,7 @@
 		</profileDesc>
 		<revisionDesc>
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000675/000675.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000675/000675.xml"
 					>GitHub </ref>
 			</change>
 		</revisionDesc>

--- a/articles/000676/000676.xml
+++ b/articles/000676/000676.xml
@@ -122,7 +122,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000676/000676.xml">GitHub </ref>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000676/000676.xml">GitHub </ref>
          </change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000677/000677.xml
+++ b/articles/000677/000677.xml
@@ -95,7 +95,7 @@
       </profileDesc>
       <revisionDesc>
          <change>The version history for this file can be found on <ref
-               target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000677/000677.xml"
+               target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000677/000677.xml"
                >GitHub </ref>
          </change>
       </revisionDesc>

--- a/articles/000679/000679.xml
+++ b/articles/000679/000679.xml
@@ -111,7 +111,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000679/000679.xml">GitHub </ref>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000679/000679.xml">GitHub </ref>
          </change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000680/000680.xml
+++ b/articles/000680/000680.xml
@@ -86,7 +86,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000680/000680.xml">GitHub</ref>
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000680/000680.xml">GitHub</ref>
          </change>
       </revisionDesc>
    </teiHeader>

--- a/articles/000681/000681.xml
+++ b/articles/000681/000681.xml
@@ -83,7 +83,7 @@
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000681/000681.xml">GitHub
+         <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000681/000681.xml">GitHub
         	   </ref>
          </change>
       </revisionDesc>

--- a/articles/000682/000682.xml
+++ b/articles/000682/000682.xml
@@ -298,7 +298,7 @@
 			</textClass>
 		</profileDesc>
 		<revisionDesc>
-			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000682/000682.xml">GitHub </ref> </change>
+			<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000682/000682.xml">GitHub </ref> </change>
 		</revisionDesc>
 	</teiHeader>
 	<text xml:lang="en" type="original">

--- a/articles/000683/000683.xml
+++ b/articles/000683/000683.xml
@@ -116,7 +116,7 @@
       </profileDesc>
       <revisionDesc>
          <change>The version history for this file can be found on <ref
-               target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000683/000683.xml"
+               target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000683/000683.xml"
                >GitHub </ref>
          </change>
       </revisionDesc>

--- a/articles/000685/000685.xml
+++ b/articles/000685/000685.xml
@@ -83,7 +83,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000685/000685.xml">GitHub </ref>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000685/000685.xml">GitHub </ref>
             </change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000687/000687.xml
+++ b/articles/000687/000687.xml
@@ -218,7 +218,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000685/000685.xml">GitHub </ref></change>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000685/000685.xml">GitHub </ref></change>
         </revisionDesc>
     </teiHeader>
     <!-- If a translation is added to the original article, add an enclosing <text> and <group> element -->

--- a/articles/000688/000688.xml
+++ b/articles/000688/000688.xml
@@ -117,7 +117,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000688/000688.xml">GitHub </ref>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000688/000688.xml">GitHub </ref>
             </change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000690/000690.xml
+++ b/articles/000690/000690.xml
@@ -78,7 +78,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000690/000690.xml">GitHub </ref>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000690/000690.xml">GitHub </ref>
             </change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000691/000691.xml
+++ b/articles/000691/000691.xml
@@ -91,7 +91,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000691/000691.xml">GitHub </ref>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000691/000691.xml">GitHub </ref>
             </change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000692/000692.xml
+++ b/articles/000692/000692.xml
@@ -90,7 +90,7 @@
         </profileDesc>
         <revisionDesc>
             <!-- Each change should include @who and @when as well as a brief note on what was done. -->
-            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000692/000692.xml">GitHub </ref>
+            <change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000692/000692.xml">GitHub </ref>
             </change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000696/000696.xml
+++ b/articles/000696/000696.xml
@@ -117,7 +117,7 @@
 		<revisionDesc>
 			<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000696/000696.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000696/000696.xml"
 					>GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000699/000699.xml
+++ b/articles/000699/000699.xml
@@ -125,7 +125,7 @@
 		<revisionDesc>
 			<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000699/000699.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000699/000699.xml"
 					>GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000717/000717.xml
+++ b/articles/000717/000717.xml
@@ -82,7 +82,7 @@
             </textClass>
         </profileDesc>
         <revisionDesc>
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000717/000717.xml">GitHub</ref></change>
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000717/000717.xml">GitHub</ref></change>
         </revisionDesc>
     </teiHeader>
     <text xml:lang="en" type="original">

--- a/articles/000718/000718.xml
+++ b/articles/000718/000718.xml
@@ -100,7 +100,7 @@
 		<revisionDesc>
 			<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
 			<change>The version history for this file can be found on <ref
-					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000718/000718.xml"
+					target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000718/000718.xml"
 					>GitHub </ref></change>
 		</revisionDesc>
 	</teiHeader>

--- a/articles/000730/000730.xml
+++ b/articles/000730/000730.xml
@@ -84,7 +84,7 @@
         </profileDesc>
         <revisionDesc>
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000730/000730.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000730/000730.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000758/000758.xml
+++ b/articles/000758/000758.xml
@@ -77,7 +77,7 @@
         <revisionDesc>
        
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000758/000758.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000758/000758.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000771/000771.xml
+++ b/articles/000771/000771.xml
@@ -114,7 +114,7 @@
         <revisionDesc>
         	
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000771/000771.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000771/000771.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000774/000774.xml
+++ b/articles/000774/000774.xml
@@ -122,7 +122,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000774/000774.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000774/000774.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000777/000777.xml
+++ b/articles/000777/000777.xml
@@ -111,7 +111,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000777/000777.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000777/000777.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000783/000783.xml
+++ b/articles/000783/000783.xml
@@ -120,7 +120,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000783/000783.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000783/000783.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000784/000784.xml
+++ b/articles/000784/000784.xml
@@ -91,7 +91,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000784/000784.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000784/000784.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000785/000785.xml
+++ b/articles/000785/000785.xml
@@ -99,7 +99,7 @@
         </profileDesc>
         <revisionDesc>
             <change>The version history for this file can be found on <ref
-                    target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000785/000785.xml"
+                    target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000785/000785.xml"
                     >GitHub </ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000786/000786.xml
+++ b/articles/000786/000786.xml
@@ -103,7 +103,7 @@
         </profileDesc>
         <revisionDesc>
             <change>The version history for this file can be found on <ref
-                    target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000786/000786.xml"
+                    target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000786/000786.xml"
                     >GitHub </ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000788/DHQ_Manuscript.xml
+++ b/articles/000788/DHQ_Manuscript.xml
@@ -103,7 +103,7 @@
             </textClass>
         </profileDesc>
         <revisionDesc>
-        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000717/000717.xml">GitHub</ref></change>
+        	<change>The version history for this file can be found on <ref target="https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000717/000717.xml">GitHub</ref></change>
         </revisionDesc>
     </teiHeader>
     <text xml:lang="en" type="original">

--- a/articles/000789/000789.xml
+++ b/articles/000789/000789.xml
@@ -119,7 +119,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000789/000789.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000789/000789.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/000801/000801.xml
+++ b/articles/000801/000801.xml
@@ -89,7 +89,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000801/000801.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000801/000801.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/999775/999775.xml
+++ b/articles/999775/999775.xml
@@ -80,7 +80,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/NNNNNN/NNNNNN.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/NNNNNN/NNNNNN.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/999775/test_article.xml
+++ b/articles/999775/test_article.xml
@@ -80,7 +80,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/NNNNNN/NNNNNN.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/NNNNNN/NNNNNN.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/templates/dhq-tei_template.xml
+++ b/articles/templates/dhq-tei_template.xml
@@ -84,7 +84,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/NNNNNN/NNNNNN.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/NNNNNN/NNNNNN.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/templates/dhq-tei_template_copoy_2.xml
+++ b/articles/templates/dhq-tei_template_copoy_2.xml
@@ -84,7 +84,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/NNNNNN/NNNNNN.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/NNNNNN/NNNNNN.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/templates/dhq-tei_template_copy.xml
+++ b/articles/templates/dhq-tei_template_copy.xml
@@ -84,7 +84,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/NNNNNN/NNNNNN.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/NNNNNN/NNNNNN.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/test_folder/000758_with_names.xml
+++ b/articles/test_folder/000758_with_names.xml
@@ -84,7 +84,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000758/000758.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000758/000758.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/articles/test_folder/000758_without_names.xml
+++ b/articles/test_folder/000758_without_names.xml
@@ -84,7 +84,7 @@
         <revisionDesc>
         	<!-- Replace "XXXXXX" in the @target of ref below with the appropriate DHQarticle-id value. -->
         	<change>The version history for this file can be found on <ref target=
-        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/master/articles/000758/000758.xml">GitHub
+        		"https://github.com/Digital-Humanities-Quarterly/dhq-journal/commits/main/articles/000758/000758.xml">GitHub
         	</ref></change>
         </revisionDesc>
     </teiHeader>

--- a/common/xslt/transformation_scenarios.scenarios
+++ b/common/xslt/transformation_scenarios.scenarios
@@ -110,7 +110,7 @@
 						<String></String>
 					</field>
 					<field name="inputXSLURL">
-						<String>https://raw.githubusercontent.com/Digital-Humanities-Quarterly/dhq-journal/master/common/xslt/dhq-preview-html.xsl</String>
+						<String>https://raw.githubusercontent.com/Digital-Humanities-Quarterly/dhq-journal/main/common/xslt/dhq-preview-html.xsl</String>
 					</field>
 					<field name="inputXMLURL">
 						<String>${currentFileURL}</String>


### PR DESCRIPTION
Used a Perl one-liner to fix these.¹ Some comments, not necessarily in an intelligent order:

- It was important to only change "master" to "main" in URLs that point to DHQ, because there are a reasonable number of references to "/master/" in non-DHQ URLs, too.
- Since this was a string-manipulation change without XML awareness, any such URLs in a comment or PI were also changed. (I think this would be a good thing, not a bad thing, but I am not sure there _were_ any, anyway.)
- All changes were in articles/, except for two:
  - README.md
  - common/xslt/transformation_scenarios.scenarios
- For that last one (the oXygen scenarios file) I was not sure if the URL _should_ be changed or not, but I tested and found that the two URLs² fetch exactly the same content.

If & when this is merged, issue #132 can be closed and branch sydb_132_main_not_master can be deleted.

### notes
¹ `perl -p -i -e 's,(Digital-Humanities-Quarterly/dhq-journal.*/)master/,$1main/,g;' $( egrep -rl 'Digital-Humanities-Quarterly/dhq-journal.*/master/' * )` Note that it was probably not remotely necessary to use the `egrep` to get a list of files to operate on — the time saved was a _lot_ less than the time it takes me to write this — but I did so because I had that cmd at my fingertips, anyway, having just used it to assess the scope of occurrences.
² `https://raw.githubusercontent.com/Digital-Humanities-Quarterly/dhq-journal/ma(ster|in)/common/xslt/dhq-preview-html.xsl`