### PR TITLE
PR 2026-05-22 from encoding_workflow: add CFP for AI Pedagogy special issue

### DIFF
--- a/articles/000864/000864.xml
+++ b/articles/000864/000864.xml
@@ -206,9 +206,9 @@
                          computing,</quote> <quote rend="inline">responsible computing,</quote> <quote rend="inline">green IT,</quote> and <quote rend="inline">‘poor' 
                              computing.</quote> These concepts encourage purposeful work with limited computational resources, either out of ethical or economic 
                      necessity or to intentionally experience hardware and IT restrictions others face, particularly in the Global South.<note>Following Gil and Risam
-                         <ptr target="#gilrisam2022" loc="91>"/>, we employ <quote rend="inline">Global North</quote> and <quote rend="inline">Global South</quote>
+                         <ptr target="#gilrisam2022" loc="n. 9"/>, we employ <word>Global North</word> and <word>Global South</word>
                          as shorthand terms to describe the economic divide between high-income and low-income economies, which result largely from colonialism. We 
-                         acknowledge, however, that these terms, like related concepts such as <quote rend="inline">developed countries,</quote> <quote rend="inline">the Third World,</quote> and <quote rend="inline">the West,</quote> have limitations due to their tendency to oversimplify and 
+                         acknowledge, however, that these terms, like related concepts such as <word>developed countries,</word> <word>the Third World</word>, and <word>the West,</word> have limitations due to their tendency to oversimplify and 
                          their geographical vagueness.</note>
                  </p>                 
              </div>
@@ -220,7 +220,7 @@
                      how minimal computing can make marginalized histories more accessible and visible. The Cyberfeminism Index showcases how a simple, text-based 
                      design can effectively present complex, specialized content. These projects, like MARXdown or Wiscomb’s <title rend="italic">democracy</title>
                      Journal Archive <ptr target="#wiscomb"/>, attempt to illustrate the versatility of minimal computing principles in creating accessible, community-oriented 
-                     resources, which are not necessarily synonymous with static websites <ptr target="#gilrisam2022" loc="3>"/>.
+                     resources, which are not necessarily synonymous with static websites <ptr target="#gilrisam2022" loc="n. 3"/>.
                  </note>
              </p><p>
                  Teaching minimal computing principles can help DH students to deliberately embrace constraints that inspire reflection on uneven barriers coded into 
@@ -383,44 +383,193 @@
                      unbalanced political economy in academia, attempting to create a useful
                      community resource while remaining cognizant of the labor conditions
                      under which it was produced.</p>
+                 <p>Our experiences as graduate students at Carnegie
+                     Mellon University also reflect a particular North American academic
+                     labor model, where doctoral students typically spend 5-7 years in
+                     programs that combine coursework, teaching responsibilities, and
+                     research. The precarity we describe — balancing teaching duties, research
+                     obligations, and community-building projects like MARXdown with limited
+                     institutional support — characterizes a specific configuration of graduate
+                     education that may not translate directly to European, Asian, or other
+                     academic systems with different funding structures, time-to-degree
+                     expectations, and teaching requirements. The labor analysis we offer
+                     should therefore be understood within this specific institutional
+                     context.</p>
+                 <p>These concerns about minimalism potentially reinforcing exploitative labor conditions connect to broader critiques in critical university studies by 
+                     scholars like Marc Bousquet in whose <title rend="italic">How the University Works</title> documents how academic labor has been increasingly casualized <ptr target="#bousquet2008"/>. </p>
+                 <p>In the years following our initial reading of <title rend="italic">Capital Vol. 1</title>, we reflected on its formative effect as
+                     students. We were disappointed that we lacked records to revisit or
+                     share with new members as a repository of institutional memory. All that
+                     remained from our sessions during the summer of 2016 were private notes
+                     saved as .docx files on local hard drives, along with a few unsuccessful
+                     attempts to use a forum widget on the group's fledgling — and now
+                     defunct — Wordpress.com site.</p>
+                 <p>We also faced several challenges: <title rend="italic">Capital Vol. 1</title> is a formidable and intimidating book — one we couldn't feasibly 
+                     (re)read every summer. Yet it was a key text that many newcomers to the group and to graduate work in literary and cultural studies often wanted to 
+                     tackle — preferably not alone.</p>
+                 <p>Our university setting also presented additional
+                     complexities. The reading group needed to accommodate a fluctuating
+                     roster of members, with students constantly entering and leaving the
+                     program. We experienced uneven participation from students and graduate
+                     instructors, which depended on the level of interest in Marx and Marxism
+                     during a given cohort year. The varying stages of degree progress,
+                     including amongst MA students, and other demands on the time of its
+                     organizers further complicated efforts to maintain continuity and
+                     engagement.</p>
+                 <p>Under these conditions, we found it challenging to construct a single, unified reading or "guide" to <title rend="italic">Capital Vol. 1 </title>as a 
+                     group. Essentially, we lacked a way to collect and preserve a composite record of the diverse academic
+                     interests and situated perspectives that had enriched our initial
+                     reading of the text. We recognized the need for some form of persistence
+                     in our collective engagement with Marx's writing. However, this
+                     persistence needed to remain flexible, allowing both existing and new
+                     members to incorporate emerging interests and lines of inquiry.</p>
+                 <p>For example, by 2018, our group had begun a
+                     sustained engagement with the resurgent energies invested in social
+                     reproduction theory in contemporary Marxist studies. So, we explored the
+                     work of scholars such as <name>Tithi Bhattacharya</name> and <name>Susan Ferguson</name>, which
+                     prompted us to revisit writings on sex, gender, and reproduction by
+                     postwar socialist feminist thinkers and activists associated with the
+                     international "Wages for Housework" campaign of the early 1970s,
+                     including <name>Mariarosa Dalla Costa</name>, <name>Leopolda Fortunati</name>, <name>Selma James</name>, and
+                     <name>Silvia Federici</name>.</p>
+                 <p>In time, these interventions of social reproduction feminism became fundamental to our critique of capital. As a result, we felt an increasing 
+                     urgency to integrate this new and important perspective into our established readings of <name>Marx</name>’s <title rend="italic">Capital</title>. 
+                     This evolution in our focus highlighted the
+                     need for a flexible, yet persistent, approach to our collective study
+                     and collaborative reading.</p>
+                 <p>Additionally, as new graduate-student members joined the group, we considered undertaking another comprehensive reading of <title rend="italic">Capital
+                         Vol. 1</title>. However, we soon realized that not everyone who
+                     wanted to participate even owned a copy of the book. For example, some
+                     members insisted on reading online, valuing the text's free access and
+                     portability. Even among those who owned physical copies, differences in
+                     translations or page numbering hindered fluid group
+                     discussions.</p>
+                 <p>Thus the need for MARXdown emerged in response to
+                     three key questions:</p>
+                 <list type="ordered">
+                     <item>How could we preserve the memory of our
+                         group's ongoing engagement with this important text over
+                         time?</item>
+                     <item>How could we enrich the experience of
+                         newcomers to the text with supplemental material deemed important by
+                         the group?</item>
+                     <item>How could we ensure these memories and
+                         materials would persist and be easily maintainable?</item>
+                 </list>
+                 <p>These considerations, along with our shared desire to make the electronic text not only readable but also pleasant to engage with on-screen and mobile devices, informed and shaped the initial "architecture of necessity" for our digital reading edition of 
+                     <title rend="italic">Capital Vol. 1</title>. We aimed to create a resource that would
+                     address our practical needs while enhancing the collective reading
+                     experience.</p>
+                 <p>Set within this context, the environmental constraints out of which MARXdown originally developed can be productively framed as responding to the first two “what-type” questions posed by <name>Gil</name>and <name>Risam</name> in the 2022 <title rend="italic">DHQ</title> 
+                     special issue on minimal computing: What do we have? and What do we need? <ptr target="#gilortega"/>.</p>
+                 <list type="ordered">
+                     <item>What we had:
+                 <list type="unordered">
+                     <item>an established, and growing, community of committed
+                         readers (CMRG-CMU)</item>
+                     <item>a desire to engage with a single shared
+                         text (<title rend="italic">Capital Vol.1</title>)</item>
+                 </list></item>
+                 <item>What we needed:
+                 <list type="unordered">
+                     <item>a way to leverage our prior
+                         knowledge of the text to enliven the
+                         experience of those new to <title rend="italic">Capital Vol.1</title> by curating supplemental material deemed important by the group’s established members.</item>
+                     <item>a method for ensuring that such memories and materials would persist, while remaining flexible and responsive to insights and intellectual trajectories brought by new members, and that they be easily
+                         maintained for future iterations of the group.</item>
+                 </list> </item> </list>
+                 
+             </div>
+             <div>
+                 <head>MARXdown’s Design and Implementation</head>
+                 <p>In the spring of 2018, we endeavored to create MARXdown as a digital reading edition that might meet these necessities of our community when we 
+                     embarked on a new reading of <title rend="italic">Capital</title> the following fall. Our hope for the reading edition was to give the reading group 
+                     access to a persistent, shared, and portable way to record our pathways through <title rend="italic">Capital</title>, marking disagreements and 
+                     departures, but also preserving breakthroughs and insights.</p>
+                 <p>While the first two “what-type” questions offer a
+                     contextual frame for understanding the project’s history — the second
+                     pair of <name>Gil</name>and <name>Risam</name>’s decision-making prompts for minimal
+                     computing—<hi style="bold">what must we prioritize?</hi> and <hi style="bold">what are we willing to give up?</hi> — offer a useful frame for narrating our design
+                     and implementation process, which should be generalizable to other
+                     digital reading edition projects:</p>
+                 <p><hi style="bold">What we prioritized</hi>:</p>
+                 <list type="ordered">
+                     <item><hi style="bold">We prioritized accessibility</hi> - by ensuring the text and annotation layer
+                         were persistent, resizable in the browser window, and
+                         mobile-friendly.</item>
+                     <item><hi style="bold">We prioritized readability</hi> - by keeping the text and its footnotes
+                         typographically legible, and minimally styled.</item>
+                     <item><hi style="bold">We prioritized portability</hi> - by making the Markdown files publicly
+                         available and usable across environments and platforms, and reusable
+                         in other applications by group members or the public.</item>        
+                 </list>
+                 <p>Across these three priority areas we tried to
+                     focus on only what felt necessary, and then only what could be done
+                     efficiently — and for free. One surprising upshot to using the
+                     minimal-computing heuristic, or “what-type” questions we’re advocating,
+                     is that it can be generative of other practical minimal computing
+                     solutions, or edition features that, while unnecessary, still add some
+                     value to the edition for readers.</p>
+                 <p><hi style="bold">What we were willing to give
+                     up:</hi></p>
+                 <list type="ordered">
+                     <item><hi style="bold">We were willing to give up scholarly scope</hi> – but it resulted in a targeted repository of materials, primary and secondary sources, and 
+                         annotations related to <title rend="italic">Capital Vol. 1</title> in a shared Zotero folder and on <ref target="https://web.hypothes.is/">hypothes.is</ref></item>
+                     <item><hi style="bold">We were willing to give up synchronicity and the emphasis on shared physical space</hi>
+                         – but it resulted in asynchronous engagement with the text and arguably more reflective notes and comments in the annotation layer than if we had discussed them in person, as well as opportunities for online collaboration with readers at other universities.</item>
+                     <item><hi style="bold">We were willing to give up copy-righted translations</hi> – but it resulted in us greatly improving on the formatting of the public-domain translation already available and (somewhat) readable on Marxists.org </item>
+                 </list>
+                 <p>Embracing minimal-computing principles as practical decision-making heuristics led us to seek efficient ways of leveraging lightweight, pre-existing 
+                     web-publishing methods rather than reinventing the digital wheel. Instead of attempting to design and build "The Greatest Marx Archive Ever" or 
+                     hosting related sources on our website, we utilized free storage and groups from Zotero. We also incorporated the pre-existing online annotation 
+                     software hypothes.is to provide an embedded conversation layer for texts. This approach empowered our group to generate situated yet persistent 
+                     "readings" of <title rend="italic">Capital Vol. 1</title> and other texts. Importantly, individual group members retained ownership of their 
+                     annotations, with the ability to edit or modify them later. This strategy allowed us to create a dynamic, collaborative reading environment while adhering to minimal computing principles and respecting individual contributions.</p>
+                 <p>Our text for <title rend="italic">Capital Vol. 1</title>was taken from the website <ref target="https://www.marxists.org/">marxists.org</ref>, using Wget to execute an automated download of the 
+                     site contents relevant to <title rend="italic">Capital Vol. 1</title>. We then converted pages from HTML to Markdown, and when necessary cleaned 
+                     them using Regular Expressions and “typeset” them in plain text editors like <name>Atom</name> and <name>Sublime</name>.</p>
                  <!--start encoding here-->
+                 
              </div>
          </body>
         <back>
             <listBibl>
+                 
+                <bibl xml:id="gilortega" label="Gil and Ortega 2016">Gil, A. and Ortega, Élika (2016) <title rend="quotes">Multilingual Practices and Minimal Computing.</title>. In Doing Digital Humanities: Practice, Training, Research, Constance Crompton, Richard J. Lane, and Ray Siemens (eds), 22–34. NY: Routledge, 2016.</bibl>
+                <bibl xml:id="bousquet2008" label="Bousquet and Nelson 2008">Bousquet, M. and Nelson, C. (2008) <title rend="italic">How the University Works: Higher Education and the Low-Wage Nation</title>. New York: New York University Press.</bibl>
                 <bibl xml:id="luka" label="Luka and Millette 2018">Luka, M.E. and Millette, M. (2018) <title rend="quotes">(Re)framing Big Data: Activating Situated Knowledges and a Feminist Ethics of Care in Social Media Research</title>. Social Media + Society, 4(2).</bibl>
                 <bibl xml:id="fitzpatrick" label="Fitzpatrick 2019">Fitzpatrick, K. (2019) <title rend="italic">Generous Thinking: A Radical Approach to Saving the University</title>. Baltimore: Johns Hopkins University Press.</bibl>
                 <bibl xml:id="kuehn" label="Kuehn &amp; Corrigan 2013">Kuehn, K. and Corrigan, T.F. (2013) <title rend="quotes">Hope Labor: The Role of Employment Prospects in Online Social Production</title>. The Political Economy of Communication, 1(1), pp. 9–25.</bibl>
                 <bibl xml:id="boler2008" label="Boler 2008">Boler, M. (ed.) (2008) <title rend="italic">Digital Media and Democracy: Tactics in Hard Times</title>. Cambridge, MA: MIT Press.</bibl>
-                <bibl xml:id="bousquet" label="Bousquet 2002">Bousquet, M. (2002) <title rend="quotes">The Waste Product of Graduate Education</title>. Social Text, 20(1), pp. 81–104. Available at: https://doi.org/10.1215/01642472-20-1_70-81.</bibl>
+                <bibl xml:id="bousquet" label="Bousquet 2002">Bousquet, M. (2002) <title rend="quotes">The Waste Product of Graduate Education</title>. Social Text, 20(1), pp. 81–104. Available at: <ref target="https://doi.org/10.1215/01642472-20-1_70-81">https://doi.org/10.1215/01642472-20-1_70-81</ref>.</bibl>
                 <bibl xml:id="risam2018" label="Risam 2018">Risam, R. (2018) <title rend="italic">New digital worlds: postcolonial digital humanities in theory, praxis, and pedagogy</title>. Evanston, Illinois: Northwestern University Press.</bibl>
-                <bibl xml:id="gotzlerwiscomb2019" label="Gotzler, Wiscomb 2019">Gotzler, S. and Wiscomb, A. (2019)<title>MARXdown</title>. Available at: https://MARXdown.github.io/ (Accessed: 1 October 2024).</bibl>
-                <bibl xml:id="visconti2016" label="Visconti (2016)">Visconti, A. (2016)<title rend="quotes">Building a static website with Jekyll and GitHub Pages</title>. Programming Historian [Preprint]. Available at: https://programminghistorian.org/en/lessons/building-static-sites-with-jekyll-github-pages (Accessed: 10 September 2024).</bibl>
-                <bibl xml:id="viscontietal2020" label="Visconti et al. (2021)">Visconti, A., Walsh, B. and Community, S.L. (2020)<title rend="quotes">Running a Collaborative Research Website and Blog with Jekyll and GitHub</title>. Programming Historian [Preprint]. Available at: https://programminghistorian.org/en/lessons/collaborative-blog-with-jekyll-github (Accessed: 14 October 2024).</bibl>
-                <bibl xml:id="weingart" label="Lincoln, Weingart 2021">Weingart, S.B. and Lincoln, M. (2021)<title rend="quotes">CMU Library Labs (2020-2024)</title>. p. 455911 Bytes. Available at: https://doi.org/10.1184/R1/13522718.</bibl>
-                <bibl xml:id="wernimont" label="Wernimont 2015">Wernimont, J. (2015) <title rend="quotes">Build a Better Panel: Feminist Interventions in Digital Studies</title>. Jacqueline Wernimont Blog, 23 January. Available at: https://jwernimont.com/build-a-better-panel-feminist-interventions-in-digital-studies/</bibl>
-                <bibl xml:id="wiscomb" label="Wiscomb 2016">Wiscomb, A. (2016) <title>democracy Journal Archive (1981-1983)</title>. Available at: https://democracyjournalarchive.wordpress.com/ (Accessed: 10 October 2024).</bibl>
-                <bibl xml:id="gotzler2019" label="Gotzler 2019">Gotzler, S. (2019)<title>Deploying Lightweight Digital Editions in the Community and Classroom, praxis-session</title>. Available at: https://sgotzler.github.io/praxis-session/ (Accessed: 1 October 2024).</bibl>
-                <bibl xml:id="gil2019" label="Gil 2019">Gil, A. (2019) <title rend="quotes">Design for Diversity: The Case of Ed</title>. 20 June. Available at: https://des4div.library.northeastern.edu/design-for-diversity-the-case-of-ed-alex-gil/ (Accessed: 24 September 2024).</bibl>
-                <bibl xml:id="beshero" label="Beshero-Bondar et al. 2020">Beshero-Bondar, E. et al. (2020) <title rend="quotes">Frankenstein Variorum</title>. Carnegie Mellon University. Available at: https://doi.org/10.1184/R1/C.4805868.V1.</bibl>
-                <bibl xml:id="gil2015" label="Gil 2015">Gil, A. (2015) <title>The User, the Learner and the Machines We Make</title>. Minimal Computing, Minimal Computing: A Working Group of GO::DH. Available at: http://go-dh.github.io/mincomp/thoughts/2015/05/21/user-vs-learner/ (Accessed: 11 September 2024).</bibl>
-                <bibl xml:id="sayers2016" label="Sayers 2016">Sayers, G. (2016) <title>Minimal Definitions, Minimal Computing: A Working Group of GO::DH</title>. Available at: http://go-dh.github.io/mincomp/thoughts/2016/10/02/minimal-definitions/.</bibl>
+                <bibl xml:id="gotzlerwiscomb2019" label="Gotzler, Wiscomb 2019">Gotzler, S. and Wiscomb, A. (2019)<title>MARXdown</title>. Available at: <ref target="https://MARXdown.github.io/">https://MARXdown.github.io/</ref> (Accessed: 1 October 2024).</bibl>
+                <bibl xml:id="visconti2016" label="Visconti (2016)">Visconti, A. (2016)<title rend="quotes">Building a static website with Jekyll and GitHub Pages</title>. Programming Historian [Preprint]. Available at: <ref target="https://programminghistorian.org/en/lessons/building-static-sites-with-jekyll-github-pages">https://programminghistorian.org/en/lessons/building-static-sites-with-jekyll-github-pages</ref> (Accessed: 10 September 2024).</bibl>
+                <bibl xml:id="viscontietal2020" label="Visconti et al. (2021)">Visconti, A., Walsh, B. and Community, S.L. (2020)<title rend="quotes">Running a Collaborative Research Website and Blog with Jekyll and GitHub</title>. Programming Historian [Preprint]. Available at: <ref target="https://programminghistorian.org/en/lessons/collaborative-blog-with-jekyll-github">https://programminghistorian.org/en/lessons/collaborative-blog-with-jekyll-github</ref> (Accessed: 14 October 2024).</bibl>
+                <bibl xml:id="weingart" label="Lincoln, Weingart 2021">Weingart, S.B. and Lincoln, M. (2021)<title rend="quotes">CMU Library Labs (2020-2024)</title>. p. 455911 Bytes. Available at: <ref target="https://doi.org/10.1184/R1/13522718">https://doi.org/10.1184/R1/13522718</ref>.</bibl>
+                <bibl xml:id="wernimont" label="Wernimont 2015">Wernimont, J. (2015) <title rend="quotes">Build a Better Panel: Feminist Interventions in Digital Studies</title>. Jacqueline Wernimont Blog, 23 January. Available at: <ref target="https://jwernimont.com/build-a-better-panel-feminist-interventions-in-digital-studies/">https://jwernimont.com/build-a-better-panel-feminist-interventions-in-digital-studies/</ref></bibl>
+                <bibl xml:id="wiscomb" label="Wiscomb 2016">Wiscomb, A. (2016) <title>democracy Journal Archive (1981-1983)</title>. Available at: <ref target="https://democracyjournalarchive.wordpress.com/">https://democracyjournalarchive.wordpress.com/</ref> (Accessed: 10 October 2024).</bibl>
+                <bibl xml:id="gotzler2019" label="Gotzler 2019">Gotzler, S. (2019)<title>Deploying Lightweight Digital Editions in the Community and Classroom, praxis-session</title>. Available at: <ref target="https://sgotzler.github.io/praxis-session/">https://sgotzler.github.io/praxis-session/</ref> (Accessed: 1 October 2024).</bibl>
+                <bibl xml:id="gil2019" label="Gil 2019">Gil, A. (2019) <title rend="quotes">Design for Diversity: The Case of Ed</title>. 20 June. Available at: <ref target="https://des4div.library.northeastern.edu/design-for-diversity-the-case-of-ed-alex-gil/">https://des4div.library.northeastern.edu/design-for-diversity-the-case-of-ed-alex-gil/</ref> (Accessed: 24 September 2024).</bibl>
+                <bibl xml:id="beshero" label="Beshero-Bondar et al. 2020">Beshero-Bondar, E. et al. (2020) <title rend="quotes">Frankenstein Variorum</title>. Carnegie Mellon University. Available at: <ref target="https://doi.org/10.1184/R1/C.4805868.V1">https://doi.org/10.1184/R1/C.4805868.V1</ref>.</bibl>
+                <bibl xml:id="gil2015" label="Gil 2015">Gil, A. (2015) <title>The User, the Learner and the Machines We Make</title>. Minimal Computing, Minimal Computing: A Working Group of GO::DH. Available at: <ref target="http://go-dh.github.io/mincomp/thoughts/2015/05/21/user-vs-learner/">http://go-dh.github.io/mincomp/thoughts/2015/05/21/user-vs-learner/</ref> (Accessed: 11 September 2024).</bibl>
+                <bibl xml:id="sayers2016" label="Sayers 2016">Sayers, G. (2016) <title>Minimal Definitions, Minimal Computing: A Working Group of GO::DH</title>. Available at: <ref target="http://go-dh.github.io/mincomp/thoughts/2016/10/02/minimal-definitions/">http://go-dh.github.io/mincomp/thoughts/2016/10/02/minimal-definitions/</ref>.</bibl>
                 <bibl xml:id="gilrisam2022" label="Gil, Risam 2022">Risam, R. and Gil, A. (2022) <title rend="quotes">Introduction: The Questions of Minimal Computing</title>. Digital Humanities Quarterly, 016(2).</bibl>
-                <bibl xml:id="knight2017" label="Knight 2017">Knight, K. (2017) <title>Making Space: Feminist DH and a Room of One's Own</title>. Minimal Computing: A Working Group of GO::DH. Available at: http://go-dh.github.io/mincomp/thoughts/2017/02/18/knight-makingspace/.</bibl>
-                <bibl xml:id="dombrowski2022" label="Dombrowski 2022">Dombrowski, Q. (2022) <title rend="quotes">Minimizing Computing Maximizes Labor</title>. Digital Humanities Quarterly, 16(2). Available at: http://www.digitalhumanities.org/dhq/vol/16/2/000594/000594.html (Accessed: 24 September 2024).</bibl>
-                <bibl xml:id="about" label="'About'"> (n.d.) Minimal Computing: A Working Group of GO::DH. Available at: https://go-dh.github.io/mincomp/about/ (Accessed: 14 September 2024).</bibl>
-                <bibl xml:id="underwood" label="Underwood 2014">Underwood, T. (2014) <title rend="quotes">Theorizing Research Practices We Forgot to Theorize Twenty Years Ago,</title> Representations, 127(1), pp. 64–72. Available at: https://doi.org/10.1525/rep.2014.127.1.64.</bibl>
-                <bibl xml:id="posner2016" label="Posner 2016">Posner, M. (2016) <title rend="quotes">What's Next: The Radical, Unrealized Potential of Digital Humanities.</title>in M.K. Gold and L.F. Klein (eds) Debates in the Digital Humanities 2016. University of Minnesota Press, pp. 32–41. Available at: https://doi.org/10.5749/j.ctt1cn6thb.6.</bibl>
-                <bibl xml:id="nowviskie2016" label="Nowviskie 2016">Nowviskie, B. (2016) <title rend="quotes">On the Origin of "Hack" and "Yack".</title>in M.K. Gold and L.F. Klein (eds) Debates in the Digital Humanities 2016. University of Minnesota Press, pp. 66–70. Available at: https://doi.org/10.5749/j.ctt1cn6thb.10</bibl>
-                <bibl xml:id="bourdieu1977" label="Bourdieu 1977">Bourdieu, P. (1977) <title rend="italic">Outline of a Theory of Practice</title>. 1st ed. Translated by R. Nice. Cambridge University Press. Available at: https://doi.org/10.1017/CBO9780511812507.</bibl>
-                <bibl xml:id="fiormonte2017" label="Fiormonte 2017">Fiormonte, D. (2017) <title rend="quotes">Digital Humanities and the Geopolitics of Knowledge</title>. Digital Studies/Le champ numérique, 7(1), p. 5. Available at: https://doi.org/10.16995/dscn.274.</bibl>
-                <bibl xml:id="otis2023" label="Otis 2023">Otis, J. (2023) <title rend="quotes">Follow the Money?: Funding and Digital Sustainability</title>. Digital Humanities Quarterly, 017(1). Available at: https://digitalhumanities.org/dhq/vol/17/1/000666/000666.html.</bibl>
+                <bibl xml:id="knight2017" label="Knight 2017">Knight, K. (2017) <title>Making Space: Feminist DH and a Room of One's Own</title>. Minimal Computing: A Working Group of GO::DH. Available at: <ref target="http://go-dh.github.io/mincomp/thoughts/2017/02/18/knight-makingspace/">http://go-dh.github.io/mincomp/thoughts/2017/02/18/knight-makingspace/</ref>.</bibl>
+                <bibl xml:id="dombrowski2022" label="Dombrowski 2022">Dombrowski, Q. (2022) <title rend="quotes">Minimizing Computing Maximizes Labor</title>. Digital Humanities Quarterly, 16(2). Available at: <ref target="http://www.digitalhumanities.org/dhq/vol/16/2/000594/000594.html">http://www.digitalhumanities.org/dhq/vol/16/2/000594/000594.html</ref> (Accessed: 24 September 2024).</bibl>
+                <bibl xml:id="about" label="'About'"> (n.d.) Minimal Computing: A Working Group of GO::DH. Available at: <ref target="https://go-dh.github.io/mincomp/about/">https://go-dh.github.io/mincomp/about/</ref> (Accessed: 14 September 2024).</bibl>
+                <bibl xml:id="underwood" label="Underwood 2014">Underwood, T. (2014) <title rend="quotes">Theorizing Research Practices We Forgot to Theorize Twenty Years Ago,</title> Representations, 127(1), pp. 64–72. Available at: <ref target="https://doi.org/10.1525/rep.2014.127.1.64">https://doi.org/10.1525/rep.2014.127.1.64</ref>.</bibl>
+                <bibl xml:id="posner2016" label="Posner 2016">Posner, M. (2016) <title rend="quotes">What's Next: The Radical, Unrealized Potential of Digital Humanities.</title>in M.K. Gold and L.F. Klein (eds) Debates in the Digital Humanities 2016. University of Minnesota Press, pp. 32–41. Available at: <ref target="https://doi.org/10.5749/j.ctt1cn6thb.6">https://doi.org/10.5749/j.ctt1cn6thb.6</ref>.</bibl>
+                <bibl xml:id="nowviskie2016" label="Nowviskie 2016">Nowviskie, B. (2016) <title rend="quotes">On the Origin of "Hack" and "Yack".</title>in M.K. Gold and L.F. Klein (eds) Debates in the Digital Humanities 2016. University of Minnesota Press, pp. 66–70. Available at: <ref target="https://doi.org/10.5749/j.ctt1cn6thb.10">https://doi.org/10.5749/j.ctt1cn6thb.10</ref></bibl>
+                <bibl xml:id="bourdieu1977" label="Bourdieu 1977">Bourdieu, P. (1977) <title rend="italic">Outline of a Theory of Practice</title>. 1st ed. Translated by R. Nice. Cambridge University Press. Available at: <ref target="https://doi.org/10.1017/CBO9780511812507">https://doi.org/10.1017/CBO9780511812507</ref>.</bibl>
+                <bibl xml:id="fiormonte2017" label="Fiormonte 2017">Fiormonte, D. (2017) <title rend="quotes">Digital Humanities and the Geopolitics of Knowledge</title>. Digital Studies/Le champ numérique, 7(1), p. 5. Available at: <ref target="https://doi.org/10.16995/dscn.274">https://doi.org/10.16995/dscn.274</ref>.</bibl>
+                <bibl xml:id="otis2023" label="Otis 2023">Otis, J. (2023) <title rend="quotes">Follow the Money?: Funding and Digital Sustainability</title>. Digital Humanities Quarterly, 017(1). Available at: <ref target="https://digitalhumanities.org/dhq/vol/17/1/000666/000666.html">https://digitalhumanities.org/dhq/vol/17/1/000666/000666.html</ref>.</bibl>
                 <bibl xml:id="blank2005" label="Blank 2005">Blank, S.G. (2005) <title rend="italic">The four steps to the epiphany: successful strategies for products that win</title>. Fifth edition. California: K &amp; S Ranch.</bibl>
                 <bibl xml:id="ries2011" label="Ries 2011">Ries, E. (2011) <title rend="italic">The lean startup: how today's entrepreneurs use continuous innovation to create radically successful businesses</title>. 1st ed. New York: Crown Business.</bibl>
-                <bibl xml:id="risamedwards" label="Risam and Edwards 2018">Risam R. and Edwards, Susan (2018) <title rend="quotes">Transforming the Landscape of Labor at Universities through Digital Humanities.</title>In Digital Humanities, Libraries, and Partnerships, edited by Robin Kear and Kate Joranson, 3–17. Cham, Switzerland: Chandos, 2018. Available at: https://digitalrepository.salemstate.edu/handle/20.500.13013/1010.</bibl>
+                <bibl xml:id="risamedwards" label="Risam and Edwards 2018">Risam R. and Edwards, Susan (2018) <title rend="quotes">Transforming the Landscape of Labor at Universities through Digital Humanities.</title>In Digital Humanities, Libraries, and Partnerships, edited by Robin Kear and Kate Joranson, 3–17. Cham, Switzerland: Chandos, 2018. Available at: <ref target="https://digitalrepository.salemstate.edu/handle/20.500.13013/1010">https://digitalrepository.salemstate.edu/handle/20.500.13013/1010</ref>.</bibl>
                 <bibl xml:id="clement" label="Clement 2015">Clement, T. (2015) <title rend="quotes">Where Is Methodology in Digital Humanities?</title>in Gold, M.K. and Klein, L.F. (eds) Debates in the Digital Humanities 2016. University of Minnesota Press.</bibl>
-                <bibl xml:id="mcpherson2012" label="McPherson 2012">McPherson, T. (2012) <title rend="quotes">Why Are the Digital Humanities So White?: or Thinking the Histories of Race and Computation</title>in M.K. Gold (ed.) Debates in the Digital Humanities. NED-New edition. University of Minnesota Press, pp. 139–160. Available at: https://www.jstor.org/stable/10.5749/j.ctttv8hq.12.</bibl>
-                <bibl xml:id="hughes2016" label="Hughes, J. (2016)">McPherson, T. (2012) <title>Minimal Definitions - Notes.</title> Available at: http://go-dh.github.io/mincomp/thoughts/2016/10/07/minimal-definitions-notes/ (Accessed: 17 September 2024).</bibl>
+                <bibl xml:id="mcpherson2012" label="McPherson 2012">McPherson, T. (2012) <title rend="quotes">Why Are the Digital Humanities So White?: or Thinking the Histories of Race and Computation</title>in M.K. Gold (ed.) Debates in the Digital Humanities. NED-New edition. University of Minnesota Press, pp. 139–160. Available at: <ref target="https://www.jstor.org/stable/10.5749/j.ctttv8hq.12">https://www.jstor.org/stable/10.5749/j.ctttv8hq.12</ref>.</bibl>
+                <bibl xml:id="hughes2016" label="Hughes, J. (2016)">McPherson, T. (2012) <title>Minimal Definitions - Notes.</title> Available at: <ref target="http://go-dh.github.io/mincomp/thoughts/2016/10/07/minimal-definitions-notes/">http://go-dh.github.io/mincomp/thoughts/2016/10/07/minimal-definitions-notes/</ref> (Accessed: 17 September 2024).</bibl>
                 <bibl xml:id="siemensetal" label="Siemens et al. (2016)">Siemens et al. (2016) <title rend="italic">Doing Digital Humanities: Practice, Training, Research.</title> NY: Routledge, 2016.</bibl>
                 
                  

--- a/submissions/cfps.html
+++ b/submissions/cfps.html
@@ -1,89 +1,84 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
-    <head>
-        <title>Calls for Proposals</title>
-    </head>
-    <body>
-        <p class="anchorNav">
-        	<a href="index.html">Submission Guidelines</a>  |  
-        	<a href="ai_policies.html">AI Policies</a>  |  
-        	<a href="textGuidelines.html">Style Guidelines</a>  |  
-        	<a href="citationGuidelines.html">Citation Guidelines</a>  |  
-        	<a href="publication_terms.html">Terms of Publication</a> |
-        	<a href="author_support.html">Author Support</a>
-        	<br />
-        	<strong>CFPs</strong>  | 
-        	<a href="specialIssuesGuidelines.html">Special Issues</a> | 
-        	<a href="peerReviewing.html">Peer Reviewing for DHQ</a>  |
-        	<a href="reviews.html">Book and Tool Reviews</a>  | 
-        	<a href="statistics.html">Acceptance Rates and Indexing</a>
-        </p>
-        <h1>Calls for Proposals</h1>
-        <p class="print">&gt;&gt; <a onclick="window.print();return false;" href="#">Print
-                Guidelines</a></p>
-        <!-- <h2>Special issue title</h2>
+	<head>
+		<title>Calls for Proposals</title>
+	</head>
+	<body>
+		<p class="anchorNav">
+			<a href="index.html">Submission Guidelines</a> | <a href="ai_policies.html">AI
+				Policies</a> | <a href="textGuidelines.html">Style Guidelines</a> | <a
+				href="citationGuidelines.html">Citation Guidelines</a> | <a
+				href="publication_terms.html">Terms of Publication</a> | <a
+				href="author_support.html">Author Support</a>
+			<br />
+			<strong>CFPs</strong> | <a href="specialIssuesGuidelines.html">Special Issues</a> | <a
+				href="peerReviewing.html">Peer Reviewing for DHQ</a> | <a href="reviews.html">Book
+				and Tool Reviews</a> | <a href="statistics.html">Acceptance Rates and Indexing</a>
+		</p>
+		<h1>Calls for Proposals</h1>
+		<p class="print">&gt;&gt; <a onclick="window.print();return false;" href="#">Print
+				Guidelines</a></p>
+		<!-- <h2>Special issue title</h2>
      <p>Guest editors: [NAMES]</p>
      <p>Abstracts due: [DATE]</p>
      <p>Description (or subdivide with <h3>)</p>
             -->
-<div id="ai_cfp">		
-	<h2>Call for Proposals: Artificial Intelligence for Digital Humanities: Research problems and critical approaches</h2>
-		<p>August 1, 2025</p>
-		<p><em>Digital Humanities Quarterly</em> invites authors to submit abstracts for a special
-			issue devoted to the topic of artificial intelligence (AI). Though AI-based approaches
-			to the digital humanities have been a part of the field for decades, recent years have
-			seen an explosion of methodologies utilizing AI. Some methods show great promise,
-			providing new modes of discoverability and analysis. Many raise questions and concerns
-			along ethical and sociotechnical dimensions. There are also conceptual challenges and
-			areas of application that are distinctive to the digital humanities. Given the volume of
-			submissions and inquiries surrounding AI and the digital humanities, the DHQ editors
-			have decided to devote a special issue to this topic in particular. </p>
-		<p> We are interested in a wide-ranging view of AI in the digital humanities context,
-			including:</p>
-		<ul>
-			<li>Different methodologies and applications, including those that look beyond
-				generative AI</li>
-			<li>Critical perspectives on AI, including ethical, political, and cultural
-				critiques</li>
-			<li>Responsible and transparent AI practices and frameworks in DH contexts</li>
-			<li>Specific use cases that open the door for new DH-relevant possibilities</li>
-			<li>Case studies within the digital humanities and in GLAM institutions, such as
-				responsible AI frameworks used to operationalize AI</li>
-			<li>Specific and grounded applications including but not limited to: translation,
-				transcription, OCR correction, summarization, captioning, text to speech, and
-				multi-modal approaches.</li>
-			<li>Experimental pieces that make use of AI in their creation (These should also
-				include an author’s statement/contextual material commenting on the experiment and
-				why the selected form is essential to the submission.) </li>
-		</ul>
-		<p>Submissions should meet the following requirements:</p>
-		<ul>
-			<li>The submission must have a direct connection to the digital humanities.</li>
-			<li>The submission should focus on research, rather than pedagogy (a second CFP
-				centered on AI and pedagogy will be forthcoming).</li>
-			<li>Except for experimental submissions, the submission must be human-authored (AI may
-				only be used for grammar and spell-checking within the writing process). </li>
-			<li>We are particularly interested in articles that will have continued value for
-				readers over time, rather than those focused on specific technologies that may
-				quickly become dated. </li>
-		</ul>
-		<p> We ask that prospective authors submit 500-word abstracts for review by September 15,
-			2025. Please send the following to <a
-				href="mailto:editors@digitalhumanities.org">editors@digitalhumanities.org</a>:</p>
-		<ul>
-			<li>An abstract of no more than 500 words</li>
-			<li>The name(s) and affiliations of the author(s)</li>
-			<li>Email address for the corresponding author</li>
-		</ul>
+
+		<div id="ai_pedagogy_cfp">
+			<h2>Artificial Intelligence and Digital Humanities Pedagogy</h2>
+			<p>Guest editors: Amanda Licastro, Ben Lee, Julia Flanders, Vanesa Cañete Jurado,
+				Nirmala Menon, John Walsh, Haining Wang, Joel Lee, Doreen Chen</p>
+			<p>Abstracts due: August 1, 2026</p>
+			<p>Digital Humanities Quarterly invites abstracts for a special issue devoted to the
+				topic of artificial intelligence (AI) in relation to digital humanities pedagogy.
+				Though AI-based approaches to the digital humanities have been a part of the field
+				for decades, recent years have seen an explosion of methodologies utilizing AI, and
+				of critical discussion concerning the implications for digital humanities pedagogy.
+				Abstracts are due August 1, 2026 to editors@digitalhumanities.org. Please use the
+				subject header: “DHQ AI Pedagogy Special Issue.” </p>
+			<p> We are interested in a wide-ranging view of AI in the digital humanities pedagogical context,
+				including:</p>
+			<ul>
+				<li> Critical perspectives on teaching (and teaching with) AI in a digital humanities context,
+					including ethical, political, and cultural critiques. </li>
+				<li> Critical examinations of AI systems themselves, from the perspective of digital
+					humanities pedagogical methods and critical frameworks.</li>
+				<li> Responsible and transparent AI practices and frameworks in DH pedagogical
+					contexts</li>
+				<li> Specific use cases that open the door for new DH-relevant teaching
+					possibilities. This can include the evaluation, adoption, contextualization,
+					resistance, and refusal of AI tools for teaching purposes. </li>
+				<li> Case studies addressing specific sites and scenarios for digital humanities
+					pedagogy (including those that go beyond formal classroom settings), grounded in
+					theory and prior work, and in replicable, scalable data and practices.</li>
+				<li> Examinations of the impact of AI on digital humanities pedagogical methods
+					focused specifically on building/making.</li>
+				<li> Examination of issues of assessment, labor, and motivation in relation to AI
+					integration in the digital humanities classroom. </li>
+			</ul>
+			<p>Submissions should meet the following requirements:</p>
+			<ol>
+				<li>The submission must have a direct connection to the digital humanities.</li>
+				<li> The submission should focus on pedagogy.</li>
+				<li> The submission must be human-authored. AI may be used for grammar and
+					spell-checking within the writing process, and for machine translation. Authors
+					should include a statement describing the use of any AI tools. </li>
+				<li> We are particularly interested in articles that will have continued value for
+					readers over time, rather than those focused on specific technologies that may
+					quickly become dated. </li>
+			</ol>
+			<p> We ask that prospective authors submit 500-word abstracts for review by August
+				1, 2026. Authors will be notified in November 2026 and invited to submit full papers
+				by March 2027, which will be peer reviewed. A full timeline will be provided to
+				authors upon the invitation to contribute a full paper. </p>
+			<p> For questions
+				related to this call, please contact the DHQ editors at:
+				<a href="mailto:editors@digitalhumanities.org">editors@digitalhumanities.org</a>. Please use the subject header: “DHQ AI Pedagogy Special Issue.”</p>
+		</div>
+
 		
-			<p>Authors will be notified in January 2026 and invited to submit full papers by
-			April 2026, which will be peer reviewed. A full timeline will be provided to authors
-			upon the invitation to contribute a full paper. </p>
-		<p> For questions related to this call, please contact the DHQ editors at: <a
-				href="mailto:editors@digitalhumanities.org">editors@digitalhumanities.org</a>
-			(please use the subject header: “DHQ AI Special Issue”).</p></div>  
 
-<p>Past CFPs can be found in our <a href="cfps_archive.html">CFP archive</a>.</p>       
+		<p>Past CFPs can be found in our <a href="cfps_archive.html">CFP archive</a>.</p>
 
-    </body>
+	</body>
 </html>

--- a/submissions/cfps_archive.html
+++ b/submissions/cfps_archive.html
@@ -22,6 +22,64 @@
         <p class="print">&gt;&gt; <a onclick="window.print();return false;" href="#">Print
                 Guidelines</a></p>
     	
+      <div id="ai_cfp">
+			<h2>Call for Proposals: Artificial Intelligence for Digital Humanities: Research
+				problems and critical approaches</h2>
+			<p>August 1, 2025</p>
+			<p><em>Digital Humanities Quarterly</em> invites authors to submit abstracts for a
+				special issue devoted to the topic of artificial intelligence (AI). Though AI-based
+				approaches to the digital humanities have been a part of the field for decades,
+				recent years have seen an explosion of methodologies utilizing AI. Some methods show
+				great promise, providing new modes of discoverability and analysis. Many raise
+				questions and concerns along ethical and sociotechnical dimensions. There are also
+				conceptual challenges and areas of application that are distinctive to the digital
+				humanities. Given the volume of submissions and inquiries surrounding AI and the
+				digital humanities, the DHQ editors have decided to devote a special issue to this
+				topic in particular. </p>
+			<p> We are interested in a wide-ranging view of AI in the digital humanities context,
+				including:</p>
+			<ul>
+				<li>Different methodologies and applications, including those that look beyond
+					generative AI</li>
+				<li>Critical perspectives on AI, including ethical, political, and cultural
+					critiques</li>
+				<li>Responsible and transparent AI practices and frameworks in DH contexts</li>
+				<li>Specific use cases that open the door for new DH-relevant possibilities</li>
+				<li>Case studies within the digital humanities and in GLAM institutions, such as
+					responsible AI frameworks used to operationalize AI</li>
+				<li>Specific and grounded applications including but not limited to: translation,
+					transcription, OCR correction, summarization, captioning, text to speech, and
+					multi-modal approaches.</li>
+				<li>Experimental pieces that make use of AI in their creation (These should also
+					include an author’s statement/contextual material commenting on the experiment
+					and why the selected form is essential to the submission.) </li>
+			</ul>
+			<p>Submissions should meet the following requirements:</p>
+			<ul>
+				<li>The submission must have a direct connection to the digital humanities.</li>
+				<li>The submission should focus on research, rather than pedagogy (a second CFP
+					centered on AI and pedagogy will be forthcoming).</li>
+				<li>Except for experimental submissions, the submission must be human-authored (AI
+					may only be used for grammar and spell-checking within the writing process). </li>
+				<li>We are particularly interested in articles that will have continued value for
+					readers over time, rather than those focused on specific technologies that may
+					quickly become dated. </li>
+			</ul>
+			<p> We ask that prospective authors submit 500-word abstracts for review by September
+				15, 2025. Please send the following to <a
+					href="mailto:editors@digitalhumanities.org"
+				>editors@digitalhumanities.org</a>:</p>
+			<ul>
+				<li>An abstract of no more than 500 words</li>
+				<li>The name(s) and affiliations of the author(s)</li>
+				<li>Email address for the corresponding author</li>
+			</ul>
+			<p>Authors will be notified in January 2026 and invited to submit full papers by April
+				2026, which will be peer reviewed. A full timeline will be provided to authors upon
+				the invitation to contribute a full paper. </p>
+			<p> For questions related to this call, please contact the DHQ editors at: <a
+					href="mailto:editors@digitalhumanities.org">editors@digitalhumanities.org</a>
+				(please use the subject header: “DHQ AI Special Issue”).</p></div>
       
 <div><h2>Data Science and History: Practicing and Theorizing Data-Driven Inquiries into the Past</h2>
     	<p>Guest editors: Gabor Toth, Caitlin Burge, Christoph Purschke, Marten Düring</p>


### PR DESCRIPTION
This PR adds the CFP for the AI Pedagogy special issue, and archives the CFP for the AI Research special issue.