### PR TITLE
Fix duplicate keys in Zotero processing

### DIFF
--- a/common/xslt/convert_tei2dhq.xsl
+++ b/common/xslt/convert_tei2dhq.xsl
@@ -84,7 +84,7 @@
             </xsl:variable>
             <!-- We use the Zotero ID as the key, because it is guaranteed to be unique and individual 
               citations can reference it to get at the unique generated ID. -->
-            <xsl:map-entry key="$zoteroId">
+            <xsl:map-entry key="xs:string($zoteroId)">
               <!-- Compile data for the bibliography entry. -->
               <xsl:call-template name="parse-bibliographic-json">
                 <xsl:with-param name="citation-map" select="$thisEntry"/>
@@ -115,7 +115,8 @@
               <xsl:for-each select="$zotero-citation-processing-instructions">
                 <xsl:map-entry key="?citationID">
                   <xsl:for-each select="?citationItems?*">
-                    <xsl:variable name="idref" select="dhq:get-bibliography-entry-id(?itemData?id cast as xs:string)"/>
+                    <xsl:variable name="zoteroID" select="?itemData?id cast as xs:string" as="xs:string"/>
+                    <xsl:variable name="idref" select="dhq:get-bibliography-entry-id($zoteroID)"/>
                     <ptr target="#{$idref}">
                       <xsl:if test="map:contains(., 'locator')">
                         <xsl:attribute name="loc" select="?locator"/>


### PR DESCRIPTION
This PR fixes a bug in the `convert_tei2dhq.xsl` stylesheet: When the original Word document included Zotero data, the stylesheet would generate the same ID for a work whose author had published more than once in the same year. The IDs would not be unique, and Saxon would report something like this: 

> Duplicate key in constructed map: {campanaro2023}

In order to test whether an ID is unique, I refactored the Zotero processing code. Bibliography entries' IDs are tested for uniqueness, and duplicates are given a unique postfix. The bibliography data is processed as part of a global variable, so all templates have access to the unique DHQ-specific ID by providing Zotero's entry ID to the new function `dhq:get-bibliography-entry-id()`.

For the test TEI file I was given, the two bibliography entries which previously matched `campanaro2023` are now identified as `campanaro2023-12` and `campanaro2023-3`. The postfix might be more useful as `campanaro2023a` and `campanaro2023b` respectively. Unfortunately, I can't guarantee that my `2023a` would match the entry Zotero has marked as "2023a".

To update the identifier and all references to it, context-click on the ID in an Oxygen editor. Choose "Manage IDs", then "Rename in File". A box will appear around the ID. Update the ID value and hit <kbd>Enter</kbd>.