### PR TITLE
fix some funky langs

### DIFF
--- a/articles/000025/000025.xml
+++ b/articles/000025/000025.xml
@@ -54,7 +54,7 @@
       <profileDesc>
          <langUsage>
             <language ident="en"/>
-            <language ident="greek"/>
+            <language ident="grc"/>
             <language ident="la"/>
             <language ident="it"/>
             <language ident="fr"/>

--- a/articles/000736/000736.xml
+++ b/articles/000736/000736.xml
@@ -104,7 +104,7 @@
       <profileDesc>
          <langUsage>
             <language ident="en" extent="default"/>
-            <language ident="gre"/>
+            <language ident="el"/>
          </langUsage>
          <textClass>
             <keywords scheme="#dhq_keywords">
@@ -343,7 +343,7 @@
                 <p>We found that 24 out of 3,178 recognised texts were empty and were therefore discarded. Some of the remaining 3,154 recognised texts, 
                    however, will likely comprise noisy output, due to images of bent pages, as in the left column of Figure 2(b), or due to content that 
                    is hard to transcribe (e.g., pages with tables or with text in a foreign language). In these cases, the recognised text consists of 
-                   scrambled meaningless text, characters one next to the other as in <q xml:lang="el">Ἐἀξμξζ,λ,βθλΗξζλΕζ (ΕΥ ΙΚΚῳ ν8Υ ψπυ</q>. This 
+                   scrambled meaningless text, characters one next to the other as in <q xml:lang="zxx">Ἐἀξμξζ,λ,βθλΗξζλΕζ (ΕΥ ΙΚΚῳ ν8Υ ψπυ</q>. This 
                    noisy text, however, hinders search and information extraction for the historian. Therefore, in order to discard low-quality texts 
                    from our corpus, we built a language model to assess the quality of each of our recognised texts. Language models are suitable for 
                    this task, as they can assess the quality of the recognised text and can be used for the evaluation of the output of text recognition 

--- a/articles/000737/000737.xml
+++ b/articles/000737/000737.xml
@@ -74,7 +74,7 @@
          <langUsage>
             <language ident="en" extent="default"/>
             <language ident="grc"/>
-            <language ident="lat"/>
+            <language ident="la"/>
          </langUsage>
          <textClass>
             <keywords scheme="#dhq_keywords">


### PR DESCRIPTION
Fixed all the invalid IANA language subtags on `@xml:lang` or the `@ident` of `<language>` listed in [the chart of language usage](https://github.com/user-attachments/files/29908561/DHQlangs.html) developed for #217, plus one other that was valid but incorrect, noticed in passing.