### PR TITLE
process localization gloss, rather than just copy its contents

### DIFF
--- a/common/xslt/common-components.xsl
+++ b/common/xslt/common-components.xsl
@@ -293,7 +293,7 @@
        some phrase-level element would require the generation of
        quotation marks of various sorts or gillmets or whatever.) -->
   <xsl:template match="gloss" mode="localization" priority="-2">
-    <xsl:sequence select="normalize-space(.)"/>
+    <xsl:apply-templates/>
   </xsl:template>
   
   <!--


### PR DESCRIPTION
The comment on ~line 292 of `common/xslt/common-components.xsl` is quite clear. We should process the contents of the localization `<gloss>` so that if there is any encoding in there (mostly likely `<q>` or similar) it can be handled. However, the code just copied over the contents of the gloss. So this PR just changes that “copy contents” to “process contents”. Since the default processing is to copy, the results should be exactly the same unless there is a template that matches a child node of the localization gloss.

I have not done anything to test this yet.