### PR TITLE
metadata for our i18n file; create l10n function

### DIFF
--- a/common/xml/i18n_terms.xml
+++ b/common/xml/i18n_terms.xml
@@ -1,45 +1,114 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Title</title>
-            </titleStmt>
-            <publicationStmt>
-                <p>Publication Information</p>
-            </publicationStmt>
-            <sourceDesc>
-                <p>Information about the source</p>
-            </sourceDesc>
-        </fileDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <list>
-                <item xml:id="ui.abstract">
-                    <desc>Heading for the article’s abstract section.</desc>
-                    <gloss xml:lang="en">Abstract</gloss>
-                    <gloss xml:lang="fr">Résumé</gloss>
-                    <gloss xml:lang="es">Resumen</gloss>
-                    <gloss xml:lang="pt">Resumo</gloss>
-                </item>
-                <item xml:id="ui.worksCited">
-                    <desc>Heading for the article’s list of cited works.</desc>
-                    <gloss xml:lang="en">Works Cited</gloss>
-                    <gloss xml:lang="fr">Œuvres citées</gloss>
-                    <gloss xml:lang="es">Obras citadas</gloss>
-                    <gloss xml:lang="pt">Obras citadas</gloss>
-                </item>
-                <item xml:id="ui.notes">
-                    <desc>Heading for the article’s notes section.</desc>
-                    <gloss xml:lang="en">Notes</gloss>
-                    <gloss xml:lang="fr">Notes</gloss>
-                    <gloss xml:lang="es"></gloss>
-                    <gloss xml:lang="pt"></gloss>
-                </item>
-            </list>
-        </body>
-    </text>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Internationalization translation lookup</title>
+        <author xml:id="jhf">
+          <persName>Julia Flanders</persName>
+        </author>
+        <author xml:id="jaw">
+          <persName>John Walsh</persName>
+        </author>
+        <editor xml:id="sdb">
+          <persName>Syd Bauman</persName>
+        </editor>          
+      </titleStmt>
+      <publicationStmt>
+        <publisher>Alliance of Digital Humanities Organizations</publisher>
+        <publisher>Association of Computers and the Humanities</publisher>
+        <availability>
+          <ab>Freely available under a <ref
+          target="https://creativecommons.org/licenses/by-nd/2.5/">Creative
+          Commons</ref>license.</ab>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <ab>born digital</ab>
+      </sourceDesc>
+    </fileDesc>
+    <revisionDesc>
+      <change when="2026-05-22T18:45:00Z" who="#sdb">
+        <list>
+          <item>Fleshed out the TEI header, including this change log.</item>
+          <item>Added front matter with an introductory explanation.</item>
+        </list>
+      </change>
+      <change when="2026-05-22T14:55:00Z" who="#jhf #jaw">
+        Added initial data for three entries in 2–4 languages each.
+      </change>
+      <change when="2026-05-22T14:45:00Z" who="#sdb">
+        Created shell with 1 entry and no data.
+      </change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <front>
+      <head>Introduction to this file</head>
+      <p>This document contains the translation table for converting
+      various boilerplate or <q>forme work</q> phrases into various
+      languages. It is a TEI file that may contain all sorts of stuff
+      (including this paragraph) that is not actually part of the
+      translation mechanism. The only part the XSLT looks at is <code
+      lang="xpath">/TEI/text/body/list[ @type eq 'i18n']</code>. That
+      list should contain a sequence of <gi>item</gi> elements, each
+      of which is required to have:
+      <list>
+        <item>a unique identifier on an <att>xml:id</att> attribute</item>
+        <item>an optional <gi>desc</gi> element for describing what
+        the particular gloss is for</item>
+        <item>one or more <gi>gloss</gi> elements, each of which
+        should have an <att>xml:lang</att> attribute; at least one of
+        which has a value that is <att>en</att> or starts with
+        <att>en-</att><note>this is not strictly necessary per XML, as
+        this whole file is in English. Thus if you left the
+        <att>xml:lang</att> off of one <gi>gloss</gi>, that one would
+        be the English one. But having it explicit makes the data lot
+        easier to proofread, and protects against future corruption if
+        and when the data is copied to a non-English
+        environment).</note>.</item>
+      </list>
+      There should never be two or more <gi>gloss</gi> siblings that
+      have the same <att>xml:lang</att>. Although not necessary for
+      processing, it is convenient for human readers if the
+      <gi>desc</gi> element comes before all the <gi>gloss</gi>
+      elements, and the <val>en</val> <gi>gloss</gi> is the first.</p>
+      <p>Note that these <soCalled>requirements</soCalled> are
+      required by our processor. We do not currently have a schema
+      that enforces these conditions. But it would not be particularly
+      difficult to come up with one if the editors would so
+      prefer.</p>
+      <p>Note also that we admit that these entries are not
+      <emph>really</emph> glosses, so <gi>gloss</gi> is mild tag
+      abuse. But TEI does not have a <gi>useThisText</gi>, and
+      <gi>reg</gi> is similarly <emph>slightly</emph> off target.</p>      
+    </front>
+    <body>
+      <list type="i18n">
+        <item xml:id="ui.abstract">
+          <desc>Heading for the article’s abstract section.</desc>
+          <gloss xml:lang="en">Abstract</gloss>
+          <gloss xml:lang="fr">Résumé</gloss>
+          <gloss xml:lang="es">Resumen</gloss>
+          <gloss xml:lang="pt">Resumo</gloss>
+        </item>
+        <item xml:id="ui.worksCited">
+          <desc>Heading for the article’s list of cited works.</desc>
+          <gloss xml:lang="en">Works Cited</gloss>
+          <gloss xml:lang="fr">Œuvres citées</gloss>
+          <gloss xml:lang="es">Obras citadas</gloss>
+          <gloss xml:lang="pt">Obras citadas</gloss>
+        </item>
+        <item xml:id="ui.notes">
+          <desc>Heading for the article’s notes section.</desc>
+          <gloss xml:lang="en">Notes</gloss>
+          <gloss xml:lang="fr">Notes</gloss>
+          <gloss xml:lang="es"></gloss>
+          <gloss xml:lang="pt"></gloss>
+        </item>
+      </list>
+    </body>
+  </text>
 </TEI>

--- a/common/xslt/common-components.xsl
+++ b/common/xslt/common-components.xsl
@@ -239,8 +239,62 @@
     <xsl:param name="number" as="xs:string"/>
     <xsl:sequence select="replace(normalize-space($number), '^0+', '')"/>
   </xsl:function>
-  
-  
+
+
+  <!--  -->
+  <xsl:function name="dhqf:localization" expand-text="yes" as="xs:string">
+    <xsl:param name="key" as="xs:string"/> <!-- arg 1 is the ID of the <item> we are looking for -->
+    <xsl:param name="here" as="node()"/> <!-- input node (so we can look up the current language) -->
+    <xsl:variable name="lang" select="('en', $here/ancestor-or-self::*/@xml:lang )[last()]" as="xs:string"/>
+    <!-- Why is the above an xs:string, not an xs:language you ask?
+         Because the only argument to the fn:lang() function is an
+         xs:string, not an xs:language, don’t know why. —Syd -->
+    <!-- check that supplied key is at least viable as an identifier -->
+    <xsl:if test="not( $key castable as xs:ID )">
+      <!-- Note: if we are strict about ID values in the i18n file, we
+           might want a stricter test, above. E.g., currently matches(
+           $key, '^ui\.[a-z]+([A-Z][a-z]+)$') would be a good
+           test. —Syd -->
+      <xsl:message terminate="yes">Internal error from dhqf:localization() — provided key ({$key}) is not a valid XML ID</xsl:message>
+    </xsl:if>
+    <!-- establish path to internationalization file -->
+    <xsl:variable name="i18n_termFile" select="'../xml/i18n_terms.xml'" as="xs:string"/>
+    <!-- make sure we can read it -->
+    <xsl:if test="not( doc-available( $i18n_termFile ) )">
+      <xsl:message terminate="yes">Error: file {$i18n_termFile} not readable</xsl:message>
+    </xsl:if>
+    <!-- OK, we can read it, go ahead and do so, extracting just the list of translations -->
+    <xsl:variable name="i18nList" select="doc($i18n_termFile)/tei:TEI/tei:text/tei:body/tei:list[ @type eq 'i18n']" as="element(tei:list)"/>
+    <!-- From that list, get the list item of interest -->
+    <xsl:variable name="i18nItem" select="$i18nList/tei:item[ @xml:id eq $key ]" as="element(tei:item)?"/>
+    <xsl:if test="not( $i18nItem )">
+      <xsl:message terminate="yes">Error: no translation entry found for key {$key}!</xsl:message>
+    </xsl:if>
+    <!-- Grab the translation. If there is an exact match, take that;
+         second choice is to look for a case where the translation is
+         a more precise version of the main language (e.g., given the
+         language we are looking for is "fr", take "fr-CA"); if
+         neither of those is available, take the English one. -->
+    <xsl:variable name="i18nGloss"
+                  select="( $i18nItem/tei:gloss[ @xml:lang eq $lang ],
+                            $i18nItem/tei:gloss[ lang($lang) ],
+                            $i18nItem/tei:gloss[ lang('en') ]
+                          )[1]" as="element(tei:gloss)"/>
+    <!-- Whatever we grabbed, return the processed version
+         thereof. -->
+    <xsl:apply-templates select="$i18nGloss" mode="localization"/>
+  </xsl:function>
+
+  <!-- Process the localization <gloss> with low priority, so some
+       other routine can override. In the vast majority, if not all,
+       of cases what we want is just the string value of the <gloss>
+       itself; but just in case there is markup of some kind *inside*
+       that gloss, we process it. This might be helpful, e.g., when
+       some phrase-level element would require the generation of
+       quotation marks of various sorts or gillmets or whatever.) -->
+  <xsl:template match="gloss" mode="localization" priority="-2">
+    <xsl:sequence select="normalize-space(.)"/>
+  </xsl:template>
   
   <!--
       SUPPORT TEMPLATES


### PR DESCRIPTION
First crack at the first steps in making use of our new internationalization file for localization of various boilerplate or “forme work” phrases.

- Added a header (with `<revisionDesc>`) and explanatory prose to common/xml/i18n_terms.xml.
- Added a new function, dhq:localization() to common/xslt/common-components.xsl. It takes two arguments: the ID of the desired phrase to be localized, and the node for which it is to be localized (which will almost certainly be the current node, i.e. **`.`**, most of the time).
