### PR TITLE
Fixes to language usage metadata

### DIFF
--- a/articles/000502/000502.xml
+++ b/articles/000502/000502.xml
@@ -76,9 +76,8 @@
         </encodingDesc>
         <profileDesc>
             <langUsage>
-                <language ident="sp" extent="default"/>
-                <!-- add <language> with appropriate @ident for any additional languages -->
-            </langUsage>
+              <language ident="es" extent="default"/>
+	    </langUsage>
             <textClass>
                 <keywords scheme="#dhq_keywords">
 		<term corresp="#archives"/>

--- a/articles/000608/000608.xml
+++ b/articles/000608/000608.xml
@@ -110,19 +110,17 @@
          </classDecl>
       </encodingDesc>
       <profileDesc>
-
          <langUsage>
-            <language ident="en" extent="abstract_only"/>
+           <language ident="es" extent="default"/>
+           <language ident="en" extent="abstract_only"/>
          </langUsage>
          <textClass>
             <keywords scheme="#dhq_keywords">
-		<term corresp="#access"/>
-		<term corresp="#collaboration"/>
-		<term corresp="#project_report"/>
-	</keywords>
+	      <term corresp="#access"/>
+	      <term corresp="#collaboration"/>
+	      <term corresp="#project_report"/>
+	    </keywords>
             <keywords scheme="#authorial_keywords">
-               
-            
               <term/>
             </keywords>
          </textClass>


### PR DESCRIPTION
This PR should be merged **before** #187 is merged.

All it does is fix what look (to me) like obvious errors in the `<langUsage>` in each of two files.